### PR TITLE
TISTUD-5066 Performance tests console output displays test cases as erro...

### DIFF
--- a/tests/com.aptana.css.core.tests/src/com/aptana/css/core/tests/PerformanceTests.java
+++ b/tests/com.aptana.css.core.tests/src/com/aptana/css/core/tests/PerformanceTests.java
@@ -14,8 +14,6 @@ import junit.framework.TestCase;
 import junit.framework.TestResult;
 import junit.framework.TestSuite;
 
-import com.aptana.core.logging.IdeLog;
-import com.aptana.css.core.CSSCorePlugin;
 import com.aptana.css.core.parsing.CSSParserPerformanceTest;
 import com.aptana.css.core.parsing.CSSScannerPerformanceTest;
 
@@ -30,8 +28,7 @@ public class PerformanceTests extends TestCase
 			public void runTest(Test test, TestResult result)
 			{
 				String msg = MessageFormat.format("Running test: {0}", test.toString());
-				IdeLog.logError(CSSCorePlugin.getDefault(), msg);
-				System.out.println(msg);
+				System.err.println(msg);
 				super.runTest(test, result);
 			}
 		};

--- a/tests/com.aptana.editor.common.tests/src/com/aptana/editor/common/tests/PerformanceTests.java
+++ b/tests/com.aptana.editor.common.tests/src/com/aptana/editor/common/tests/PerformanceTests.java
@@ -13,8 +13,6 @@ import junit.framework.Test;
 import junit.framework.TestResult;
 import junit.framework.TestSuite;
 
-import com.aptana.core.logging.IdeLog;
-import com.aptana.editor.common.CommonEditorPlugin;
 import com.aptana.editor.common.internal.peer.CharacterPairMatcherPerfTest;
 import com.aptana.editor.common.internal.peer.PeerCharacterCloserPerfTest;
 import com.aptana.editor.common.internal.scripting.DocumentScopeManagerPerformanceTest;
@@ -32,8 +30,7 @@ public class PerformanceTests
 			public void runTest(Test test, TestResult result)
 			{
 				String msg = MessageFormat.format("Running test: {0}", test.toString());
-				IdeLog.logError(CommonEditorPlugin.getDefault(), msg);
-				System.out.println(msg);
+				System.err.println(msg);
 				super.runTest(test, result);
 			}
 		};

--- a/tests/com.aptana.editor.css.tests/src/com/aptana/editor/css/tests/PerformanceTests.java
+++ b/tests/com.aptana.editor.css.tests/src/com/aptana/editor/css/tests/PerformanceTests.java
@@ -13,9 +13,7 @@ import junit.framework.Test;
 import junit.framework.TestResult;
 import junit.framework.TestSuite;
 
-import com.aptana.core.logging.IdeLog;
 import com.aptana.editor.css.CSSCodeScannerPerformanceTest;
-import com.aptana.editor.css.CSSPlugin;
 import com.aptana.editor.css.tests.performance.OpenCSSEditorTest;
 
 public class PerformanceTests
@@ -29,8 +27,7 @@ public class PerformanceTests
 			public void runTest(Test test, TestResult result)
 			{
 				String msg = MessageFormat.format("Running test: {0}", test.toString());
-				IdeLog.logError(CSSPlugin.getDefault(), msg);
-				System.out.println(msg);
+				System.err.println(msg);
 				super.runTest(test, result);
 			}
 		};

--- a/tests/com.aptana.editor.html.tests/src/com/aptana/editor/html/tests/PerformanceTests.java
+++ b/tests/com.aptana.editor.html.tests/src/com/aptana/editor/html/tests/PerformanceTests.java
@@ -13,8 +13,6 @@ import junit.framework.Test;
 import junit.framework.TestResult;
 import junit.framework.TestSuite;
 
