### PR TITLE
Fix TISTUD-5052 When "missing semicolons" option is set to Ignore, no related marker should appear in the editor

### DIFF
--- a/plugins/com.aptana.js.core/parsing/JS.grammar
+++ b/plugins/com.aptana.js.core/parsing/JS.grammar
@@ -382,7 +382,7 @@
 					throws IOException
 			{
 				boolean recovered = super.recover(parser, lastToken, currentToken, in, report);
-				if (recovered)
+				if (recovered && fSemicolonSeverity != IProblem.Severity.IGNORE)
 				{
 					fWorking.addError(new ParseError(IJSConstants.CONTENT_TYPE_JS, lastToken, Messages.JSParser_MissingSemicolonMsg, fSemicolonSeverity));
 				}

--- a/plugins/com.aptana.js.core/src/com/aptana/js/core/parsing/JSParser.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/core/parsing/JSParser.java
@@ -496,7 +496,7 @@ public class JSParser extends Parser implements IParser {
 					throws IOException
 			{
 				boolean recovered = super.recover(parser, lastToken, currentToken, in, report);
-				if (recovered)
+				if (recovered && fSemicolonSeverity != IProblem.Severity.IGNORE)
 				{
 					fWorking.addError(new ParseError(IJSConstants.CONTENT_TYPE_JS, lastToken, Messages.JSParser_MissingSemicolonMsg, fSemicolonSeverity));
 				}

--- a/tests/com.aptana.js.core.tests/src/com/aptana/js/internal/core/build/JSParserValidatorTest.java
+++ b/tests/com.aptana.js.core.tests/src/com/aptana/js/internal/core/build/JSParserValidatorTest.java
@@ -10,13 +10,16 @@ package com.aptana.js.internal.core.build;
 import java.util.List;
 
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 
 import com.aptana.buildpath.core.tests.AbstractValidatorTestCase;
 import com.aptana.core.build.IBuildParticipant;
 import com.aptana.core.build.IProblem;
+import com.aptana.core.util.EclipseUtil;
 import com.aptana.js.core.IJSConstants;
 import com.aptana.js.core.JSCorePlugin;
 import com.aptana.js.core.parsing.JSParseState;
+import com.aptana.js.core.preferences.IPreferenceConstants;
 
 @SuppressWarnings("nls")
 public class JSParserValidatorTest extends AbstractValidatorTestCase
@@ -75,9 +78,33 @@ public class JSParserValidatorTest extends AbstractValidatorTestCase
 		assertEquals(1, items.size());
 		IProblem problem = items.get(0);
 		assertEquals("Error was not found on expected line", 1, problem.getLineNumber());
-		assertEquals("Error message did not match expected error message", "Missing semicolon",
-				problem.getMessage());
+		assertEquals("Error message did not match expected error message", "Missing semicolon", problem.getMessage());
 		assertEquals(IProblem.Severity.WARNING, problem.getSeverity());
+	}
+
+	public void testMissingSemicolonSetToIgnoreReportsNoWarning() throws Exception
+	{
+		IEclipsePreferences prefs = EclipseUtil.instanceScope().getNode(JSCorePlugin.PLUGIN_ID);
+		prefs.put(IPreferenceConstants.PREF_MISSING_SEMICOLON_SEVERITY, IProblem.Severity.IGNORE.id());
+		prefs.flush();
+
+		try
+		{
+			// @formatter:off
+			String text = "var USPostalReg = /^\\d{5}(-\\d{4})?$/\n" +
+						"if (!USPostalReg.test(textFields_array[i].value)) {\n" +
+						"    inValidValue = true;\n" +
+						"}";
+			// @formatter:on
+
+			List<IProblem> items = getParseErrors(text);
+			assertEquals("Expected no warning about missing semicolons but received one", 0, items.size());
+		}
+		finally
+		{
+			prefs.remove(IPreferenceConstants.PREF_MISSING_SEMICOLON_SEVERITY);
+			prefs.flush();
+		}
 	}
 
 	protected List<IProblem> getParseErrors(String source) throws CoreException


### PR DESCRIPTION
- when set to ignore, don't add problem at all
- add unit test to verify fix
