### PR TITLE
TISTUD-4962 Tag performance test to participate in performance summary

### DIFF
--- a/tests/com.aptana.css.core.tests/src/com/aptana/css/core/parsing/CSSParserPerformanceTest.java
+++ b/tests/com.aptana.css.core.tests/src/com/aptana/css/core/parsing/CSSParserPerformanceTest.java
@@ -12,64 +12,61 @@ import java.io.InputStream;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.test.performance.Dimension;
 import org.eclipse.test.performance.PerformanceTestCase;
 
 import com.aptana.core.util.IOUtil;
 import com.aptana.parsing.IParseState;
 import com.aptana.parsing.ParseState;
 
-public class CSSParserPerformanceTest extends PerformanceTestCase
-{
+public class CSSParserPerformanceTest extends PerformanceTestCase {
 
 	private CSSParser fParser;
 
 	@Override
-	protected void setUp() throws Exception
-	{
+	protected void setUp() throws Exception {
 		super.setUp();
 		fParser = new CSSParser();
 	}
 
 	@Override
-	protected void tearDown() throws Exception
-	{
+	protected void tearDown() throws Exception {
 		fParser = null;
 		super.tearDown();
 	}
 
-	public void testWordpressAdminCSS() throws Exception
-	{
+	public void testWordpressAdminCSS() throws Exception {
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		parseTest("wp-admin.css", 330);
 	}
 
-	public void testWordpressAdminDev() throws Exception
-	{
+	public void testWordpressAdminDev() throws Exception {
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		parseTest("wp-admin.dev.css", 1250);
 	}
 
-	public void testFromMetadata() throws Exception
-	{
+	public void testFromMetadata() throws Exception {
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		parseTest("from-metadata.css", 50);
 	}
 
-	public void testGithubFormatted() throws Exception
-	{
+	public void testGithubFormatted() throws Exception {
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		parseTest("github-formatted.css", 25);
 	}
 
-	public void testGithubMinimized() throws Exception
-	{
+	public void testGithubMinimized() throws Exception {
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		parseTest("github-minimized.css", 25);
 	}
 
-	private void parseTest(String fileName, int iterations) throws Exception
-	{
-		InputStream stream = FileLocator.openStream(Platform.getBundle("com.aptana.css.core.tests"),
+	private void parseTest(String fileName, int iterations) throws Exception {
+		InputStream stream = FileLocator.openStream(
+				Platform.getBundle("com.aptana.css.core.tests"),
 				Path.fromPortableString("performance/" + fileName), false);
 		String src = IOUtil.read(stream);
 
-		for (int i = 0; i < iterations; i++)
-		{
+		for (int i = 0; i < iterations; i++) {
 			IParseState parseState = new ParseState(src);
 			startMeasuring();
 			fParser.parse(parseState);

--- a/tests/com.aptana.css.core.tests/src/com/aptana/css/core/parsing/CSSScannerPerformanceTest.java
+++ b/tests/com.aptana.css.core.tests/src/com/aptana/css/core/parsing/CSSScannerPerformanceTest.java
@@ -12,52 +12,50 @@ import java.io.InputStream;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.test.performance.Dimension;
 import org.eclipse.test.performance.PerformanceTestCase;
 
 import beaver.Symbol;
 
 import com.aptana.core.util.IOUtil;
 
-public class CSSScannerPerformanceTest extends PerformanceTestCase
-{
+public class CSSScannerPerformanceTest extends PerformanceTestCase {
 	private CSSFlexScanner fScanner;
 
 	@Override
-	protected void setUp() throws Exception
-	{
+	protected void setUp() throws Exception {
 		super.setUp();
 		fScanner = new CSSFlexScanner();
 	}
 
 	@Override
-	protected void tearDown() throws Exception
-	{
+	protected void tearDown() throws Exception {
 		fScanner = null;
 		super.tearDown();
 	}
 
-	public void testWordpressAdminCSS() throws Exception
-	{
+	public void testWordpressAdminCSS() throws Exception {
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		timeScan("wp-admin.css", 50);
 	}
 
-	public void testWordpressAdminDev() throws Exception
-	{
+	public void testWordpressAdminDev() throws Exception {
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		timeScan("wp-admin.dev.css", 50);
 	}
 
-	public void testFromMetadata() throws Exception
-	{
+	public void testFromMetadata() throws Exception {
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		timeScan("from-metadata.css", 50);
 	}
 
-	public void testGithubFormatted() throws Exception
-	{
+	public void testGithubFormatted() throws Exception {
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		timeScan("github-formatted.css", 50);
 	}
 
-	public void testGithubMinimized() throws Exception
-	{
+	public void testGithubMinimized() throws Exception {
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		timeScan("github-minimized.css", 50);
 	}
 
@@ -69,22 +67,20 @@ public class CSSScannerPerformanceTest extends PerformanceTestCase
 	 * @param numRuns
 	 * @throws Exception
 	 */
-	private void timeScan(String resourceName, int numRuns) throws Exception
-	{
-		InputStream stream = FileLocator.openStream(Platform.getBundle("com.aptana.css.core.tests"),
+	private void timeScan(String resourceName, int numRuns) throws Exception {
+		InputStream stream = FileLocator.openStream(
+				Platform.getBundle("com.aptana.css.core.tests"),
 				Path.fromPortableString("performance/" + resourceName), false);
 		String src = IOUtil.read(stream);
 
-		for (int i = 0; i < numRuns; i++)
-		{
+		for (int i = 0; i < numRuns; i++) {
 			startMeasuring();
 
 			fScanner.setSource(src);
 
 			Symbol symbol = fScanner.nextToken();
 
-			while (symbol != null && symbol.getId() != 0)
-			{
+			while (symbol != null && symbol.getId() != 0) {
 				symbol = fScanner.nextToken();
 			}
 

--- a/tests/com.aptana.editor.common.tests/src/com/aptana/editor/common/internal/peer/CharacterPairMatcherPerfTest.java
+++ b/tests/com.aptana.editor.common.tests/src/com/aptana/editor/common/internal/peer/CharacterPairMatcherPerfTest.java
@@ -16,6 +16,7 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.source.ICharacterPairMatcher;
+import org.eclipse.test.performance.Dimension;
 import org.eclipse.test.performance.PerformanceTestCase;
 import org.eclipse.ui.ide.IDE;
 
@@ -48,6 +49,7 @@ public class CharacterPairMatcherPerfTest extends PerformanceTestCase
 
 	public void testPairMatching() throws Exception
 	{
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		URL url = FileLocator.find(Platform.getBundle("com.aptana.editor.common.tests"),
 				Path.fromPortableString("performance/jquery-1.6.4.js"), null);
 		URI uri = ResourceUtil.resourcePathToURI(url);

--- a/tests/com.aptana.editor.common.tests/src/com/aptana/editor/common/internal/peer/PeerCharacterCloserPerfTest.java
+++ b/tests/com.aptana.editor.common.tests/src/com/aptana/editor/common/internal/peer/PeerCharacterCloserPerfTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IDocument;
+import org.eclipse.test.performance.Dimension;
 import org.eclipse.test.performance.PerformanceTestCase;
 
 public class PeerCharacterCloserPerfTest extends PerformanceTestCase
@@ -19,6 +20,7 @@ public class PeerCharacterCloserPerfTest extends PerformanceTestCase
 
 	public void testCheckUnpairedClose() throws Exception
 	{
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		PeerCharacterCloser closer = new PeerCharacterCloser(null)
 		{
 			protected List<Character> getPairs(String scope)

--- a/tests/com.aptana.editor.common.tests/src/com/aptana/editor/common/internal/scripting/DocumentScopeManagerPerformanceTest.java
+++ b/tests/com.aptana.editor.common.tests/src/com/aptana/editor/common/internal/scripting/DocumentScopeManagerPerformanceTest.java
@@ -9,6 +9,7 @@ import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.source.ISourceViewer;
+import org.eclipse.test.performance.Dimension;
 import org.eclipse.test.performance.PerformanceTestCase;
 import org.eclipse.ui.IEditorReference;
 import org.eclipse.ui.IWorkbenchPage;
@@ -32,6 +33,7 @@ public class DocumentScopeManagerPerformanceTest extends PerformanceTestCase
 	 */
 	public void testGetScopeAtOffsetSourceViewer() throws Exception
 	{
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		IDocumentScopeManager manager = CommonEditorPlugin.getDefault().getDocumentScopeManager();
 		ITextEditor editor = null;
 		File file = null;
@@ -48,7 +50,7 @@ public class DocumentScopeManagerPerformanceTest extends PerformanceTestCase
 			IDocument doc = viewer.getDocument();
 			int length = doc.getLength();
 			EditorTestHelper.closeAllEditors();
-			
+
 			IEditorReference[] refs = page.getEditorReferences();
 			assertEquals(0, refs.length);
 

--- a/tests/com.aptana.editor.common.tests/src/com/aptana/editor/common/text/reconciler/RubyRegexpFolderPerformanceTest.java
+++ b/tests/com.aptana.editor.common.tests/src/com/aptana/editor/common/text/reconciler/RubyRegexpFolderPerformanceTest.java
@@ -15,6 +15,7 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IDocument;
+import org.eclipse.test.performance.Dimension;
 import org.eclipse.test.performance.PerformanceTestCase;
 import org.jruby.Ruby;
 import org.jruby.RubyRegexp;
@@ -27,6 +28,7 @@ public class RubyRegexpFolderPerformanceTest extends PerformanceTestCase
 
 	public void testYUICSSFolding() throws Exception
 	{
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		Ruby runtime = Ruby.newInstance();
 		final RubyRegexp endFolding = RubyRegexp.newRegexp(runtime, "(?<!\\*)\\*\\*\\/|^\\s*\\}",
 				RegexpOptions.NULL_OPTIONS);

--- a/tests/com.aptana.editor.common.tests/src/com/aptana/editor/common/text/rules/ThemeingDamagerRepairerPerfTest.java
+++ b/tests/com.aptana.editor.common.tests/src/com/aptana/editor/common/text/rules/ThemeingDamagerRepairerPerfTest.java
@@ -8,6 +8,7 @@ import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.source.ISourceViewer;
+import org.eclipse.test.performance.Dimension;
 import org.eclipse.test.performance.PerformanceTestCase;
 import org.eclipse.ui.ide.IDE;
 
@@ -33,6 +34,7 @@ public class ThemeingDamagerRepairerPerfTest extends PerformanceTestCase
 
 	public void testForcedRecoloringOfEntireFile() throws Exception
 	{
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		URL url = FileLocator.find(Platform.getBundle("com.aptana.editor.common.tests"),
 				Path.fromPortableString("performance/ext-all-debug.js"), null);
 		URI uri = ResourceUtil.resourcePathToURI(url);
@@ -51,6 +53,7 @@ public class ThemeingDamagerRepairerPerfTest extends PerformanceTestCase
 	// Add a test for edits in the file to make sure edits are as fast/faster...
 	public void testEditingFileLive() throws Exception
 	{
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		URL url = FileLocator.find(Platform.getBundle("com.aptana.editor.common.tests"),
 				Path.fromPortableString("performance/ext-all-debug.js"), null);
 		URI uri = ResourceUtil.resourcePathToURI(url);

--- a/tests/com.aptana.editor.css.tests/src/com/aptana/editor/css/CSSCodeScannerPerformanceTest.java
+++ b/tests/com.aptana.editor.css.tests/src/com/aptana/editor/css/CSSCodeScannerPerformanceTest.java
@@ -18,6 +18,7 @@ import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.rules.ITokenScanner;
 import org.eclipse.jface.text.rules.Token;
+import org.eclipse.test.performance.Dimension;
 import org.eclipse.test.performance.PerformanceTestCase;
 
 import com.aptana.core.util.IOUtil;
@@ -44,31 +45,37 @@ public class CSSCodeScannerPerformanceTest extends PerformanceTestCase
 
 	public void testScanningFromMetadata() throws Exception
 	{
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		perfScan("from-metadata.css", 10);
 	}
 
 	public void testGithubFormatted() throws Exception
 	{
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		perfScan("github-formatted.css", 20);
 	}
 
 	public void testGithubMinimized() throws Exception
 	{
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		perfScan("github-minimized.css", 20);
 	}
 
 	public void testScanningWordpressAdminCSS() throws Exception
 	{
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		perfScan("wp-admin.css", 80);
 	}
 
 	public void testScanningWordpressAdminDevCSS() throws Exception
 	{
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		perfScan("wp-admin.dev.css", 30);
 	}
 
 	public void testScanningYuiCSS() throws Exception
 	{
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		perfScan("yui.css", 80);
 	}
 

--- a/tests/com.aptana.editor.css.tests/src/com/aptana/editor/css/CSSScannerPerformanceTest.java
+++ b/tests/com.aptana.editor.css.tests/src/com/aptana/editor/css/CSSScannerPerformanceTest.java
@@ -12,6 +12,7 @@ import java.io.InputStream;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.test.performance.Dimension;
 import org.eclipse.test.performance.PerformanceTestCase;
 
 import com.aptana.core.util.IOUtil;
@@ -39,6 +40,7 @@ public class CSSScannerPerformanceTest extends PerformanceTestCase
 
 	public void testScanningWordpressAdminCSS() throws Exception
 	{
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		InputStream stream = FileLocator.openStream(Platform.getBundle("com.aptana.editor.css.tests"),
 				Path.fromPortableString("performance/wp-admin.css"), false);
 		String src = IOUtil.read(stream);

--- a/tests/com.aptana.editor.css.tests/src/com/aptana/editor/css/CSSSourcePartitionScannerPerformanceTest.java
+++ b/tests/com.aptana.editor.css.tests/src/com/aptana/editor/css/CSSSourcePartitionScannerPerformanceTest.java
@@ -17,6 +17,7 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IDocumentPartitioner;
+import org.eclipse.test.performance.Dimension;
 import org.eclipse.test.performance.PerformanceTestCase;
 
 import com.aptana.core.util.IOUtil;
@@ -51,31 +52,37 @@ public class CSSSourcePartitionScannerPerformanceTest extends PerformanceTestCas
 
 	public void testScanningFromMetadata() throws Exception
 	{
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		perfPartition("from-metadata.css", 10);
 	}
 
 	public void testGithubFormatted() throws Exception
 	{
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		perfPartition("github-formatted.css", 20);
 	}
 
 	public void testGithubMinimized() throws Exception
 	{
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		perfPartition("github-minimized.css", 20);
 	}
 
 	public void testScanningWordpressAdminCSS() throws Exception
 	{
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		perfPartition("wp-admin.css", 80);
 	}
 
 	public void testScanningWordpressAdminDevCSS() throws Exception
 	{
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		perfPartition("wp-admin.dev.css", 30);
 	}
 
 	public void testScanningYuiCSS() throws Exception
 	{
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		perfPartition("yui.css", 80);
 	}
 

--- a/tests/com.aptana.editor.html.tests/src/com/aptana/editor/html/HTMLTagScannerPerformanceTest.java
+++ b/tests/com.aptana.editor.html.tests/src/com/aptana/editor/html/HTMLTagScannerPerformanceTest.java
@@ -16,6 +16,7 @@ import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.rules.IToken;
 import org.eclipse.jface.text.rules.Token;
+import org.eclipse.test.performance.Dimension;
 import org.eclipse.test.performance.PerformanceTestCase;
 
 import com.aptana.core.util.IOUtil;
@@ -48,6 +49,7 @@ public class HTMLTagScannerPerformanceTest extends PerformanceTestCase
 
 	public void testAmazonHTML() throws Exception
 	{
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		// read in the file
 		InputStream stream = FileLocator.openStream(Platform.getBundle("com.aptana.editor.html.tests"),
 				Path.fromPortableString("performance/amazon.html"), false);

--- a/tests/com.aptana.editor.html.tests/src/com/aptana/editor/html/parsing/HTMLParserPerformanceTest.java
+++ b/tests/com.aptana.editor.html.tests/src/com/aptana/editor/html/parsing/HTMLParserPerformanceTest.java
@@ -12,6 +12,7 @@ import java.io.InputStream;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.test.performance.Dimension;
 import org.eclipse.test.performance.PerformanceTestCase;
 
 import com.aptana.core.util.IOUtil;
@@ -42,21 +43,25 @@ public class HTMLParserPerformanceTest extends PerformanceTestCase
 
 	public void testAmazonFrontPage() throws Exception
 	{
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		parseTest("amazon.html", 1500);
 	}
 
 	public void testReddit() throws Exception
 	{
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		parseTest("reddit.html", 120);
 	}
 
 	public void testRedditNoCSSNoJS() throws Exception
 	{
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		parseTest("reddit-no-css-no-js.html", 175);
 	}
 
 	public void testBigHTML() throws Exception
 	{
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		parseTest("BigHTML.html", 10);
 	}
 

--- a/tests/com.aptana.editor.html.tests/src/com/aptana/editor/html/validator/HTMLTidyValidatorPerformanceTest.java
+++ b/tests/com.aptana.editor.html.tests/src/com/aptana/editor/html/validator/HTMLTidyValidatorPerformanceTest.java
@@ -15,6 +15,7 @@ import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.test.performance.Dimension;
 import org.eclipse.test.performance.PerformanceTestCase;
 
 import com.aptana.core.util.ResourceUtil;
@@ -59,6 +60,7 @@ public class HTMLTidyValidatorPerformanceTest extends PerformanceTestCase
 
 	public void testValidate() throws Exception
 	{
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		// read in the file
 		URL url = FileLocator.find(Platform.getBundle("com.aptana.editor.html.tests"),
 				Path.fromPortableString("performance/amazon.html"), null);

--- a/tests/com.aptana.editor.js.tests/src/com/aptana/editor/js/contentassist/JSBuildPerformanceTest.java
+++ b/tests/com.aptana.editor.js.tests/src/com/aptana/editor/js/contentassist/JSBuildPerformanceTest.java
@@ -21,6 +21,7 @@ import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.test.performance.Dimension;
 import org.eclipse.test.performance.PerformanceTestCase;
 
 import com.aptana.core.build.UnifiedBuilder;
@@ -70,6 +71,7 @@ public class JSBuildPerformanceTest extends PerformanceTestCase
 
 	public void testBuildJaxer() throws Exception
 	{
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		URL url = FileLocator.find(Platform.getBundle(JSCorePlugin.PLUGIN_ID), new Path("performance/jaxer"), null);
 		IFileStore fileStore = EFS.getStore(ResourceUtil.resourcePathToURI(url));
 		IFileStore destination = EFS.getStore(project.getURI());

--- a/tests/com.aptana.editor.js.tests/src/com/aptana/editor/js/contentassist/JSIndexingPerformanceTest.java
+++ b/tests/com.aptana.editor.js.tests/src/com/aptana/editor/js/contentassist/JSIndexingPerformanceTest.java
@@ -20,6 +20,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.test.performance.Dimension;
 import org.eclipse.test.performance.PerformanceTestCase;
 
 import com.aptana.core.util.IOUtil;
@@ -133,6 +134,7 @@ public class JSIndexingPerformanceTest extends PerformanceTestCase
 	 */
 	public void testDojoUncompressed() throws Exception
 	{
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		timeIndex(10, "performance/dojo.js.uncompressed.js");
 	}
 
@@ -143,6 +145,7 @@ public class JSIndexingPerformanceTest extends PerformanceTestCase
 	 */
 	public void testExt() throws Exception
 	{
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		timeIndex(20, "performance/ext/ext-core.js");
 	}
 
@@ -153,6 +156,7 @@ public class JSIndexingPerformanceTest extends PerformanceTestCase
 	 */
 	public void testJaxerFiles() throws Exception
 	{
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		timeIndex(5, "performance/jaxer/11.2.2-1-n.js", "performance/jaxer/15.10.6.2-2.js",
 				"performance/jaxer/15.5.4.7-2.js", "performance/jaxer/15.9.5.21-3.js",
 				"performance/jaxer/ComposerCommands.js",
@@ -209,6 +213,7 @@ public class JSIndexingPerformanceTest extends PerformanceTestCase
 	 */
 	public void testTiMobile() throws Exception
 	{
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		timeIndex(10, "performance/timobile.js");
 	}
 
@@ -219,6 +224,7 @@ public class JSIndexingPerformanceTest extends PerformanceTestCase
 	 */
 	public void testTinyMce() throws Exception
 	{
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		timeIndex(50, "performance/tiny_mce.js");
 	}
 

--- a/tests/com.aptana.editor.js.tests/src/com/aptana/editor/js/tests/performance/JSLintValidatorPerformanceTest.java
+++ b/tests/com.aptana.editor.js.tests/src/com/aptana/editor/js/tests/performance/JSLintValidatorPerformanceTest.java
@@ -15,6 +15,7 @@ import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.test.performance.Dimension;
 import org.eclipse.test.performance.PerformanceTestCase;
 
 import com.aptana.core.build.AbstractBuildParticipant;
@@ -112,11 +113,13 @@ public class JSLintValidatorPerformanceTest extends PerformanceTestCase
 
 	public void testValidateUncompressedDojo() throws Exception
 	{
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		perfValidate("dojo.js.uncompressed.js", 10);
 	}
 
 	public void testValidateMinifiedDojo() throws Exception
 	{
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		perfValidate("dojo.js.minified.js", 10);
 	}
 
@@ -127,11 +130,13 @@ public class JSLintValidatorPerformanceTest extends PerformanceTestCase
 
 	public void testValidateTiMobile() throws Exception
 	{
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		perfValidate("timobile.js", 10);
 	}
 
 	public void testValidateTinyMCE() throws Exception
 	{
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		perfValidate("tiny_mce.js", 10);
 	}
 }

--- a/tests/com.aptana.editor.js.tests/src/com/aptana/editor/js/tests/performance/JSParserValidatorPerformanceTest.java
+++ b/tests/com.aptana.editor.js.tests/src/com/aptana/editor/js/tests/performance/JSParserValidatorPerformanceTest.java
@@ -13,6 +13,7 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.test.performance.Dimension;
 import org.eclipse.test.performance.PerformanceTestCase;
 
 import com.aptana.core.build.AbstractBuildParticipant;
@@ -102,6 +103,7 @@ public class JSParserValidatorPerformanceTest extends PerformanceTestCase
 
 	public void testThreeMinJS() throws Exception
 	{
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		perfValidate("three.min.js", 1);
 	}
 }

--- a/tests/com.aptana.editor.js.tests/src/com/aptana/editor/js/text/JSCodeScannerPerformanceTest.java
+++ b/tests/com.aptana.editor.js.tests/src/com/aptana/editor/js/text/JSCodeScannerPerformanceTest.java
@@ -18,11 +18,11 @@ import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.rules.ITokenScanner;
 import org.eclipse.jface.text.rules.Token;
+import org.eclipse.test.performance.Dimension;
 import org.eclipse.test.performance.PerformanceTestCase;
 
 import com.aptana.core.util.IOUtil;
 import com.aptana.editor.epl.tests.EditorTestHelper;
-import com.aptana.editor.js.text.JSCodeScanner;
 import com.aptana.js.core.JSCorePlugin;
 
 public class JSCodeScannerPerformanceTest extends PerformanceTestCase
@@ -47,21 +47,25 @@ public class JSCodeScannerPerformanceTest extends PerformanceTestCase
 
 	public void testScanUncompressedDojo() throws Exception
 	{
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		perfScan("dojo.js.uncompressed.js", 50);
 	}
 
 	public void testScanMinifiedDojo() throws Exception
 	{
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		perfScan("dojo.js.minified.js", 70);
 	}
 
 	public void testScanTiMobile() throws Exception
 	{
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		perfScan("timobile.js", 15);
 	}
 
 	public void testScanTinyMCE() throws Exception
 	{
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		perfScan("tiny_mce.js", 20);
 	}
 

--- a/tests/com.aptana.editor.js.tests/src/com/aptana/editor/js/text/JSSourcePartitionScannerPerformanceTest.java
+++ b/tests/com.aptana.editor.js.tests/src/com/aptana/editor/js/text/JSSourcePartitionScannerPerformanceTest.java
@@ -17,6 +17,7 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IDocumentPartitioner;
+import org.eclipse.test.performance.Dimension;
 import org.eclipse.test.performance.PerformanceTestCase;
 
 import com.aptana.core.util.IOUtil;
@@ -52,21 +53,25 @@ public class JSSourcePartitionScannerPerformanceTest extends PerformanceTestCase
 
 	public void testPartitionUncompressedDojo() throws Exception
 	{
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		perfPartition("dojo.js.uncompressed.js", 100);
 	}
 
 	public void testPartitionMinifiedDojo() throws Exception
 	{
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		perfPartition("dojo.js.minified.js", 70);
 	}
 
 	public void testPartitionTiMobile() throws Exception
 	{
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		perfPartition("timobile.js", 30);
 	}
 
 	public void testPartitionTinyMCE() throws Exception
 	{
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		perfPartition("tiny_mce.js", 45);
 	}
 

--- a/tests/com.aptana.editor.json.tests/src/com/aptana/editor/json/JSONScannerPerformanceTest.java
+++ b/tests/com.aptana.editor.json.tests/src/com/aptana/editor/json/JSONScannerPerformanceTest.java
@@ -15,6 +15,7 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.rules.Token;
+import org.eclipse.test.performance.Dimension;
 import org.eclipse.test.performance.PerformanceTestCase;
 
 import com.aptana.core.util.IOUtil;
@@ -44,6 +45,7 @@ public class JSONScannerPerformanceTest extends PerformanceTestCase
 
 	public void testLongOneLiner() throws Exception
 	{
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		// read in the file
 		InputStream stream = FileLocator.openStream(Platform.getBundle("com.aptana.editor.json.tests"), //$NON-NLS-1$
 				Path.fromPortableString("performance/api-aptana-format.json"), false); //$NON-NLS-1$

--- a/tests/com.aptana.js.core.tests/src/com/aptana/js/core/parsing/JSFlexScannerPerformanceTest.java
+++ b/tests/com.aptana.js.core.tests/src/com/aptana/js/core/parsing/JSFlexScannerPerformanceTest.java
@@ -13,6 +13,7 @@ import java.io.InputStream;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.test.performance.Dimension;
 import org.eclipse.test.performance.PerformanceTestCase;
 
 import beaver.Symbol;
@@ -23,8 +24,7 @@ import com.aptana.js.core.tests.ITestFiles;
 import com.aptana.parsing.IParseState;
 import com.aptana.parsing.ParseState;
 
-public class JSFlexScannerPerformanceTest extends PerformanceTestCase
-{
+public class JSFlexScannerPerformanceTest extends PerformanceTestCase {
 	private JSFlexScanner fScanner;
 
 	/**
@@ -34,8 +34,7 @@ public class JSFlexScannerPerformanceTest extends PerformanceTestCase
 	 * @return
 	 * @throws IOException
 	 */
-	private String getSource(InputStream stream) throws IOException
-	{
+	private String getSource(InputStream stream) throws IOException {
 		return IOUtil.read(stream);
 	}
 
@@ -46,20 +45,20 @@ public class JSFlexScannerPerformanceTest extends PerformanceTestCase
 	 * @return
 	 * @throws IOException
 	 */
-	private String getSource(String resourceName) throws IOException
-	{
-		InputStream stream = FileLocator.openStream(Platform.getBundle(JSCorePlugin.PLUGIN_ID), new Path(resourceName),
+	private String getSource(String resourceName) throws IOException {
+		InputStream stream = FileLocator.openStream(Platform
+				.getBundle(JSCorePlugin.PLUGIN_ID), new Path(resourceName),
 				false);
 		return getSource(stream);
 	}
 
 	/*
 	 * (non-Javadoc)
+	 * 
 	 * @see junit.framework.TestCase#setUp()
 	 */
 	@Override
-	protected void setUp() throws Exception
-	{
+	protected void setUp() throws Exception {
 		super.setUp();
 
 		fScanner = new JSFlexScanner();
@@ -68,11 +67,11 @@ public class JSFlexScannerPerformanceTest extends PerformanceTestCase
 
 	/*
 	 * (non-Javadoc)
+	 * 
 	 * @see junit.framework.TestCase#tearDown()
 	 */
 	@Override
-	protected void tearDown() throws Exception
-	{
+	protected void tearDown() throws Exception {
 		fScanner = null;
 
 		super.tearDown();
@@ -83,13 +82,13 @@ public class JSFlexScannerPerformanceTest extends PerformanceTestCase
 	 * 
 	 * @throws Exception
 	 */
-	public void testDojo() throws Exception
-	{
+	public void testDojo() throws Exception {
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		assertScan(75, ITestFiles.DOJO_FILES);
 	}
 
-	public void testDojoMinified() throws Exception
-	{
+	public void testDojoMinified() throws Exception {
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		assertScan(500, "performance/dojo.js.minified.js");
 	}
 
@@ -98,8 +97,8 @@ public class JSFlexScannerPerformanceTest extends PerformanceTestCase
 	 * 
 	 * @throws Exception
 	 */
-	public void testExt() throws Exception
-	{
+	public void testExt() throws Exception {
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		assertScan(30, ITestFiles.EXT_FILES);
 	}
 
@@ -108,8 +107,8 @@ public class JSFlexScannerPerformanceTest extends PerformanceTestCase
 	 * 
 	 * @throws Exception
 	 */
-	public void testTiMobile() throws Exception
-	{
+	public void testTiMobile() throws Exception {
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		assertScan(50, ITestFiles.TIMOBILE_FILES);
 	}
 
@@ -118,8 +117,8 @@ public class JSFlexScannerPerformanceTest extends PerformanceTestCase
 	 * 
 	 * @throws Exception
 	 */
-	public void testTinyMce() throws Exception
-	{
+	public void testTinyMce() throws Exception {
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		assertScan(150, ITestFiles.TINY_MCE_FILES);
 	}
 
@@ -128,8 +127,8 @@ public class JSFlexScannerPerformanceTest extends PerformanceTestCase
 	 * 
 	 * @throws Exception
 	 */
-	public void testJaxerFiles() throws Exception
-	{
+	public void testJaxerFiles() throws Exception {
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		assertScan(125, ITestFiles.JAXER_FILES);
 	}
 
@@ -139,10 +138,8 @@ public class JSFlexScannerPerformanceTest extends PerformanceTestCase
 	 * @param resourceName
 	 * @throws Exception
 	 */
-	private void assertScan(int numRuns, String... resources) throws Exception
-	{
-		for (String resourceName : resources)
-		{
+	private void assertScan(int numRuns, String... resources) throws Exception {
+		for (String resourceName : resources) {
 			timeScan(resourceName, numRuns);
 		}
 		commitMeasurements();
@@ -156,8 +153,7 @@ public class JSFlexScannerPerformanceTest extends PerformanceTestCase
 	 * @param numRuns
 	 * @throws Exception
 	 */
-	private void timeScan(String resourceName, int numRuns) throws Exception
-	{
+	private void timeScan(String resourceName, int numRuns) throws Exception {
 		this.timeScan(resourceName, getSource(resourceName), numRuns);
 	}
 
@@ -167,21 +163,19 @@ public class JSFlexScannerPerformanceTest extends PerformanceTestCase
 	 * @param resourceName
 	 * @throws Exception
 	 */
-	private void timeScan(String resourceName, String src, int numRuns) throws Exception
-	{
+	private void timeScan(String resourceName, String src, int numRuns)
+			throws Exception {
 		// apply to parse state
 		IParseState parseState = new ParseState(src);
 
-		for (int i = 0; i < numRuns; i++)
-		{
+		for (int i = 0; i < numRuns; i++) {
 			startMeasuring();
 
 			fScanner.setSource(src);
 
 			Symbol symbol = fScanner.nextToken();
 
-			while (symbol != null && symbol.getId() != 0)
-			{
+			while (symbol != null && symbol.getId() != 0) {
 				symbol = fScanner.nextToken();
 			}
 

--- a/tests/com.aptana.js.core.tests/src/com/aptana/js/core/parsing/JSParserPerformanceTest.java
+++ b/tests/com.aptana.js.core.tests/src/com/aptana/js/core/parsing/JSParserPerformanceTest.java
@@ -21,6 +21,7 @@ import java.util.Queue;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.test.performance.Dimension;
 import org.eclipse.test.performance.Performance;
 import org.eclipse.test.performance.PerformanceTestCase;
 
@@ -28,8 +29,7 @@ import com.aptana.core.util.IOUtil;
 import com.aptana.js.core.JSCorePlugin;
 import com.aptana.js.core.tests.ITestFiles;
 
-public class JSParserPerformanceTest extends PerformanceTestCase
-{
+public class JSParserPerformanceTest extends PerformanceTestCase {
 
 	private JSParser fParser;
 
@@ -39,19 +39,17 @@ public class JSParserPerformanceTest extends PerformanceTestCase
 	 * @param root
 	 * @throws Exception
 	 */
-	public void assertLocalFiles(File root) throws Exception
-	{
+	public void assertLocalFiles(File root) throws Exception {
 		List<File> files = collectFiles(root);
 
-		for (File file : files)
-		{
-			if (fPerformanceMeter != null)
-			{
+		for (File file : files) {
+			if (fPerformanceMeter != null) {
 				fPerformanceMeter.dispose();
 			}
 
 			Performance performance = Performance.getDefault();
-			fPerformanceMeter = performance.createPerformanceMeter(file.getAbsolutePath());
+			fPerformanceMeter = performance.createPerformanceMeter(file
+					.getAbsolutePath());
 
 			FileInputStream fis = new FileInputStream(file);
 			String source = getSource(fis);
@@ -69,17 +67,15 @@ public class JSParserPerformanceTest extends PerformanceTestCase
 	 * @param resourceName
 	 * @throws Exception
 	 */
-	private void assertParse(int numRuns, String... resources) throws Exception
-	{
-		for (String resourceName : resources)
-		{
-			if (fPerformanceMeter != null)
-			{
+	private void assertParse(int numRuns, String... resources) throws Exception {
+		for (String resourceName : resources) {
+			if (fPerformanceMeter != null) {
 				fPerformanceMeter.dispose();
 			}
 
 			Performance performance = Performance.getDefault();
-			fPerformanceMeter = performance.createPerformanceMeter(resourceName);
+			fPerformanceMeter = performance
+					.createPerformanceMeter(resourceName);
 
 			timeParse(resourceName, numRuns);
 
@@ -94,22 +90,17 @@ public class JSParserPerformanceTest extends PerformanceTestCase
 	 * @param root
 	 * @return
 	 */
-	private List<File> collectFiles(File root)
-	{
+	private List<File> collectFiles(File root) {
 		List<File> result = new ArrayList<File>();
 		final Queue<File> directories = new LinkedList<File>();
 
 		directories.offer(root);
 
-		while (!directories.isEmpty())
-		{
+		while (!directories.isEmpty()) {
 			File directory = directories.poll();
-			File[] files = directory.listFiles(new FileFilter()
-			{
-				public boolean accept(File pathname)
-				{
-					if (pathname.isDirectory())
-					{
+			File[] files = directory.listFiles(new FileFilter() {
+				public boolean accept(File pathname) {
+					if (pathname.isDirectory()) {
 						directories.add(pathname);
 						return false;
 					}
@@ -131,8 +122,7 @@ public class JSParserPerformanceTest extends PerformanceTestCase
 	 * @return
 	 * @throws IOException
 	 */
-	private String getSource(InputStream stream) throws IOException
-	{
+	private String getSource(InputStream stream) throws IOException {
 		return IOUtil.read(stream);
 	}
 
@@ -143,31 +133,31 @@ public class JSParserPerformanceTest extends PerformanceTestCase
 	 * @return
 	 * @throws IOException
 	 */
-	private String getSource(String resourceName) throws IOException
-	{
-		InputStream stream = FileLocator.openStream(Platform.getBundle(JSCorePlugin.PLUGIN_ID), new Path(resourceName),
+	private String getSource(String resourceName) throws IOException {
+		InputStream stream = FileLocator.openStream(Platform
+				.getBundle(JSCorePlugin.PLUGIN_ID), new Path(resourceName),
 				false);
 		return getSource(stream);
 	}
 
 	/*
 	 * (non-Javadoc)
+	 * 
 	 * @see junit.framework.TestCase#setUp()
 	 */
 	@Override
-	protected void setUp() throws Exception
-	{
+	protected void setUp() throws Exception {
 		super.setUp();
 		fParser = new JSParser();
 	}
 
 	/*
 	 * (non-Javadoc)
+	 * 
 	 * @see junit.framework.TestCase#tearDown()
 	 */
 	@Override
-	protected void tearDown() throws Exception
-	{
+	protected void tearDown() throws Exception {
 		fParser = null;
 		super.tearDown();
 	}
@@ -177,13 +167,13 @@ public class JSParserPerformanceTest extends PerformanceTestCase
 	 * 
 	 * @throws Exception
 	 */
-	public void testDojo() throws Exception
-	{
+	public void testDojo() throws Exception {
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		assertParse(1000, ITestFiles.DOJO_FILES);
 	}
 
-	public void testDojoMinified() throws Exception
-	{
+	public void testDojoMinified() throws Exception {
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		assertParse(1000, "performance/dojo.js.minified.js");
 	}
 
@@ -192,8 +182,8 @@ public class JSParserPerformanceTest extends PerformanceTestCase
 	 * 
 	 * @throws Exception
 	 */
-	public void testExt() throws Exception
-	{
+	public void testExt() throws Exception {
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		assertParse(15, ITestFiles.EXT_FILES);
 	}
 
@@ -202,8 +192,8 @@ public class JSParserPerformanceTest extends PerformanceTestCase
 	 * 
 	 * @throws Exception
 	 */
-	public void testJaxerFiles() throws Exception
-	{
+	public void testJaxerFiles() throws Exception {
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		assertParse(50, ITestFiles.JAXER_FILES);
 	}
 
@@ -212,8 +202,8 @@ public class JSParserPerformanceTest extends PerformanceTestCase
 	 * 
 	 * @throws Exception
 	 */
-	public void testTiMobile() throws Exception
-	{
+	public void testTiMobile() throws Exception {
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		assertParse(375, ITestFiles.TIMOBILE_FILES);
 	}
 
@@ -222,8 +212,8 @@ public class JSParserPerformanceTest extends PerformanceTestCase
 	 * 
 	 * @throws Exception
 	 */
-	public void testTinyMce() throws Exception
-	{
+	public void testTinyMce() throws Exception {
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		assertParse(430, ITestFiles.TINY_MCE_FILES);
 	}
 
@@ -234,8 +224,7 @@ public class JSParserPerformanceTest extends PerformanceTestCase
 	 * @param numRuns
 	 * @throws Exception
 	 */
-	private void timeParse(String resourceName, int numRuns) throws Exception
-	{
+	private void timeParse(String resourceName, int numRuns) throws Exception {
 		this.timeParse(resourceName, getSource(resourceName), numRuns);
 	}
 
@@ -245,20 +234,16 @@ public class JSParserPerformanceTest extends PerformanceTestCase
 	 * @param resourceName
 	 * @throws Exception
 	 */
-	private void timeParse(String resourceName, String src, int numRuns) throws Exception
-	{
+	private void timeParse(String resourceName, String src, int numRuns)
+			throws Exception {
 		// apply to parse state
 		JSParseState parseState = new JSParseState(src);
 
-		for (int i = 0; i < numRuns; i++)
-		{
+		for (int i = 0; i < numRuns; i++) {
 			startMeasuring();
-			try
-			{
+			try {
 				fParser.parse(parseState);
-			}
-			catch (Exception e)
-			{
+			} catch (Exception e) {
 				fail(e.getMessage());
 			}
 			stopMeasuring();

--- a/tests/com.aptana.js.core.tests/src/com/aptana/js/internal/core/parsing/sdoc/SDocParserPerformanceTest.java
+++ b/tests/com.aptana.js.core.tests/src/com/aptana/js/internal/core/parsing/sdoc/SDocParserPerformanceTest.java
@@ -17,15 +17,16 @@ import java.util.regex.Pattern;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.test.performance.Dimension;
 import org.eclipse.test.performance.PerformanceTestCase;
 
 import com.aptana.core.util.IOUtil;
 import com.aptana.js.core.JSCorePlugin;
 import com.aptana.js.core.tests.ITestFiles;
 
-public class SDocParserPerformanceTest extends PerformanceTestCase
-{
-	private static final Pattern COMMENT = Pattern.compile("/\\*\\*.*?\\*/", Pattern.DOTALL);
+public class SDocParserPerformanceTest extends PerformanceTestCase {
+	private static final Pattern COMMENT = Pattern.compile("/\\*\\*.*?\\*/",
+			Pattern.DOTALL);
 	private SDocParser fParser;
 
 	/**
@@ -35,8 +36,7 @@ public class SDocParserPerformanceTest extends PerformanceTestCase
 	 * @return
 	 * @throws IOException
 	 */
-	private String getSource(InputStream stream) throws IOException
-	{
+	private String getSource(InputStream stream) throws IOException {
 		return IOUtil.read(stream);
 	}
 
@@ -47,20 +47,20 @@ public class SDocParserPerformanceTest extends PerformanceTestCase
 	 * @return
 	 * @throws IOException
 	 */
-	private String getSource(String resourceName) throws IOException
-	{
-		InputStream stream = FileLocator.openStream(Platform.getBundle(JSCorePlugin.PLUGIN_ID), new Path(resourceName),
+	private String getSource(String resourceName) throws IOException {
+		InputStream stream = FileLocator.openStream(Platform
+				.getBundle(JSCorePlugin.PLUGIN_ID), new Path(resourceName),
 				false);
 		return getSource(stream);
 	}
 
 	/*
 	 * (non-Javadoc)
+	 * 
 	 * @see junit.framework.TestCase#setUp()
 	 */
 	@Override
-	protected void setUp() throws Exception
-	{
+	protected void setUp() throws Exception {
 		super.setUp();
 
 		fParser = new SDocParser();
@@ -68,11 +68,11 @@ public class SDocParserPerformanceTest extends PerformanceTestCase
 
 	/*
 	 * (non-Javadoc)
+	 * 
 	 * @see junit.framework.TestCase#tearDown()
 	 */
 	@Override
-	protected void tearDown() throws Exception
-	{
+	protected void tearDown() throws Exception {
 		fParser = null;
 		super.tearDown();
 	}
@@ -82,8 +82,8 @@ public class SDocParserPerformanceTest extends PerformanceTestCase
 	 * 
 	 * @throws Exception
 	 */
-	public void testTiMobile() throws Exception
-	{
+	public void testTiMobile() throws Exception {
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		assertParse(10, ITestFiles.TIMOBILE_FILES);
 	}
 
@@ -93,10 +93,8 @@ public class SDocParserPerformanceTest extends PerformanceTestCase
 	 * @param resourceName
 	 * @throws Exception
 	 */
-	private void assertParse(int numRuns, String... resources) throws Exception
-	{
-		for (String resourceName : resources)
-		{
+	private void assertParse(int numRuns, String... resources) throws Exception {
+		for (String resourceName : resources) {
 			timeParse(resourceName, numRuns);
 		}
 		commitMeasurements();
@@ -110,8 +108,7 @@ public class SDocParserPerformanceTest extends PerformanceTestCase
 	 * @param numRuns
 	 * @throws Exception
 	 */
-	private void timeParse(String resourceName, int numRuns) throws Exception
-	{
+	private void timeParse(String resourceName, int numRuns) throws Exception {
 		this.timeParse(resourceName, getSource(resourceName), numRuns);
 	}
 
@@ -121,13 +118,11 @@ public class SDocParserPerformanceTest extends PerformanceTestCase
 	 * @param src
 	 * @return
 	 */
-	protected List<String> collectComments(String src)
-	{
+	protected List<String> collectComments(String src) {
 		List<String> result = new ArrayList<String>();
 		Matcher m = COMMENT.matcher(src);
 
-		while (m.find())
-		{
+		while (m.find()) {
 			result.add(m.group());
 		}
 
@@ -140,23 +135,18 @@ public class SDocParserPerformanceTest extends PerformanceTestCase
 	 * @param resourceName
 	 * @throws Exception
 	 */
-	private void timeParse(String resourceName, String src, int numRuns) throws Exception
-	{
+	private void timeParse(String resourceName, String src, int numRuns)
+			throws Exception {
 		List<String> comments = collectComments(src);
 
 		// apply to parse state
-		for (int i = 0; i < numRuns; i++)
-		{
+		for (int i = 0; i < numRuns; i++) {
 			startMeasuring();
 
-			for (String comment : comments)
-			{
-				try
-				{
+			for (String comment : comments) {
+				try {
 					fParser.parse(comment);
-				}
-				catch (Exception e)
-				{
+				} catch (Exception e) {
 					// fail(e.getMessage());
 					// System.out.println("Failed\n" + comment);
 				}

--- a/tests/com.aptana.scripting.tests/src/com/aptana/scripting/model/BundleLoadingPerformanceTest.java
+++ b/tests/com.aptana.scripting.tests/src/com/aptana/scripting/model/BundleLoadingPerformanceTest.java
@@ -1,5 +1,6 @@
 package com.aptana.scripting.model;
 
+import org.eclipse.test.performance.Dimension;
 import org.eclipse.test.performance.PerformanceTestCase;
 
 public class BundleLoadingPerformanceTest extends PerformanceTestCase
@@ -25,6 +26,7 @@ public class BundleLoadingPerformanceTest extends PerformanceTestCase
 
 	public void testLoadingUserBundlesWithoutCache() throws Exception
 	{
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		System.setProperty("use.bundle.cache", Boolean.FALSE.toString());
 		for (int i = 0; i < 25; i++)
 		{
@@ -38,6 +40,7 @@ public class BundleLoadingPerformanceTest extends PerformanceTestCase
 
 	public void testLoadingUserBundlesWithCache() throws Exception
 	{
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		System.setProperty("use.bundle.cache", Boolean.TRUE.toString());
 		for (int i = 0; i < 25; i++)
 		{

--- a/tests/com.aptana.theme.tests/src/com/aptana/theme/ThemePerformanceTest.java
+++ b/tests/com.aptana.theme.tests/src/com/aptana/theme/ThemePerformanceTest.java
@@ -16,6 +16,7 @@ import java.util.List;
 
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Path;
+import org.eclipse.test.performance.Dimension;
 import org.eclipse.test.performance.PerformanceTestCase;
 
 import com.aptana.core.epl.util.LRUCache;
@@ -48,6 +49,7 @@ public class ThemePerformanceTest extends PerformanceTestCase
 	@SuppressWarnings("rawtypes")
 	public void testLoadingUserBundlesWithCache() throws Exception
 	{
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
 		// Note: scopes_performance.txt was generated from opening the js editor using google.html
 		// attached to https://jira.appcelerator.org/browse/APSTUD-4015.
 

--- a/tests/com.aptana.xml.core.tests/src/com/aptana/xml/core/parsing/XMLParserPerformanceTest.java
+++ b/tests/com.aptana.xml.core.tests/src/com/aptana/xml/core/parsing/XMLParserPerformanceTest.java
@@ -12,40 +12,37 @@ import java.io.InputStream;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.test.performance.Dimension;
 import org.eclipse.test.performance.PerformanceTestCase;
 
 import com.aptana.core.util.IOUtil;
 import com.aptana.parsing.IParseState;
 import com.aptana.parsing.ParseState;
-import com.aptana.xml.core.parsing.XMLParser;
 
-public class XMLParserPerformanceTest extends PerformanceTestCase
-{
+public class XMLParserPerformanceTest extends PerformanceTestCase {
 
 	private XMLParser fParser;
 
 	@Override
-	protected void setUp() throws Exception
-	{
+	protected void setUp() throws Exception {
 		super.setUp();
 		fParser = new XMLParser();
 	}
 
 	@Override
-	protected void tearDown() throws Exception
-	{
+	protected void tearDown() throws Exception {
 		fParser = null;
 		super.tearDown();
 	}
 
-	public void testDOM2XMLMetadata() throws Exception
-	{
-		InputStream stream = FileLocator.openStream(Platform.getBundle("com.aptana.xml.core.tests"),
+	public void testDOM2XMLMetadata() throws Exception {
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
+		InputStream stream = FileLocator.openStream(
+				Platform.getBundle("com.aptana.xml.core.tests"),
 				Path.fromPortableString("performance/dom_2.xml"), false);
 		String src = IOUtil.read(stream);
 
-		for (int i = 0; i < 50; i++)
-		{
+		for (int i = 0; i < 50; i++) {
 			IParseState parseState = new ParseState(src);
 			startMeasuring();
 			fParser.parse(parseState);

--- a/tests/com.aptana.xml.core.tests/src/com/aptana/xml/core/parsing/XMLParserScannerPerformanceTest.java
+++ b/tests/com.aptana.xml.core.tests/src/com/aptana/xml/core/parsing/XMLParserScannerPerformanceTest.java
@@ -12,43 +12,39 @@ import java.io.InputStream;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.test.performance.Dimension;
 import org.eclipse.test.performance.PerformanceTestCase;
 
 import com.aptana.core.util.IOUtil;
 import com.aptana.dtd.core.parsing.Terminals;
-import com.aptana.xml.core.parsing.XMLScanner;
 
-public class XMLParserScannerPerformanceTest extends PerformanceTestCase
-{
+public class XMLParserScannerPerformanceTest extends PerformanceTestCase {
 
 	private XMLScanner fScanner;
 
 	@Override
-	protected void setUp() throws Exception
-	{
+	protected void setUp() throws Exception {
 		super.setUp();
 		fScanner = new XMLScanner();
 	}
 
 	@Override
-	protected void tearDown() throws Exception
-	{
+	protected void tearDown() throws Exception {
 		fScanner = null;
 		super.tearDown();
 	}
 
-	public void testDOM2XMLMetadata() throws Exception
-	{
-		InputStream stream = FileLocator.openStream(Platform.getBundle("com.aptana.xml.core.tests"),
+	public void testDOM2XMLMetadata() throws Exception {
+		tagAsGlobalSummary(getDefaultScenarioId(), Dimension.ELAPSED_PROCESS);
+		InputStream stream = FileLocator.openStream(
+				Platform.getBundle("com.aptana.xml.core.tests"),
 				Path.fromPortableString("performance/dom_2.xml"), false);
 		String src = IOUtil.read(stream);
 
-		for (int i = 0; i < 500; i++)
-		{
+		for (int i = 0; i < 500; i++) {
 			startMeasuring();
 			fScanner.setSource(src);
-			while (fScanner.nextToken().getId() != Terminals.EOF)
-			{
+			while (fScanner.nextToken().getId() != Terminals.EOF) {
 			}
 			stopMeasuring();
 		}

--- a/tests/org.eclipse.test.performance/src/org/eclipse/test/performance/Performance.java
+++ b/tests/org.eclipse.test.performance/src/org/eclipse/test/performance/Performance.java
@@ -13,7 +13,6 @@ package org.eclipse.test.performance;
 import junit.framework.TestCase;
 
 import org.eclipse.core.runtime.Platform;
-
 import org.eclipse.test.internal.performance.InternalDimensions;
 import org.eclipse.test.internal.performance.InternalPerformanceMeter;
 import org.eclipse.test.internal.performance.NullPerformanceMeter;
@@ -37,23 +36,22 @@ import org.osgi.framework.Bundle;
  * @since 3.1
  */
 public class Performance {
-	
-	/**
-	 *  A comment kind of a comment that explains a performance degradation.
-	 */
-	public static final int EXPLAINS_DEGRADATION_COMMENT= 1;
 
-	private static final String PERFORMANCE_METER_FACTORY= "/option/performanceMeterFactory"; //$NON-NLS-1$
-	private static final String PERFORMANCE_METER_FACTORY_PROPERTY= "PerformanceMeterFactory"; //$NON-NLS-1$
+	/**
+	 * A comment kind of a comment that explains a performance degradation.
+	 */
+	public static final int EXPLAINS_DEGRADATION_COMMENT = 1;
+
+	private static final String PERFORMANCE_METER_FACTORY = "/option/performanceMeterFactory"; //$NON-NLS-1$
+	private static final String PERFORMANCE_METER_FACTORY_PROPERTY = "PerformanceMeterFactory"; //$NON-NLS-1$
 
 	private static Performance fgDefault;
-	
+
 	private PerformanceMeterFactory fPerformanceMeterFactory;
 	private IEvaluator fDefaultEvaluator;
 
 	/** Null performance meter singleton */
 	private NullPerformanceMeter fNullPeformanceMeter;
-	
 
 	/**
 	 * Private constructor to block instance creation.
@@ -61,7 +59,7 @@ public class Performance {
 	private Performance() {
 		// empty
 	}
-	
+
 	/**
 	 * Returns the singleton of <code>Performance</code>
 	 * 
@@ -69,76 +67,105 @@ public class Performance {
 	 */
 	public static Performance getDefault() {
 		if (fgDefault == null)
-			fgDefault= new Performance();
+			fgDefault = new Performance();
 		return fgDefault;
 	}
-	
+
 	/**
 	 * Asserts default properties of the measurements captured by the given
 	 * performance meter.
 	 * 
-	 * @param performanceMeter the performance meter
-	 * @throws RuntimeException if the properties do not hold
+	 * @param performanceMeter
+	 *            the performance meter
+	 * @throws RuntimeException
+	 *             if the properties do not hold
 	 */
 	public void assertPerformance(PerformanceMeter performanceMeter) {
 		if (fDefaultEvaluator == null) {
-			fDefaultEvaluator= new Evaluator();
-			fDefaultEvaluator.setAssertCheckers(new AssertChecker[] {
-			        new RelativeBandChecker(InternalDimensions.ELAPSED_PROCESS, 0.0f, 1.10f),
-			        //new RelativeBandChecker(InternalDimensions.CPU_TIME, 0.0f, 1.10f),
-			        //new RelativeBandChecker(InternalDimensions.WORKING_SET, 0.0f, 3.00f),
-			        //new RelativeBandChecker(InternalDimensions.USED_JAVA_HEAP, 0.0f, 2.00f),
-			        //new RelativeBandChecker(InternalDimensions.SYSTEM_TIME, 0.0f, 1.10f)
-			});
+			fDefaultEvaluator = new Evaluator();
+			fDefaultEvaluator
+					.setAssertCheckers(new AssertChecker[] { new RelativeBandChecker(
+							InternalDimensions.ELAPSED_PROCESS, 0.0f, 1.10f),
+					// new RelativeBandChecker(InternalDimensions.CPU_TIME,
+					// 0.0f, 1.10f),
+					// new RelativeBandChecker(InternalDimensions.WORKING_SET,
+					// 0.0f, 3.00f),
+					// new
+					// RelativeBandChecker(InternalDimensions.USED_JAVA_HEAP,
+					// 0.0f, 2.00f),
+					// new RelativeBandChecker(InternalDimensions.SYSTEM_TIME,
+					// 0.0f, 1.10f)
+					});
 		}
 		fDefaultEvaluator.evaluate(performanceMeter);
 	}
 
 	/**
-	 * Asserts that the measurement specified by the dimension captured in the given
-	 * performance meter is within a certain range with respect to some reference value.
-	 * If the performance meter doesn't provide the specified dimension, the call has no effect.
+	 * Asserts that the measurement specified by the dimension captured in the
+	 * given performance meter is within a certain range with respect to some
+	 * reference value. If the performance meter doesn't provide the specified
+	 * dimension, the call has no effect.
 	 * 
-	 * @param performanceMeter the performance meter
-	 * @param dim the Dimension to check
-	 * @param lowerPercentage a negative number indicating the percentage the measured value is allowed to be smaller than some reference value
-	 * @param upperPercentage a positive number indicating the percentage the measured value is allowed to be greater than some reference value
-	 * @throws RuntimeException if the properties do not hold
+	 * @param performanceMeter
+	 *            the performance meter
+	 * @param dim
+	 *            the Dimension to check
+	 * @param lowerPercentage
+	 *            a negative number indicating the percentage the measured value
+	 *            is allowed to be smaller than some reference value
+	 * @param upperPercentage
+	 *            a positive number indicating the percentage the measured value
+	 *            is allowed to be greater than some reference value
+	 * @throws RuntimeException
+	 *             if the properties do not hold
 	 */
-	public void assertPerformanceInRelativeBand(PerformanceMeter performanceMeter, Dimension dim, int lowerPercentage, int upperPercentage) {
-	    Evaluator e= new Evaluator();
-		e.setAssertCheckers(new AssertChecker[] {
-		        new RelativeBandChecker((Dim) dim, 1.0+(lowerPercentage / 100.0), 1.0+(upperPercentage / 100.0)),
-		});
+	public void assertPerformanceInRelativeBand(
+			PerformanceMeter performanceMeter, Dimension dim,
+			int lowerPercentage, int upperPercentage) {
+		Evaluator e = new Evaluator();
+		e.setAssertCheckers(new AssertChecker[] { new RelativeBandChecker(
+				(Dim) dim, 1.0 + (lowerPercentage / 100.0),
+				1.0 + (upperPercentage / 100.0)), });
 		e.evaluate(performanceMeter);
 	}
 
 	/**
-	 * Asserts that the measurement specified by the dimension captured in the given
-	 * performance meter is within a certain range with respect to some reference value.
-	 * If the performance meter doesn't provide the specified dimension, the call has no effect.
+	 * Asserts that the measurement specified by the dimension captured in the
+	 * given performance meter is within a certain range with respect to some
+	 * reference value. If the performance meter doesn't provide the specified
+	 * dimension, the call has no effect.
 	 * 
-	 * @param performanceMeter the performance meter
-	 * @param dim the Dimension to check
-	 * @param lowerBand a negative number indicating the absolute amount the measured value is allowed to be smaller than some reference value
-	 * @param upperBand a positive number indicating the absolute amount the measured value is allowed to be greater than some reference value
-	 * @throws RuntimeException if the properties do not hold
+	 * @param performanceMeter
+	 *            the performance meter
+	 * @param dim
+	 *            the Dimension to check
+	 * @param lowerBand
+	 *            a negative number indicating the absolute amount the measured
+	 *            value is allowed to be smaller than some reference value
+	 * @param upperBand
+	 *            a positive number indicating the absolute amount the measured
+	 *            value is allowed to be greater than some reference value
+	 * @throws RuntimeException
+	 *             if the properties do not hold
 	 */
-	public void assertPerformanceInAbsoluteBand(PerformanceMeter performanceMeter, Dimension dim, int lowerBand, int upperBand) {
-	    Evaluator e= new Evaluator();
-		e.setAssertCheckers(new AssertChecker[] {
-		        new AbsoluteBandChecker((Dim) dim, lowerBand, upperBand),
-		});
+	public void assertPerformanceInAbsoluteBand(
+			PerformanceMeter performanceMeter, Dimension dim, int lowerBand,
+			int upperBand) {
+		Evaluator e = new Evaluator();
+		e.setAssertCheckers(new AssertChecker[] { new AbsoluteBandChecker(
+				(Dim) dim, lowerBand, upperBand), });
 		e.evaluate(performanceMeter);
 	}
 
 	/**
 	 * Creates a performance meter for the given scenario id.
 	 * 
-	 * @param scenarioId the scenario id
+	 * @param scenarioId
+	 *            the scenario id
 	 * @return a performance meter for the given scenario id
-	 * @throws IllegalArgumentException if a performance meter for the given
-	 *                 scenario id has already been created
+	 * @throws IllegalArgumentException
+	 *             if a performance meter for the given scenario id has already
+	 *             been created
 	 */
 	public PerformanceMeter createPerformanceMeter(String scenarioId) {
 		return getPeformanceMeterFactory().createPerformanceMeter(scenarioId);
@@ -151,30 +178,33 @@ public class Performance {
 	 */
 	public PerformanceMeter getNullPerformanceMeter() {
 		if (fNullPeformanceMeter == null)
-			fNullPeformanceMeter= new NullPerformanceMeter();
+			fNullPeformanceMeter = new NullPerformanceMeter();
 		return fNullPeformanceMeter;
 	}
 
 	/**
-	 * Returns a default scenario id for the given test. The test's name
-	 * must have been set, such that <code>test.getName()</code> is not
+	 * Returns a default scenario id for the given test. The test's name must
+	 * have been set, such that <code>test.getName()</code> is not
 	 * <code>null</code>.
 	 * 
-	 * @param test the test
+	 * @param test
+	 *            the test
 	 * @return the default scenario id for the test
 	 */
 	public String getDefaultScenarioId(TestCase test) {
 		return test.getClass().getName() + '#' + test.getName() + "()"; //$NON-NLS-1$
 	}
-	
+
 	/**
-	 * Returns a default scenario id for the given test and id. The test's
-	 * name must have been set, such that <code>test.getName()</code> is
-	 * not <code>null</code>. The id distinguishes multiple scenarios in
-	 * the same test.
+	 * Returns a default scenario id for the given test and id. The test's name
+	 * must have been set, such that <code>test.getName()</code> is not
+	 * <code>null</code>. The id distinguishes multiple scenarios in the same
+	 * test.
 	 * 
-	 * @param test the test
-	 * @param id the id
+	 * @param test
+	 *            the test
+	 * @param id
+	 *            the id
 	 * @return the default scenario id for the test and the id
 	 */
 	public String getDefaultScenarioId(TestCase test, String id) {
@@ -183,46 +213,49 @@ public class Performance {
 
 	private PerformanceMeterFactory getPeformanceMeterFactory() {
 		if (fPerformanceMeterFactory == null)
-			fPerformanceMeterFactory= createPerformanceMeterFactory();
+			fPerformanceMeterFactory = createPerformanceMeterFactory();
 		return fPerformanceMeterFactory;
 	}
-	
+
 	private PerformanceMeterFactory createPerformanceMeterFactory() {
 		PerformanceMeterFactory factory;
-		factory= tryInstantiate(System.getProperty(PERFORMANCE_METER_FACTORY_PROPERTY));
+		factory = tryInstantiate(System
+				.getProperty(PERFORMANCE_METER_FACTORY_PROPERTY));
 		if (factory != null)
 			return factory;
-		
-		factory= tryInstantiate(Platform.getDebugOption(PerformanceTestPlugin.PLUGIN_ID + PERFORMANCE_METER_FACTORY));
+
+		factory = tryInstantiate(Platform
+				.getDebugOption(PerformanceTestPlugin.PLUGIN_ID
+						+ PERFORMANCE_METER_FACTORY));
 		if (factory != null)
 			return factory;
-		
+
 		return createDefaultPerformanceMeterFactory();
 	}
-	
+
 	private PerformanceMeterFactory tryInstantiate(String className) {
-		PerformanceMeterFactory instance= null;
+		PerformanceMeterFactory instance = null;
 		if (className != null && className.length() > 0) {
 			try {
-				int separator= className.indexOf(':');
-				Bundle bundle= null;
+				int separator = className.indexOf(':');
+				Bundle bundle = null;
 				if (separator == -1) {
-					bundle= PerformanceTestPlugin.getDefault().getBundle();
+					bundle = PerformanceTestPlugin.getDefault().getBundle();
 				} else {
-					String bundleName= className.substring(0, separator);
-					className= className.substring(separator + 1);
-					bundle= Platform.getBundle(bundleName);
+					String bundleName = className.substring(0, separator);
+					className = className.substring(separator + 1);
+					bundle = Platform.getBundle(bundleName);
 				}
-				Class c= bundle.loadClass(className);
-				instance= (PerformanceMeterFactory) c.newInstance();
+				Class c = bundle.loadClass(className);
+				instance = (PerformanceMeterFactory) c.newInstance();
 			} catch (ClassNotFoundException e) {
-		        PerformanceTestPlugin.log(e);
+				PerformanceTestPlugin.log(e);
 			} catch (InstantiationException e) {
-		        PerformanceTestPlugin.log(e);
+				PerformanceTestPlugin.log(e);
 			} catch (IllegalAccessException e) {
-		        PerformanceTestPlugin.log(e);
+				PerformanceTestPlugin.log(e);
 			} catch (ClassCastException e) {
-		        PerformanceTestPlugin.log(e);
+				PerformanceTestPlugin.log(e);
 			}
 		}
 		return instance;
@@ -231,82 +264,111 @@ public class Performance {
 	private PerformanceMeterFactory createDefaultPerformanceMeterFactory() {
 		return new OSPerformanceMeterFactory();
 	}
-	
+
 	/**
-	 * Mark the scenario represented by the given PerformanceMeter
-	 * to be included into the global and the component performance summary. The summary shows
-	 * the given dimension of the scenario and labels the scenario with the short name.
+	 * Mark the scenario represented by the given PerformanceMeter to be
+	 * included into the global and the component performance summary. The
+	 * summary shows the given dimension of the scenario and labels the scenario
+	 * with the short name.
 	 * 
-	 * @param pm the PerformanceMeter
-	 * @param shortName a short (shorter than 40 characters) descriptive name of the scenario
-	 * @param dimension the dimension to show in the summary
+	 * @param pm
+	 *            the PerformanceMeter
+	 * @param shortName
+	 *            a short (shorter than 40 characters) descriptive name of the
+	 *            scenario
+	 * @param dimension
+	 *            the dimension to show in the summary
 	 */
-	public void tagAsGlobalSummary(PerformanceMeter pm, String shortName, Dimension dimension) {
-	    tagAsGlobalSummary(pm, shortName, new Dimension[] { dimension } );
+	public void tagAsGlobalSummary(PerformanceMeter pm, String shortName,
+			Dimension dimension) {
+		tagAsGlobalSummary(pm, shortName, new Dimension[] { dimension });
 	}
 
 	/**
-	 * Mark the scenario represented by the given PerformanceMeter
-	 * to be included into the global and the component performance summary. The summary shows
-	 * the given dimensions of the scenario and labels the scenario with the short name.
+	 * Mark the scenario represented by the given PerformanceMeter to be
+	 * included into the global and the component performance summary. The
+	 * summary shows the given dimensions of the scenario and labels the
+	 * scenario with the short name.
 	 * 
-	 * @param pm the PerformanceMeter
-	 * @param shortName a short (shorter than 40 characters) descriptive name of the scenario
-	 * @param dimensions an array of dimensions to show in the summary
+	 * @param pm
+	 *            the PerformanceMeter
+	 * @param shortName
+	 *            a short (shorter than 40 characters) descriptive name of the
+	 *            scenario
+	 * @param dimensions
+	 *            an array of dimensions to show in the summary
 	 */
-	public void tagAsGlobalSummary(PerformanceMeter pm, String shortName, Dimension[] dimensions) {
-	    if (pm instanceof InternalPerformanceMeter) {
-	        InternalPerformanceMeter ipm= (InternalPerformanceMeter) pm;
-	        ipm.tagAsSummary(true, shortName, dimensions);
-	    }
-	}
-
-	
-	/**
-	 * Mark the scenario represented by the given PerformanceMeter
-	 * to be included into the component performance summary. The summary shows
-	 * the given dimension of the scenario and labels the scenario with the short name.
-	 * 
-	 * @param pm the PerformanceMeter
-	 * @param shortName a short (shorter than 40 characters) descriptive name of the scenario
-	 * @param dimension the dimension to show in the summary
-	 */
-	public void tagAsSummary(PerformanceMeter pm, String shortName, Dimension dimension) {
-	    tagAsSummary(pm, shortName, new Dimension[] { dimension } );
+	public void tagAsGlobalSummary(PerformanceMeter pm, String shortName,
+			Dimension[] dimensions) {
+		if (pm instanceof InternalPerformanceMeter) {
+			InternalPerformanceMeter ipm = (InternalPerformanceMeter) pm;
+			ipm.tagAsSummary(true, shortName, dimensions);
+		}
 	}
 
 	/**
-	 * Mark the scenario represented by the given PerformanceMeter
-	 * to be included into the component performance summary. The summary shows
-	 * the given dimensions of the scenario and labels the scenario with the short name.
+	 * Mark the scenario represented by the given PerformanceMeter to be
+	 * included into the component performance summary. The summary shows the
+	 * given dimension of the scenario and labels the scenario with the short
+	 * name.
 	 * 
-	 * @param pm the PerformanceMeter
-	 * @param shortName a short (shorter than 40 characters) descriptive name of the scenario
-	 * @param dimensions an array of dimensions to show in the summary
+	 * @param pm
+	 *            the PerformanceMeter
+	 * @param shortName
+	 *            a short (shorter than 40 characters) descriptive name of the
+	 *            scenario
+	 * @param dimension
+	 *            the dimension to show in the summary
 	 */
-	public void tagAsSummary(PerformanceMeter pm, String shortName, Dimension[] dimensions) {
-	    if (pm instanceof InternalPerformanceMeter) {
-	        InternalPerformanceMeter ipm= (InternalPerformanceMeter) pm;
-	        ipm.tagAsSummary(false, shortName, dimensions);
-	    }
+	public void tagAsSummary(PerformanceMeter pm, String shortName,
+			Dimension dimension) {
+		tagAsSummary(pm, shortName, new Dimension[] { dimension });
+	}
+
+	/**
+	 * Mark the scenario represented by the given PerformanceMeter to be
+	 * included into the component performance summary. The summary shows the
+	 * given dimensions of the scenario and labels the scenario with the short
+	 * name.
+	 * 
+	 * @param pm
+	 *            the PerformanceMeter
+	 * @param shortName
+	 *            a short (shorter than 40 characters) descriptive name of the
+	 *            scenario
+	 * @param dimensions
+	 *            an array of dimensions to show in the summary
+	 */
+	public void tagAsSummary(PerformanceMeter pm, String shortName,
+			Dimension[] dimensions) {
+		if (pm instanceof InternalPerformanceMeter) {
+			InternalPerformanceMeter ipm = (InternalPerformanceMeter) pm;
+			ipm.tagAsSummary(false, shortName, dimensions);
+		}
 	}
 
 	/**
 	 * Set a comment for the scenario represented by the given PerformanceMeter.
-	 * Currently only comments with a commentKind of EXPLAINS_DEGRADATION_COMMENT are used.
-	 * Their commentText is shown in a hover of the performance summaries graph if a performance
-	 * degradation exists.
+	 * Currently only comments with a commentKind of
+	 * EXPLAINS_DEGRADATION_COMMENT are used. Their commentText is shown in a
+	 * hover of the performance summaries graph if a performance degradation
+	 * exists.
 	 * 
-	 * @param pm the PerformanceMeter
-	 * @param commentKind kind of comment. Must be EXPLAINS_DEGRADATION_COMMENT to have an effect.
-	 * @param commentText the comment (shorter than 400 characters)
+	 * @param pm
+	 *            the PerformanceMeter
+	 * @param commentKind
+	 *            kind of comment. Must be EXPLAINS_DEGRADATION_COMMENT to have
+	 *            an effect.
+	 * @param commentText
+	 *            the comment (shorter than 400 characters)
 	 */
-	public void setComment(PerformanceMeter pm, int commentKind, String commentText) {
+	public void setComment(PerformanceMeter pm, int commentKind,
+			String commentText) {
 		if (commentKind == EXPLAINS_DEGRADATION_COMMENT) {
-		    if (pm instanceof InternalPerformanceMeter) {
-		        InternalPerformanceMeter ipm= (InternalPerformanceMeter) pm;
-		        ipm.setComment(commentKind, commentText);
-		    }
+			if (pm instanceof InternalPerformanceMeter) {
+				InternalPerformanceMeter ipm = (InternalPerformanceMeter) pm;
+				ipm.setComment(commentKind, commentText);
+			}
 		}
 	}
 }

--- a/tests/org.eclipse.test.performance/src/org/eclipse/test/performance/PerformanceTestCase.java
+++ b/tests/org.eclipse.test.performance/src/org/eclipse/test/performance/PerformanceTestCase.java
@@ -13,10 +13,11 @@ package org.eclipse.test.performance;
 import junit.framework.TestCase;
 
 /**
- * A PerformanceTestCase is a convenience class that takes care of managing
- * a <code>PerformanceMeter</code>.
+ * A PerformanceTestCase is a convenience class that takes care of managing a
+ * <code>PerformanceMeter</code>.
  * <p>
  * Here is an example:
+ * 
  * <pre>
  * public class MyPerformanceTestCase extends PeformanceTestCase {
  * 		
@@ -30,7 +31,7 @@ import junit.framework.TestCase;
  *     }
  *     commitMeasurements();
  *     assertPerformance();
- *   }	
+ *   }
  * }
  */
 public class PerformanceTestCase extends TestCase {
@@ -46,23 +47,28 @@ public class PerformanceTestCase extends TestCase {
 
 	/**
 	 * Constructs a performance test case with the given name.
-	 * @param name the name of the performance test case
+	 * 
+	 * @param name
+	 *            the name of the performance test case
 	 */
 	public PerformanceTestCase(String name) {
 		super(name);
 	}
-	
+
 	/**
 	 * Overridden to create a default performance meter for this test case.
+	 * 
 	 * @throws Exception
 	 */
 	protected void setUp() throws Exception {
-		Performance performance= Performance.getDefault();
-		fPerformanceMeter= performance.createPerformanceMeter(performance.getDefaultScenarioId(this));
+		Performance performance = Performance.getDefault();
+		fPerformanceMeter = performance.createPerformanceMeter(performance
+				.getDefaultScenarioId(this));
 	}
 
 	/**
 	 * Overridden to dispose of the performance meter.
+	 * 
 	 * @throws Exception
 	 */
 	protected void tearDown() throws Exception {
@@ -70,125 +76,167 @@ public class PerformanceTestCase extends TestCase {
 	}
 
 	/**
-	 * Mark the scenario of this test case
-	 * to be included into the global and the component performance summary. The summary shows
-	 * the given dimension of the scenario and labels the scenario with the short name.
+	 * Returns a default scenario id for the given test. The test's name must
+	 * have been set, such that <code>test.getName()</code> is not
+	 * <code>null</code>.
 	 * 
-	 * @param shortName a short (shorter than 40 characters) descritive name of the scenario
-	 * @param dimension the dimension to show in the summary
+	 * @return the default scenario id for the test
+	 */
+	protected String getDefaultScenarioId() {
+		return getClass().getName() + '#' + getName() + "()"; //$NON-NLS-1$
+	}
+
+	/**
+	 * Mark the scenario of this test case to be included into the global and
+	 * the component performance summary. The summary shows the given dimension
+	 * of the scenario and labels the scenario with the short name.
+	 * 
+	 * @param shortName
+	 *            a short (shorter than 40 characters) descritive name of the
+	 *            scenario
+	 * @param dimension
+	 *            the dimension to show in the summary
 	 */
 	public void tagAsGlobalSummary(String shortName, Dimension dimension) {
-		Performance performance= Performance.getDefault();
-		performance.tagAsGlobalSummary(fPerformanceMeter, shortName, new Dimension[] { dimension } );
+		Performance performance = Performance.getDefault();
+		performance.tagAsGlobalSummary(fPerformanceMeter, shortName,
+				new Dimension[] { dimension });
 	}
 
 	/**
-	 * Mark the scenario represented by the given PerformanceMeter
-	 * to be included into the global and the component performance summary. The summary shows
-	 * the given dimensions of the scenario and labels the scenario with the short name.
+	 * Mark the scenario represented by the given PerformanceMeter to be
+	 * included into the global and the component performance summary. The
+	 * summary shows the given dimensions of the scenario and labels the
+	 * scenario with the short name.
 	 * 
-	 * @param shortName a short (shorter than 40 characters) descritive name of the scenario
-	 * @param dimensions an array of dimensions to show in the summary
+	 * @param shortName
+	 *            a short (shorter than 40 characters) descritive name of the
+	 *            scenario
+	 * @param dimensions
+	 *            an array of dimensions to show in the summary
 	 */
 	public void tagAsGlobalSummary(String shortName, Dimension[] dimensions) {
-		Performance performance= Performance.getDefault();
-		performance.tagAsGlobalSummary(fPerformanceMeter, shortName, dimensions );
-	}
-	
-	/**
-	 * Mark the scenario of this test case
-	 * to be included into the component performance summary. The summary shows
-	 * the given dimension of the scenario and labels the scenario with the short name.
-	 * 
-	 * @param shortName a short (shorter than 40 characters) descritive name of the scenario
-	 * @param dimension the dimension to show in the summary
-	 */
-	public void tagAsSummary(String shortName, Dimension dimension) {
-		Performance performance= Performance.getDefault();
-		performance.tagAsSummary(fPerformanceMeter, shortName, new Dimension[] { dimension } );
+		Performance performance = Performance.getDefault();
+		performance
+				.tagAsGlobalSummary(fPerformanceMeter, shortName, dimensions);
 	}
 
 	/**
-	 * Mark the scenario represented by the given PerformanceMeter
-	 * to be included into the component performance summary. The summary shows
-	 * the given dimensions of the scenario and labels the scenario with the short name.
+	 * Mark the scenario of this test case to be included into the component
+	 * performance summary. The summary shows the given dimension of the
+	 * scenario and labels the scenario with the short name.
 	 * 
-	 * @param shortName a short (shorter than 40 characters) descritive name of the scenario
-	 * @param dimensions an array of dimensions to show in the summary
+	 * @param shortName
+	 *            a short (shorter than 40 characters) descritive name of the
+	 *            scenario
+	 * @param dimension
+	 *            the dimension to show in the summary
+	 */
+	public void tagAsSummary(String shortName, Dimension dimension) {
+		Performance performance = Performance.getDefault();
+		performance.tagAsSummary(fPerformanceMeter, shortName,
+				new Dimension[] { dimension });
+	}
+
+	/**
+	 * Mark the scenario represented by the given PerformanceMeter to be
+	 * included into the component performance summary. The summary shows the
+	 * given dimensions of the scenario and labels the scenario with the short
+	 * name.
+	 * 
+	 * @param shortName
+	 *            a short (shorter than 40 characters) descritive name of the
+	 *            scenario
+	 * @param dimensions
+	 *            an array of dimensions to show in the summary
 	 */
 	public void tagAsSummary(String shortName, Dimension[] dimensions) {
-		Performance performance= Performance.getDefault();
-		performance.tagAsSummary(fPerformanceMeter, shortName, dimensions );
+		Performance performance = Performance.getDefault();
+		performance.tagAsSummary(fPerformanceMeter, shortName, dimensions);
 	}
-	
+
 	/**
-	 * Set a comment for the scenario represented by this TestCase.
-	 * Currently only comments with a commentKind of EXPLAINS_DEGRADATION_COMMENT are used.
-	 * Their commentText is shown in a hover of the performance summaries graph if a performance
-	 * degradation exists.
+	 * Set a comment for the scenario represented by this TestCase. Currently
+	 * only comments with a commentKind of EXPLAINS_DEGRADATION_COMMENT are
+	 * used. Their commentText is shown in a hover of the performance summaries
+	 * graph if a performance degradation exists.
 	 * 
-	 * @param commentKind kind of comment. Must be EXPLAINS_DEGRADATION_COMMENT to have an effect.
-	 * @param commentText the comment (shorter than 400 characters)
+	 * @param commentKind
+	 *            kind of comment. Must be EXPLAINS_DEGRADATION_COMMENT to have
+	 *            an effect.
+	 * @param commentText
+	 *            the comment (shorter than 400 characters)
 	 */
 	public void setComment(int commentKind, String commentText) {
-		Performance performance= Performance.getDefault();
+		Performance performance = Performance.getDefault();
 		performance.setComment(fPerformanceMeter, commentKind, commentText);
 	}
-	
+
 	/**
-	 * Called from within a test case immediately before the code to measure is run.
-	 * It starts capturing of performance data.
-	 * Must be followed by a call to {@link PerformanceTestCase#stopMeasuring()} before subsequent calls
-	 * to this method or {@link PerformanceTestCase#commitMeasurements()}.
+	 * Called from within a test case immediately before the code to measure is
+	 * run. It starts capturing of performance data. Must be followed by a call
+	 * to {@link PerformanceTestCase#stopMeasuring()} before subsequent calls to
+	 * this method or {@link PerformanceTestCase#commitMeasurements()}.
 	 * 
 	 * @see PerformanceMeter#start()
 	 */
 	protected void startMeasuring() {
 		fPerformanceMeter.start();
 	}
-	
+
 	/**
-	 * Called from within a test case immediately after the operation to measure.
-	 * Must be preceded by a call to {@link PerformanceTestCase#startMeasuring()}, that follows any
-	 * previous call to this method.
+	 * Called from within a test case immediately after the operation to
+	 * measure. Must be preceded by a call to
+	 * {@link PerformanceTestCase#startMeasuring()}, that follows any previous
+	 * call to this method.
 	 * 
 	 * @see PerformanceMeter#stop()
 	 */
 	protected void stopMeasuring() {
 		fPerformanceMeter.stop();
 	}
-	
+
 	/**
-	 * Called exactly once after repeated measurements are done and before
-	 * their analysis. Afterwards {@link PerformanceTestCase#startMeasuring()} and
+	 * Called exactly once after repeated measurements are done and before their
+	 * analysis. Afterwards {@link PerformanceTestCase#startMeasuring()} and
 	 * {@link PerformanceTestCase#stopMeasuring()} must not be called.
 	 * 
 	 * @see PerformanceMeter#commit()
 	 */
 	protected void commitMeasurements() {
-		fPerformanceMeter.commit(); 
+		fPerformanceMeter.commit();
 	}
 
 	/**
-	 * Asserts default properties of the measurements captured for this test case.
+	 * Asserts default properties of the measurements captured for this test
+	 * case.
 	 * 
-	 * @throws RuntimeException if the properties do not hold
+	 * @throws RuntimeException
+	 *             if the properties do not hold
 	 */
 	protected void assertPerformance() {
 		Performance.getDefault().assertPerformance(fPerformanceMeter);
 	}
 
 	/**
-	 * Asserts that the measurement specified by the given dimension
-	 * is within a certain range with respect to some reference value.
-	 * If the specified dimension isn't available, the call has no effect.
+	 * Asserts that the measurement specified by the given dimension is within a
+	 * certain range with respect to some reference value. If the specified
+	 * dimension isn't available, the call has no effect.
 	 * 
-	 * @param dim the Dimension to check
-	 * @param lowerPercentage a negative number indicating the percentage the measured value is allowed to be smaller than some reference value
-	 * @param upperPercentage a positive number indicating the percentage the measured value is allowed to be greater than some reference value
-	 * @throws RuntimeException if the properties do not hold
+	 * @param dim
+	 *            the Dimension to check
+	 * @param lowerPercentage
+	 *            a negative number indicating the percentage the measured value
+	 *            is allowed to be smaller than some reference value
+	 * @param upperPercentage
+	 *            a positive number indicating the percentage the measured value
+	 *            is allowed to be greater than some reference value
+	 * @throws RuntimeException
+	 *             if the properties do not hold
 	 */
-	protected void assertPerformanceInRelativeBand(Dimension dim, int lowerPercentage, int upperPercentage) {
-		Performance.getDefault().assertPerformanceInRelativeBand(fPerformanceMeter, dim, lowerPercentage, upperPercentage);
+	protected void assertPerformanceInRelativeBand(Dimension dim,
+			int lowerPercentage, int upperPercentage) {
+		Performance.getDefault().assertPerformanceInRelativeBand(
+				fPerformanceMeter, dim, lowerPercentage, upperPercentage);
 	}
 }


### PR DESCRIPTION
Allowing all the performance test cases to globally participate in the ELAPSED_TIME dimension for creating the performance test charts.