-import com.aptana.core.logging.IdeLog;
-import com.aptana.editor.html.HTMLPlugin;
 import com.aptana.editor.html.HTMLTagScannerPerformanceTest;
 import com.aptana.editor.html.parsing.HTMLParserPerformanceTest;
 import com.aptana.editor.html.tests.performance.OpenHTMLEditorTest;
@@ -31,8 +29,7 @@ public class PerformanceTests
 			public void runTest(Test test, TestResult result)
 			{
 				String msg = MessageFormat.format("Running test: {0}", test.toString());
-				IdeLog.logError(HTMLPlugin.getDefault(), msg);
-				System.out.println(msg);
+				System.err.println(msg);
 				super.runTest(test, result);
 			}
 		};

--- a/tests/com.aptana.editor.js.tests/src/com/aptana/editor/js/tests/PerformanceTests.java
+++ b/tests/com.aptana.editor.js.tests/src/com/aptana/editor/js/tests/PerformanceTests.java
@@ -13,8 +13,6 @@ import junit.framework.Test;
 import junit.framework.TestResult;
 import junit.framework.TestSuite;
 
-import com.aptana.core.logging.IdeLog;
-import com.aptana.editor.js.JSPlugin;
 import com.aptana.editor.js.contentassist.JSBuildPerformanceTest;
 import com.aptana.editor.js.contentassist.JSContentAssistProcessorPerformanceTest;
 import com.aptana.editor.js.contentassist.JSIndexingPerformanceTest;
@@ -36,8 +34,7 @@ public class PerformanceTests
 			public void runTest(Test test, TestResult result)
 			{
 				String msg = MessageFormat.format("Running test: {0}", test.toString());
-				IdeLog.logError(JSPlugin.getDefault(), msg);
-				System.out.println(msg);
+				System.err.println(msg);
 				super.runTest(test, result);
 			}
 		};

--- a/tests/com.aptana.editor.json.tests/src/com/aptana/editor/json/tests/PerformanceTests.java
+++ b/tests/com.aptana.editor.json.tests/src/com/aptana/editor/json/tests/PerformanceTests.java
@@ -13,8 +13,6 @@ import junit.framework.Test;
 import junit.framework.TestResult;
 import junit.framework.TestSuite;
 
-import com.aptana.core.logging.IdeLog;
-import com.aptana.editor.json.JSONPlugin;
 import com.aptana.editor.json.JSONScannerPerformanceTest;
 
 public class PerformanceTests
@@ -28,8 +26,7 @@ public class PerformanceTests
 			public void runTest(Test test, TestResult result)
 			{
 				String msg = MessageFormat.format("Running test: {0}", test.toString());
-				IdeLog.logError(JSONPlugin.getDefault(), msg);
-				System.out.println(msg);
+				System.err.println(msg);
 				super.runTest(test, result);
 			}
 		};

--- a/tests/com.aptana.js.core.tests/src/com/aptana/js/core/tests/PerformanceTests.java
+++ b/tests/com.aptana.js.core.tests/src/com/aptana/js/core/tests/PerformanceTests.java
@@ -7,8 +7,6 @@ import junit.framework.TestCase;
 import junit.framework.TestResult;
 import junit.framework.TestSuite;
 
-import com.aptana.core.logging.IdeLog;
-import com.aptana.js.core.JSCorePlugin;
 import com.aptana.js.core.parsing.JSFlexScannerPerformanceTest;
 import com.aptana.js.core.parsing.JSParserPerformanceTest;
 import com.aptana.js.internal.core.parsing.sdoc.SDocParserPerformanceTest;
@@ -24,8 +22,7 @@ public class PerformanceTests extends TestCase
 			public void runTest(Test test, TestResult result)
 			{
 				String msg = MessageFormat.format("Running test: {0}", test.toString());
-				IdeLog.logError(JSCorePlugin.getDefault(), msg);
-				System.out.println(msg);
+				System.err.println(msg);
 				super.runTest(test, result);
 			}
 		};

