### PR TITLE
TISTUD-4962 Tag performance test to participate in performance summary

### DIFF
--- a/tests/com.aptana.css.core.tests/src/com/aptana/css/core/parsing/CSSParserPerformanceTest.java
+++ b/tests/com.aptana.css.core.tests/src/com/aptana/css/core/parsing/CSSParserPerformanceTest.java
@@ -12,13 +12,13 @@ import java.io.InputStream;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.test.performance.PerformanceTestCase;
+import org.eclipse.test.performance.GlobalTimePerformanceTestCase;
 
 import com.aptana.core.util.IOUtil;
 import com.aptana.parsing.IParseState;
 import com.aptana.parsing.ParseState;
 
-public class CSSParserPerformanceTest extends PerformanceTestCase
+public class CSSParserPerformanceTest extends GlobalTimePerformanceTestCase
 {
 
 	private CSSParser fParser;

--- a/tests/com.aptana.css.core.tests/src/com/aptana/css/core/parsing/CSSScannerPerformanceTest.java
+++ b/tests/com.aptana.css.core.tests/src/com/aptana/css/core/parsing/CSSScannerPerformanceTest.java
@@ -12,13 +12,13 @@ import java.io.InputStream;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.test.performance.PerformanceTestCase;
+import org.eclipse.test.performance.GlobalTimePerformanceTestCase;
 
 import beaver.Symbol;
 
 import com.aptana.core.util.IOUtil;
 
-public class CSSScannerPerformanceTest extends PerformanceTestCase
+public class CSSScannerPerformanceTest extends GlobalTimePerformanceTestCase
 {
 	private CSSFlexScanner fScanner;
 

--- a/tests/com.aptana.editor.common.tests/src/com/aptana/editor/common/internal/peer/CharacterPairMatcherPerfTest.java
+++ b/tests/com.aptana.editor.common.tests/src/com/aptana/editor/common/internal/peer/CharacterPairMatcherPerfTest.java
@@ -16,14 +16,14 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.source.ICharacterPairMatcher;
-import org.eclipse.test.performance.PerformanceTestCase;
+import org.eclipse.test.performance.GlobalTimePerformanceTestCase;
 import org.eclipse.ui.ide.IDE;
 
 import com.aptana.core.util.ResourceUtil;
 import com.aptana.editor.common.AbstractThemeableEditor;
 import com.aptana.ui.util.UIUtils;
 
-public class CharacterPairMatcherPerfTest extends PerformanceTestCase
+public class CharacterPairMatcherPerfTest extends GlobalTimePerformanceTestCase
 {
 	private static final char[] pairs = new char[] { '(', ')', '{', '}', '[', ']', '`', '`', '\'', '\'', '"', '"' };
 	private ICharacterPairMatcher matcher;

--- a/tests/com.aptana.editor.common.tests/src/com/aptana/editor/common/internal/peer/PeerCharacterCloserPerfTest.java
+++ b/tests/com.aptana.editor.common.tests/src/com/aptana/editor/common/internal/peer/PeerCharacterCloserPerfTest.java
@@ -12,9 +12,9 @@ import java.util.List;
 
 import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IDocument;
-import org.eclipse.test.performance.PerformanceTestCase;
+import org.eclipse.test.performance.GlobalTimePerformanceTestCase;
 
-public class PeerCharacterCloserPerfTest extends PerformanceTestCase
+public class PeerCharacterCloserPerfTest extends GlobalTimePerformanceTestCase
 {
 
 	public void testCheckUnpairedClose() throws Exception

--- a/tests/com.aptana.editor.common.tests/src/com/aptana/editor/common/internal/scripting/DocumentScopeManagerPerformanceTest.java
+++ b/tests/com.aptana.editor.common.tests/src/com/aptana/editor/common/internal/scripting/DocumentScopeManagerPerformanceTest.java
@@ -9,7 +9,7 @@ import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.source.ISourceViewer;
-import org.eclipse.test.performance.PerformanceTestCase;
+import org.eclipse.test.performance.GlobalTimePerformanceTestCase;
 import org.eclipse.ui.IEditorReference;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.ide.IDE;
@@ -22,7 +22,7 @@ import com.aptana.editor.common.scripting.commands.TextEditorUtils;
 import com.aptana.editor.epl.tests.EditorTestHelper;
 import com.aptana.ui.util.UIUtils;
 
-public class DocumentScopeManagerPerformanceTest extends PerformanceTestCase
+public class DocumentScopeManagerPerformanceTest extends GlobalTimePerformanceTestCase
 {
 
 	/**

--- a/tests/com.aptana.editor.common.tests/src/com/aptana/editor/common/text/reconciler/RubyRegexpFolderPerformanceTest.java
+++ b/tests/com.aptana.editor.common.tests/src/com/aptana/editor/common/text/reconciler/RubyRegexpFolderPerformanceTest.java
@@ -15,14 +15,14 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IDocument;
-import org.eclipse.test.performance.PerformanceTestCase;
+import org.eclipse.test.performance.GlobalTimePerformanceTestCase;
 import org.jruby.Ruby;
 import org.jruby.RubyRegexp;
 import org.jruby.util.RegexpOptions;
 
 import com.aptana.core.util.IOUtil;
 
-public class RubyRegexpFolderPerformanceTest extends PerformanceTestCase
+public class RubyRegexpFolderPerformanceTest extends GlobalTimePerformanceTestCase
 {
 
 	public void testYUICSSFolding() throws Exception

--- a/tests/com.aptana.editor.common.tests/src/com/aptana/editor/common/text/rules/ThemeingDamagerRepairerPerfTest.java
+++ b/tests/com.aptana.editor.common.tests/src/com/aptana/editor/common/text/rules/ThemeingDamagerRepairerPerfTest.java
@@ -8,7 +8,7 @@ import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.source.ISourceViewer;
-import org.eclipse.test.performance.PerformanceTestCase;
+import org.eclipse.test.performance.GlobalTimePerformanceTestCase;
 import org.eclipse.ui.ide.IDE;
 
 import com.aptana.core.util.ResourceUtil;
@@ -16,7 +16,7 @@ import com.aptana.editor.common.AbstractThemeableEditor;
 import com.aptana.editor.epl.tests.EditorTestHelper;
 import com.aptana.ui.util.UIUtils;
 
-public class ThemeingDamagerRepairerPerfTest extends PerformanceTestCase
+public class ThemeingDamagerRepairerPerfTest extends GlobalTimePerformanceTestCase
 {
 	private AbstractThemeableEditor editor;
 

--- a/tests/com.aptana.editor.css.tests/src/com/aptana/editor/css/CSSCodeScannerPerformanceTest.java
+++ b/tests/com.aptana.editor.css.tests/src/com/aptana/editor/css/CSSCodeScannerPerformanceTest.java
@@ -18,12 +18,12 @@ import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.rules.ITokenScanner;
 import org.eclipse.jface.text.rules.Token;
-import org.eclipse.test.performance.PerformanceTestCase;
+import org.eclipse.test.performance.GlobalTimePerformanceTestCase;
 
 import com.aptana.core.util.IOUtil;
 import com.aptana.editor.epl.tests.EditorTestHelper;
 
-public class CSSCodeScannerPerformanceTest extends PerformanceTestCase
+public class CSSCodeScannerPerformanceTest extends GlobalTimePerformanceTestCase
 {
 
 	private ITokenScanner fScanner;

--- a/tests/com.aptana.editor.css.tests/src/com/aptana/editor/css/CSSScannerPerformanceTest.java
+++ b/tests/com.aptana.editor.css.tests/src/com/aptana/editor/css/CSSScannerPerformanceTest.java
@@ -12,13 +12,13 @@ import java.io.InputStream;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.test.performance.PerformanceTestCase;
+import org.eclipse.test.performance.GlobalTimePerformanceTestCase;
 
 import com.aptana.core.util.IOUtil;
 import com.aptana.css.core.parsing.CSSTokenType;
 import com.aptana.editor.css.parsing.CSSScanner;
 
-public class CSSScannerPerformanceTest extends PerformanceTestCase
+public class CSSScannerPerformanceTest extends GlobalTimePerformanceTestCase
 {
 
 	private CSSScanner fScanner;

--- a/tests/com.aptana.editor.css.tests/src/com/aptana/editor/css/CSSSourcePartitionScannerPerformanceTest.java
+++ b/tests/com.aptana.editor.css.tests/src/com/aptana/editor/css/CSSSourcePartitionScannerPerformanceTest.java
@@ -17,7 +17,7 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IDocumentPartitioner;
-import org.eclipse.test.performance.PerformanceTestCase;
+import org.eclipse.test.performance.GlobalTimePerformanceTestCase;
 
 import com.aptana.core.util.IOUtil;
 import com.aptana.editor.common.CommonEditorPlugin;
@@ -25,7 +25,7 @@ import com.aptana.editor.common.ExtendedFastPartitioner;
 import com.aptana.editor.common.IPartitioningConfiguration;
 import com.aptana.editor.epl.tests.EditorTestHelper;
 
-public class CSSSourcePartitionScannerPerformanceTest extends PerformanceTestCase
+public class CSSSourcePartitionScannerPerformanceTest extends GlobalTimePerformanceTestCase
 {
 	private IDocumentPartitioner fPartitioner;
 	private IPartitioningConfiguration configuration;

--- a/tests/com.aptana.editor.html.tests/src/com/aptana/editor/html/HTMLTagScannerPerformanceTest.java
+++ b/tests/com.aptana.editor.html.tests/src/com/aptana/editor/html/HTMLTagScannerPerformanceTest.java
@@ -16,11 +16,11 @@ import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.rules.IToken;
 import org.eclipse.jface.text.rules.Token;
-import org.eclipse.test.performance.PerformanceTestCase;
+import org.eclipse.test.performance.GlobalTimePerformanceTestCase;
 
 import com.aptana.core.util.IOUtil;
 
-public class HTMLTagScannerPerformanceTest extends PerformanceTestCase
+public class HTMLTagScannerPerformanceTest extends GlobalTimePerformanceTestCase
 {
 
 	private HTMLTagScanner fScanner;

--- a/tests/com.aptana.editor.html.tests/src/com/aptana/editor/html/parsing/HTMLParserPerformanceTest.java
+++ b/tests/com.aptana.editor.html.tests/src/com/aptana/editor/html/parsing/HTMLParserPerformanceTest.java
@@ -12,7 +12,7 @@ import java.io.InputStream;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.test.performance.PerformanceTestCase;
+import org.eclipse.test.performance.GlobalTimePerformanceTestCase;
 
 import com.aptana.core.util.IOUtil;
 import com.aptana.editor.epl.tests.EditorTestHelper;
@@ -21,7 +21,7 @@ import com.aptana.parsing.IParseState;
 /**
  * @author cwilliams
  */
-public class HTMLParserPerformanceTest extends PerformanceTestCase
+public class HTMLParserPerformanceTest extends GlobalTimePerformanceTestCase
 {
 
 	private HTMLParser fParser;

--- a/tests/com.aptana.editor.html.tests/src/com/aptana/editor/html/validator/HTMLTidyValidatorPerformanceTest.java
+++ b/tests/com.aptana.editor.html.tests/src/com/aptana/editor/html/validator/HTMLTidyValidatorPerformanceTest.java
@@ -15,7 +15,7 @@ import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.test.performance.PerformanceTestCase;
+import org.eclipse.test.performance.GlobalTimePerformanceTestCase;
 
 import com.aptana.core.util.ResourceUtil;
 import com.aptana.editor.epl.tests.EditorTestHelper;
@@ -23,7 +23,7 @@ import com.aptana.editor.html.HTMLPlugin;
 import com.aptana.index.core.FileStoreBuildContext;
 import com.aptana.index.core.build.BuildContext;
 
-public class HTMLTidyValidatorPerformanceTest extends PerformanceTestCase
+public class HTMLTidyValidatorPerformanceTest extends GlobalTimePerformanceTestCase
 {
 
 	private HTMLTidyValidator validator;

--- a/tests/com.aptana.editor.js.tests/src/com/aptana/editor/js/contentassist/JSBuildPerformanceTest.java
+++ b/tests/com.aptana.editor.js.tests/src/com/aptana/editor/js/contentassist/JSBuildPerformanceTest.java
@@ -21,14 +21,14 @@ import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.test.performance.PerformanceTestCase;
+import org.eclipse.test.performance.GlobalTimePerformanceTestCase;
 
 import com.aptana.core.build.UnifiedBuilder;
 import com.aptana.core.tests.TestProject;
 import com.aptana.core.util.ResourceUtil;
 import com.aptana.js.core.JSCorePlugin;
 
-public class JSBuildPerformanceTest extends PerformanceTestCase
+public class JSBuildPerformanceTest extends GlobalTimePerformanceTestCase
 {
 
 	private TestProject project;

--- a/tests/com.aptana.editor.js.tests/src/com/aptana/editor/js/contentassist/JSIndexingPerformanceTest.java
+++ b/tests/com.aptana.editor.js.tests/src/com/aptana/editor/js/contentassist/JSIndexingPerformanceTest.java
@@ -20,7 +20,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.test.performance.PerformanceTestCase;
+import org.eclipse.test.performance.GlobalTimePerformanceTestCase;
 
 import com.aptana.core.util.IOUtil;
 import com.aptana.index.core.FileStoreBuildContext;
@@ -36,7 +36,7 @@ import com.aptana.parsing.ParseResult;
 import com.aptana.parsing.ParseState;
 import com.aptana.parsing.ast.IParseRootNode;
 
-public class JSIndexingPerformanceTest extends PerformanceTestCase
+public class JSIndexingPerformanceTest extends GlobalTimePerformanceTestCase
 {
 
 	private JSParser fParser;

--- a/tests/com.aptana.editor.js.tests/src/com/aptana/editor/js/tests/performance/JSLintValidatorPerformanceTest.java
+++ b/tests/com.aptana.editor.js.tests/src/com/aptana/editor/js/tests/performance/JSLintValidatorPerformanceTest.java
@@ -15,7 +15,7 @@ import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.test.performance.PerformanceTestCase;
+import org.eclipse.test.performance.GlobalTimePerformanceTestCase;
 
 import com.aptana.core.build.AbstractBuildParticipant;
 import com.aptana.core.util.ResourceUtil;
@@ -29,7 +29,7 @@ import com.aptana.parsing.IParseState;
 import com.aptana.parsing.ParseResult;
 import com.aptana.parsing.WorkingParseResult;
 
-public class JSLintValidatorPerformanceTest extends PerformanceTestCase
+public class JSLintValidatorPerformanceTest extends GlobalTimePerformanceTestCase
 {
 	private AbstractBuildParticipant validator;
 

--- a/tests/com.aptana.editor.js.tests/src/com/aptana/editor/js/tests/performance/JSParserValidatorPerformanceTest.java
+++ b/tests/com.aptana.editor.js.tests/src/com/aptana/editor/js/tests/performance/JSParserValidatorPerformanceTest.java
@@ -13,7 +13,7 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.test.performance.PerformanceTestCase;
+import org.eclipse.test.performance.GlobalTimePerformanceTestCase;
 
 import com.aptana.core.build.AbstractBuildParticipant;
 import com.aptana.core.tests.TestProject;
@@ -24,7 +24,7 @@ import com.aptana.index.core.build.BuildContext;
 import com.aptana.js.core.JSCorePlugin;
 import com.aptana.js.internal.core.build.JSParserValidator;
 
-public class JSParserValidatorPerformanceTest extends PerformanceTestCase
+public class JSParserValidatorPerformanceTest extends GlobalTimePerformanceTestCase
 {
 	private AbstractBuildParticipant validator;
 	private TestProject project;

--- a/tests/com.aptana.editor.js.tests/src/com/aptana/editor/js/text/JSCodeScannerPerformanceTest.java
+++ b/tests/com.aptana.editor.js.tests/src/com/aptana/editor/js/text/JSCodeScannerPerformanceTest.java
@@ -18,14 +18,13 @@ import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.rules.ITokenScanner;
 import org.eclipse.jface.text.rules.Token;
-import org.eclipse.test.performance.PerformanceTestCase;
+import org.eclipse.test.performance.GlobalTimePerformanceTestCase;
 
 import com.aptana.core.util.IOUtil;
 import com.aptana.editor.epl.tests.EditorTestHelper;
-import com.aptana.editor.js.text.JSCodeScanner;
 import com.aptana.js.core.JSCorePlugin;
 
-public class JSCodeScannerPerformanceTest extends PerformanceTestCase
+public class JSCodeScannerPerformanceTest extends GlobalTimePerformanceTestCase
 {
 	private ITokenScanner fScanner;
 

--- a/tests/com.aptana.editor.js.tests/src/com/aptana/editor/js/text/JSSourcePartitionScannerPerformanceTest.java
+++ b/tests/com.aptana.editor.js.tests/src/com/aptana/editor/js/text/JSSourcePartitionScannerPerformanceTest.java
@@ -17,7 +17,7 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IDocumentPartitioner;
-import org.eclipse.test.performance.PerformanceTestCase;
+import org.eclipse.test.performance.GlobalTimePerformanceTestCase;
 
 import com.aptana.core.util.IOUtil;
 import com.aptana.editor.common.CommonEditorPlugin;
@@ -27,7 +27,7 @@ import com.aptana.editor.epl.tests.EditorTestHelper;
 import com.aptana.editor.js.JSSourceConfiguration;
 import com.aptana.js.core.JSCorePlugin;
 
-public class JSSourcePartitionScannerPerformanceTest extends PerformanceTestCase
+public class JSSourcePartitionScannerPerformanceTest extends GlobalTimePerformanceTestCase
 {
 	private IDocumentPartitioner fPartitioner;
 	private IPartitioningConfiguration configuration;

--- a/tests/com.aptana.editor.json.tests/src/com/aptana/editor/json/JSONScannerPerformanceTest.java
+++ b/tests/com.aptana.editor.json.tests/src/com/aptana/editor/json/JSONScannerPerformanceTest.java
@@ -15,14 +15,14 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.rules.Token;
-import org.eclipse.test.performance.PerformanceTestCase;
+import org.eclipse.test.performance.GlobalTimePerformanceTestCase;
 
 import com.aptana.core.util.IOUtil;
 
 /**
  * JSONScannerPerformanceTest
  */
-public class JSONScannerPerformanceTest extends PerformanceTestCase
+public class JSONScannerPerformanceTest extends GlobalTimePerformanceTestCase
 {
 	private JSONSourceScanner fScanner;
 

--- a/tests/com.aptana.js.core.tests/src/com/aptana/js/core/parsing/JSFlexScannerPerformanceTest.java
+++ b/tests/com.aptana.js.core.tests/src/com/aptana/js/core/parsing/JSFlexScannerPerformanceTest.java
@@ -13,7 +13,7 @@ import java.io.InputStream;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.test.performance.PerformanceTestCase;
+import org.eclipse.test.performance.GlobalTimePerformanceTestCase;
 
 import beaver.Symbol;
 
@@ -23,7 +23,7 @@ import com.aptana.js.core.tests.ITestFiles;
 import com.aptana.parsing.IParseState;
 import com.aptana.parsing.ParseState;
 
-public class JSFlexScannerPerformanceTest extends PerformanceTestCase
+public class JSFlexScannerPerformanceTest extends GlobalTimePerformanceTestCase
 {
 	private JSFlexScanner fScanner;
 

--- a/tests/com.aptana.js.core.tests/src/com/aptana/js/core/parsing/JSParserPerformanceTest.java
+++ b/tests/com.aptana.js.core.tests/src/com/aptana/js/core/parsing/JSParserPerformanceTest.java
@@ -21,14 +21,14 @@ import java.util.Queue;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.test.performance.GlobalTimePerformanceTestCase;
 import org.eclipse.test.performance.Performance;
-import org.eclipse.test.performance.PerformanceTestCase;
 
 import com.aptana.core.util.IOUtil;
 import com.aptana.js.core.JSCorePlugin;
 import com.aptana.js.core.tests.ITestFiles;
 
-public class JSParserPerformanceTest extends PerformanceTestCase
+public class JSParserPerformanceTest extends GlobalTimePerformanceTestCase
 {
 
 	private JSParser fParser;

--- a/tests/com.aptana.js.core.tests/src/com/aptana/js/internal/core/parsing/sdoc/SDocParserPerformanceTest.java
+++ b/tests/com.aptana.js.core.tests/src/com/aptana/js/internal/core/parsing/sdoc/SDocParserPerformanceTest.java
@@ -17,13 +17,13 @@ import java.util.regex.Pattern;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.test.performance.PerformanceTestCase;
+import org.eclipse.test.performance.GlobalTimePerformanceTestCase;
 
 import com.aptana.core.util.IOUtil;
 import com.aptana.js.core.JSCorePlugin;
 import com.aptana.js.core.tests.ITestFiles;
 
-public class SDocParserPerformanceTest extends PerformanceTestCase
+public class SDocParserPerformanceTest extends GlobalTimePerformanceTestCase
 {
 	private static final Pattern COMMENT = Pattern.compile("/\\*\\*.*?\\*/", Pattern.DOTALL);
 	private SDocParser fParser;

--- a/tests/com.aptana.scripting.tests/src/com/aptana/scripting/model/BundleLoadingPerformanceTest.java
+++ b/tests/com.aptana.scripting.tests/src/com/aptana/scripting/model/BundleLoadingPerformanceTest.java
@@ -1,8 +1,8 @@
 package com.aptana.scripting.model;
 
-import org.eclipse.test.performance.PerformanceTestCase;
+import org.eclipse.test.performance.GlobalTimePerformanceTestCase;
 
-public class BundleLoadingPerformanceTest extends PerformanceTestCase
+public class BundleLoadingPerformanceTest extends GlobalTimePerformanceTestCase
 {
 	private BundleManager manager;
 

--- a/tests/com.aptana.theme.tests/src/com/aptana/theme/ThemePerformanceTest.java
+++ b/tests/com.aptana.theme.tests/src/com/aptana/theme/ThemePerformanceTest.java
@@ -16,7 +16,7 @@ import java.util.List;
 
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Path;
-import org.eclipse.test.performance.PerformanceTestCase;
+import org.eclipse.test.performance.GlobalTimePerformanceTestCase;
 
 import com.aptana.core.epl.util.LRUCache;
 import com.aptana.core.util.IOUtil;
@@ -24,7 +24,7 @@ import com.aptana.core.util.StringUtil;
 import com.aptana.scope.ScopeSelector;
 import com.aptana.theme.internal.ThemeManager;
 
-public class ThemePerformanceTest extends PerformanceTestCase
+public class ThemePerformanceTest extends GlobalTimePerformanceTestCase
 {
 	// @formatter:off
 	/**

--- a/tests/com.aptana.xml.core.tests/src/com/aptana/xml/core/parsing/XMLParserPerformanceTest.java
+++ b/tests/com.aptana.xml.core.tests/src/com/aptana/xml/core/parsing/XMLParserPerformanceTest.java
@@ -12,14 +12,13 @@ import java.io.InputStream;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.test.performance.PerformanceTestCase;
+import org.eclipse.test.performance.GlobalTimePerformanceTestCase;
 
 import com.aptana.core.util.IOUtil;
 import com.aptana.parsing.IParseState;
 import com.aptana.parsing.ParseState;
-import com.aptana.xml.core.parsing.XMLParser;
 
-public class XMLParserPerformanceTest extends PerformanceTestCase
+public class XMLParserPerformanceTest extends GlobalTimePerformanceTestCase
 {
 
 	private XMLParser fParser;

--- a/tests/com.aptana.xml.core.tests/src/com/aptana/xml/core/parsing/XMLParserScannerPerformanceTest.java
+++ b/tests/com.aptana.xml.core.tests/src/com/aptana/xml/core/parsing/XMLParserScannerPerformanceTest.java
@@ -12,13 +12,12 @@ import java.io.InputStream;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.test.performance.PerformanceTestCase;
+import org.eclipse.test.performance.GlobalTimePerformanceTestCase;
 
 import com.aptana.core.util.IOUtil;
 import com.aptana.dtd.core.parsing.Terminals;
-import com.aptana.xml.core.parsing.XMLScanner;
 
-public class XMLParserScannerPerformanceTest extends PerformanceTestCase
+public class XMLParserScannerPerformanceTest extends GlobalTimePerformanceTestCase
 {
 
 	private XMLScanner fScanner;

--- a/tests/org.eclipse.test.performance/src/org/eclipse/test/performance/GlobalTimePerformanceTestCase.java
+++ b/tests/org.eclipse.test.performance/src/org/eclipse/test/performance/GlobalTimePerformanceTestCase.java
@@ -1,0 +1,35 @@
+/**
+ * Aptana Studio
+ * Copyright (c) 2013 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the GNU Public License (GPL) v3 (with exceptions).
+ * Please see the license.html included with this distribution for details.
+ * Any modifications to this file must keep this entire header intact.
+ */
+
+package org.eclipse.test.performance;
+
+/**
+ * All performance test cases extending this class will get tagged for participating in the global summary of elapsed
+ * process time.
+ * 
+ * @author pinnamuri
+ */
+public class GlobalTimePerformanceTestCase extends PerformanceTestCase
+{
+
+	public GlobalTimePerformanceTestCase()
+	{
+	}
+
+	public GlobalTimePerformanceTestCase(String name)
+	{
+		super(name);
+	}
+
+	protected void setUp() throws Exception
+	{
+		super.setUp();
+		tagAsGlobalSummary(Performance.getDefault().getDefaultScenarioId(this), Dimension.ELAPSED_PROCESS);
+	}
+
+}

--- a/tests/org.eclipse.test.performance/src/org/eclipse/test/performance/PerformanceTestCase.java
+++ b/tests/org.eclipse.test.performance/src/org/eclipse/test/performance/PerformanceTestCase.java
@@ -66,7 +66,6 @@ public class PerformanceTestCase extends TestCase
 	{
 		Performance performance = Performance.getDefault();
 		fPerformanceMeter = performance.createPerformanceMeter(performance.getDefaultScenarioId(this));
-		tagAsGlobalSummary(performance.getDefaultScenarioId(this), Dimension.ELAPSED_PROCESS);
 	}
 
 	/**


### PR DESCRIPTION
Instead of tagging every PerformanceTestCase to global summary, I added it to the parent class PerformanceTestCase setup() method that it tags every performance test case globally. Hope this would avoid adding it to all performance test cases.
