### PR TITLE
Set maxerr jslint option so that jslint does not bail out with "too many errors" so early

### DIFF
--- a/plugins/org.mozilla.rhino/fulljslint.js
+++ b/plugins/org.mozilla.rhino/fulljslint.js
@@ -5,6 +5,7 @@ aptanaOptions.undef = true;
 aptanaOptions.browser = true;
 aptanaOptions.jscript = true;
 aptanaOptions.debug = true;
+aptanaOptions.maxerr = 1000;
 aptanaOptions.predef = ["Ti","Titanium","alert","require","exports","native","implements"];
 
 // jslint.js


### PR DESCRIPTION
This is especially useful when using filtering of errors/warnings of the validator in Aptana.

This should also "fix" http://developer.appcelerator.com/question/118054/jslint-reported and alleviate https://aptanastudio.tenderapp.com/discussions/questions/933-configure-jslint

I tested this by locally modifying fulljslint.js in the rhino jar, and it works nicely.