--- a/tests/com.aptana.scripting.tests/src/com/aptana/scripting/tests/PerformanceTests.java
+++ b/tests/com.aptana.scripting.tests/src/com/aptana/scripting/tests/PerformanceTests.java
@@ -13,8 +13,6 @@ import junit.framework.Test;
 import junit.framework.TestResult;
 import junit.framework.TestSuite;
 
-import com.aptana.core.logging.IdeLog;
-import com.aptana.scripting.ScriptingActivator;
 import com.aptana.scripting.model.BundleLoadingPerformanceTest;
 
 public class PerformanceTests
@@ -28,8 +26,7 @@ public class PerformanceTests
 			public void runTest(Test test, TestResult result)
 			{
 				String msg = MessageFormat.format("Running test: {0}", test.toString());
-				IdeLog.logError(ScriptingActivator.getDefault(), msg);
-				System.out.println(msg);
+				System.err.println(msg);
 				super.runTest(test, result);
 			}
 		};

--- a/tests/com.aptana.studio.tests.all/src/com/aptana/git/core/tests/PerformanceTests.java
+++ b/tests/com.aptana.studio.tests.all/src/com/aptana/git/core/tests/PerformanceTests.java
@@ -6,8 +6,6 @@ import junit.framework.Test;
 import junit.framework.TestResult;
 import junit.framework.TestSuite;
 
-import com.aptana.core.logging.IdeLog;
-import com.aptana.git.core.GitPlugin;
 import com.aptana.git.core.model.GitIndexPerformanceTest;
 
 public class PerformanceTests
@@ -21,8 +19,7 @@ public class PerformanceTests
 			public void runTest(Test test, TestResult result)
 			{
 				String msg = MessageFormat.format("Running test: {0}", test.toString());
-				IdeLog.logError(GitPlugin.getDefault(), msg);
-				System.out.println(msg);
+				System.err.println(msg);
 				super.runTest(test, result);
 			}
 		};

--- a/tests/com.aptana.theme.tests/src/com/aptana/theme/tests/PerformanceTests.java
+++ b/tests/com.aptana.theme.tests/src/com/aptana/theme/tests/PerformanceTests.java
@@ -6,9 +6,7 @@ import junit.framework.Test;
 import junit.framework.TestResult;
 import junit.framework.TestSuite;
 
-import com.aptana.core.logging.IdeLog;
 import com.aptana.theme.ThemePerformanceTest;
-import com.aptana.theme.ThemePlugin;
 
 public class PerformanceTests
 {
@@ -20,8 +18,7 @@ public class PerformanceTests
 			public void runTest(Test test, TestResult result)
 			{
 				String msg = MessageFormat.format("Running test: {0}", test.toString());
-				IdeLog.logError(ThemePlugin.getDefault(), msg);
-				System.out.println(msg);
+				System.err.println(msg);
 				super.runTest(test, result);
 			}
 		};

--- a/tests/com.aptana.xml.core.tests/src/com/aptana/xml/core/tests/PerformanceTests.java
+++ b/tests/com.aptana.xml.core.tests/src/com/aptana/xml/core/tests/PerformanceTests.java
@@ -13,8 +13,6 @@ import junit.framework.Test;
 import junit.framework.TestResult;
 import junit.framework.TestSuite;
 
-import com.aptana.core.logging.IdeLog;
-import com.aptana.xml.core.XMLCorePlugin;
 import com.aptana.xml.core.parsing.XMLParserPerformanceTest;
 import com.aptana.xml.core.parsing.XMLParserScannerPerformanceTest;
 
@@ -29,8 +27,7 @@ public class PerformanceTests
 			public void runTest(Test test, TestResult result)
 			{
 				String msg = MessageFormat.format("Running test: {0}", test.toString());
-				IdeLog.logError(XMLCorePlugin.getDefault(), msg);
-				System.out.println(msg);
+				System.err.println(msg);
 				super.runTest(test, result);
 			}
 		};


### PR DESCRIPTION
Replacing the Idelog.logError calls with sys.err.printLn() to display the test case logging messages similar to core development tests.
