### PR TITLE
TISTUD-2948	Add Alloy samples to Samples view

### DIFF
--- a/plugins/com.aptana.core/src/com/aptana/core/util/FileUtil.java
+++ b/plugins/com.aptana.core/src/com/aptana/core/util/FileUtil.java
@@ -71,6 +71,19 @@ public class FileUtil
 	}
 
 	/**
+	 * Returns true if the given file is a zip archive.
+	 * 
+	 * @param file
+	 * @return
+	 */
+	public static boolean isZipFile(File file)
+	{
+		String filePath = file.getAbsolutePath();
+		// TODO: should be generic to other archive formats ?
+		return filePath.toLowerCase().endsWith(".zip");
+	}
+
+	/**
 	 * Removes the "middle" part from a path to make it short enough to fit within the specified length, i.e.
 	 * c:/Documents and Settings/username/My Documents/workspace/whatever.txt would become c:/.../username/My
 	 * Documents/workspace/whatever.txt.

--- a/plugins/com.aptana.projects/src/com/aptana/projects/ProjectData.java
+++ b/plugins/com.aptana.projects/src/com/aptana/projects/ProjectData.java
@@ -30,9 +30,11 @@ public class ProjectData
 	public boolean cloneFromGit;
 	public IProject project;
 
+	public static String DEFAULT_PUBLISHER_URL = "http://";
+
 	public ProjectData()
 	{
-		this(null, null, null, false, null, null, null, null, false);
+		this(null, null, null, false, null, DEFAULT_PUBLISHER_URL, null, null, false);
 	}
 
 	public ProjectData(IProject project, String projectName, String directory, boolean isDefaultLocation, String appId,

--- a/plugins/com.aptana.samples.ui/src/com/aptana/samples/ui/handlers/ImportSampleHandler.java
+++ b/plugins/com.aptana.samples.ui/src/com/aptana/samples/ui/handlers/ImportSampleHandler.java
@@ -1,6 +1,6 @@
 /**
  * Aptana Studio
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the GNU Public License (GPL) v3 (with exceptions).
  * Please see the license.html included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.
@@ -16,6 +16,7 @@ import org.eclipse.ui.handlers.HandlerUtil;
 
 import com.aptana.core.util.StringUtil;
 import com.aptana.samples.SamplesPlugin;
+import com.aptana.samples.model.IProjectSample;
 import com.aptana.samples.model.SamplesReference;
 import com.aptana.samples.ui.project.SampleProjectCreator;
 
@@ -42,7 +43,7 @@ public class ImportSampleHandler extends AbstractHandler
 		}
 		else
 		{
-			SamplesReference samplesRef = SamplesPlugin.getDefault().getSamplesManager().getSample(id);
+			IProjectSample samplesRef = SamplesPlugin.getDefault().getSamplesManager().getSample(id);
 			if (samplesRef != null)
 			{
 				SampleProjectCreator.createSampleProject(samplesRef);

--- a/plugins/com.aptana.samples.ui/src/com/aptana/samples/ui/portal/actionController/SamplesActionController.java
+++ b/plugins/com.aptana.samples.ui/src/com/aptana/samples/ui/portal/actionController/SamplesActionController.java
@@ -1,6 +1,6 @@
 /**
  * Aptana Studio
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the GNU Public License (GPL) v3 (with exceptions).
  * Please see the license.html included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.
@@ -14,11 +14,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import com.aptana.jetty.util.epl.ajax.JSON;
-
 import com.aptana.configurations.processor.ConfigurationStatus;
 import com.aptana.core.logging.IdeLog;
 import com.aptana.core.util.StringUtil;
+import com.aptana.jetty.util.epl.ajax.JSON;
 import com.aptana.portal.ui.IDebugScopes;
 import com.aptana.portal.ui.PortalUIPlugin;
 import com.aptana.portal.ui.dispatch.IBrowserNotificationConstants;
@@ -27,8 +26,8 @@ import com.aptana.portal.ui.dispatch.actionControllers.CommandHandlerActionContr
 import com.aptana.portal.ui.dispatch.actionControllers.ControllerAction;
 import com.aptana.samples.ISamplesManager;
 import com.aptana.samples.SamplesPlugin;
+import com.aptana.samples.model.IProjectSample;
 import com.aptana.samples.model.SampleCategory;
-import com.aptana.samples.model.SamplesReference;
 import com.aptana.samples.ui.SamplesUIPlugin;
 
 /**
@@ -96,7 +95,7 @@ public class SamplesActionController extends AbstractActionController
 		List<SampleCategory> categories = samplesManager.getCategories();
 		for (SampleCategory category : categories)
 		{
-			for (SamplesReference sample : samplesManager.getSamplesForCategory(category.getId()))
+			for (IProjectSample sample : samplesManager.getSamplesForCategory(category.getId()))
 			{
 				Map<String, String> sampleInfo = new HashMap<String, String>();
 				sampleInfo.put(SAMPLE_INFO.CATEGORY.toString(), category.getName());
@@ -168,7 +167,7 @@ public class SamplesActionController extends AbstractActionController
 		{
 			String message = MessageFormat
 					.format("Wrong argument type passed to SamplesActionController::importSample. Expected Object[] and got {0}", //$NON-NLS-1$
-					((attributes == null) ? "null" : attributes.getClass().getName())); //$NON-NLS-1$
+							((attributes == null) ? "null" : attributes.getClass().getName())); //$NON-NLS-1$
 			IdeLog.logError(PortalUIPlugin.getDefault(), new Exception(message));
 		}
 		return null;

--- a/plugins/com.aptana.samples.ui/src/com/aptana/samples/ui/portal/actionController/SamplesNotification.java
+++ b/plugins/com.aptana.samples.ui/src/com/aptana/samples/ui/portal/actionController/SamplesNotification.java
@@ -1,6 +1,6 @@
 /**
  * Aptana Studio
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the GNU Public License (GPL) v3 (with exceptions).
  * Please see the license.html included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.
@@ -10,17 +10,16 @@ package com.aptana.samples.ui.portal.actionController;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.aptana.jetty.util.epl.ajax.JSON;
-
 import com.aptana.core.logging.IdeLog;
 import com.aptana.core.util.StringUtil;
+import com.aptana.jetty.util.epl.ajax.JSON;
 import com.aptana.portal.ui.IDebugScopes;
 import com.aptana.portal.ui.dispatch.IBrowserNotificationConstants;
 import com.aptana.portal.ui.dispatch.browserNotifications.AbstractBrowserNotification;
 import com.aptana.samples.ISampleListener;
 import com.aptana.samples.SamplesPlugin;
+import com.aptana.samples.model.IProjectSample;
 import com.aptana.samples.model.SampleCategory;
-import com.aptana.samples.model.SamplesReference;
 import com.aptana.samples.ui.SamplesUIPlugin;
 
 /**
@@ -63,7 +62,7 @@ public class SamplesNotification extends AbstractBrowserNotification
 	 * 
 	 * @param sample
 	 */
-	protected void notifyAdd(SamplesReference sample)
+	protected void notifyAdd(IProjectSample sample)
 	{
 		IdeLog.logInfo(SamplesUIPlugin.getDefault(), "Sample added. Notifying portal...", IDebugScopes.START_PAGE); //$NON-NLS-1$
 		notifyTargets(IBrowserNotificationConstants.EVENT_ID_SAMPLES, IBrowserNotificationConstants.EVENT_TYPE_ADDED,
@@ -75,7 +74,7 @@ public class SamplesNotification extends AbstractBrowserNotification
 	 * 
 	 * @param sample
 	 */
-	protected void notifyRemoved(SamplesReference sample)
+	protected void notifyRemoved(IProjectSample sample)
 	{
 		IdeLog.logInfo(SamplesUIPlugin.getDefault(), "Sample removed. Notifying portal...", IDebugScopes.START_PAGE); //$NON-NLS-1$
 		notifyTargets(IBrowserNotificationConstants.EVENT_ID_SAMPLES, IBrowserNotificationConstants.EVENT_TYPE_DELETED,
@@ -88,7 +87,7 @@ public class SamplesNotification extends AbstractBrowserNotification
 	 * @param sample
 	 * @return A JSON representation of the sample that was added or removed.
 	 */
-	protected String createSampleInfo(SamplesReference sample)
+	protected String createSampleInfo(IProjectSample sample)
 	{
 		Map<String, String> sampleInfo = new HashMap<String, String>();
 		SampleCategory category = sample.getCategory();
@@ -110,7 +109,7 @@ public class SamplesNotification extends AbstractBrowserNotification
 		{
 			listener = new ISampleListener()
 			{
-				public void sampleRemoved(SamplesReference sample)
+				public void sampleRemoved(IProjectSample sample)
 				{
 					if (isListening)
 					{
@@ -118,7 +117,7 @@ public class SamplesNotification extends AbstractBrowserNotification
 					}
 				}
 
-				public void sampleAdded(SamplesReference sample)
+				public void sampleAdded(IProjectSample sample)
 				{
 					if (isListening)
 					{

--- a/plugins/com.aptana.samples.ui/src/com/aptana/samples/ui/project/NewSampleProjectWizard.java
+++ b/plugins/com.aptana.samples.ui/src/com/aptana/samples/ui/project/NewSampleProjectWizard.java
@@ -8,7 +8,6 @@
 package com.aptana.samples.ui.project;
 
 import java.io.File;
-import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
 import java.text.MessageFormat;
@@ -52,7 +51,6 @@ import com.aptana.core.logging.IdeLog;
 import com.aptana.core.util.ArrayUtil;
 import com.aptana.core.util.FileUtil;
 import com.aptana.core.util.ResourceUtil;
-import com.aptana.core.util.ZipUtil;
 import com.aptana.git.core.model.GitRepository;
 import com.aptana.git.ui.CloneJob;
 import com.aptana.git.ui.actions.DisconnectHandler;
@@ -210,18 +208,15 @@ public class NewSampleProjectWizard extends BasicNewResourceWizard implements IE
 			}
 			else
 			{
-				doBasicCreateProject(newProjectHandle, description);
+				ProjectData projectData = mainPage.getProjectData();
 
-				// FIXME Move the logic for extracting/applying samples to IProjectSample! See IProjectTemplate!
-				ZipUtil.extract(new File(sample.getLocation()), newProjectHandle.getLocation(),
-						ZipUtil.Conflict.PROMPT, new NullProgressMonitor());
-
+				// Initialize the basic project data
+				projectData.project = newProjectHandle;
+				projectData.directory = mainPage.getLocationURI().getRawPath();
+				projectData.appURL = "http://"; // TODO: not used here.
+				doBasicCreateProject(newProjectHandle, description, sample, projectData);
 				doPostProjectCreation(newProjectHandle);
 			}
-		}
-		catch (IOException e)
-		{
-			return null;
 		}
 		catch (CoreException e)
 		{
@@ -232,27 +227,34 @@ public class NewSampleProjectWizard extends BasicNewResourceWizard implements IE
 		return newProject;
 	}
 
-	private void doBasicCreateProject(IProject project, final IProjectDescription description) throws CoreException
+	private void doBasicCreateProject(final IProject project, final IProjectDescription description,
+			final IProjectSample sample, final ProjectData projectData) throws CoreException
 	{
 		// create the new project operation
 		IRunnableWithProgress op = new IRunnableWithProgress()
 		{
 			public void run(IProgressMonitor monitor) throws InvocationTargetException
 			{
-				CreateProjectOperation op = new CreateProjectOperation(description,
-						Messages.NewSampleProjectWizard_CreateOp_Title);
 				try
 				{
+					CreateProjectOperation op = new CreateProjectOperation(description,
+							Messages.NewSampleProjectWizard_CreateOp_Title);
 					// see bug https://bugs.eclipse.org/bugs/show_bug.cgi?id=219901
 					// directly execute the operation so that the undo state is
 					// not preserved. Making this undoable resulted in too many
 					// accidental file deletions.
 					op.execute(monitor, WorkspaceUndoUtil.getUIInfoAdapter(getShell()));
+					sample.createNewProject(project, projectData, monitor);
+				}
+				catch (CoreException e)
+				{
+					throw new InvocationTargetException(e);
 				}
 				catch (ExecutionException e)
 				{
 					throw new InvocationTargetException(e);
 				}
+
 			}
 		};
 

--- a/plugins/com.aptana.samples.ui/src/com/aptana/samples/ui/views/SamplesView.java
+++ b/plugins/com.aptana.samples.ui/src/com/aptana/samples/ui/views/SamplesView.java
@@ -1,6 +1,6 @@
 /**
  * Aptana Studio
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the GNU Public License (GPL) v3 (with exceptions).
  * Please see the license.html included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.
@@ -26,7 +26,7 @@ import org.eclipse.ui.part.ViewPart;
 import com.aptana.samples.ISampleListener;
 import com.aptana.samples.ISamplesManager;
 import com.aptana.samples.SamplesPlugin;
-import com.aptana.samples.model.SamplesReference;
+import com.aptana.samples.model.IProjectSample;
 import com.aptana.theme.ThemePlugin;
 import com.aptana.ui.util.UIUtils;
 
@@ -46,12 +46,12 @@ public class SamplesView extends ViewPart
 	private ISampleListener sampleListener = new ISampleListener()
 	{
 
-		public void sampleAdded(SamplesReference sample)
+		public void sampleAdded(IProjectSample sample)
 		{
 			refresh();
 		}
 
-		public void sampleRemoved(SamplesReference sample)
+		public void sampleRemoved(IProjectSample sample)
 		{
 			refresh();
 		}

--- a/plugins/com.aptana.samples.ui/src/com/aptana/samples/ui/views/SamplesViewContentProvider.java
+++ b/plugins/com.aptana.samples.ui/src/com/aptana/samples/ui/views/SamplesViewContentProvider.java
@@ -1,6 +1,6 @@
 /**
  * Aptana Studio
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the GNU Public License (GPL) v3 (with exceptions).
  * Please see the license.html included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.
@@ -16,6 +16,7 @@ import org.eclipse.jface.viewers.Viewer;
 import com.aptana.core.util.ArrayUtil;
 import com.aptana.samples.ISamplesManager;
 import com.aptana.samples.SamplesPlugin;
+import com.aptana.samples.model.IProjectSample;
 import com.aptana.samples.model.SampleCategory;
 import com.aptana.samples.model.SamplesReference;
 
@@ -43,7 +44,7 @@ public class SamplesViewContentProvider implements ITreeContentProvider
 			List<SampleCategory> result = new ArrayList<SampleCategory>();
 			for (SampleCategory category : categories)
 			{
-				List<SamplesReference> samples = manager.getSamplesForCategory(category.getId());
+				List<IProjectSample> samples = manager.getSamplesForCategory(category.getId());
 				if (samples != null && samples.size() > 0)
 				{
 					result.add(category);
@@ -53,10 +54,10 @@ public class SamplesViewContentProvider implements ITreeContentProvider
 		}
 		if (parentElement instanceof SampleCategory)
 		{
-			List<SamplesReference> samplesRefs = SamplesPlugin.getDefault().getSamplesManager()
+			List<IProjectSample> samplesRefs = SamplesPlugin.getDefault().getSamplesManager()
 					.getSamplesForCategory(((SampleCategory) parentElement).getId());
 			List<Object> children = new ArrayList<Object>();
-			for (SamplesReference ref : samplesRefs)
+			for (IProjectSample ref : samplesRefs)
 			{
 				children.add(ref);
 			}

--- a/plugins/com.aptana.samples/META-INF/MANIFEST.MF
+++ b/plugins/com.aptana.samples/META-INF/MANIFEST.MF
@@ -7,7 +7,8 @@ Bundle-Activator: com.aptana.samples.SamplesPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: com.aptana.core,
- com.aptana.scripting
+ com.aptana.scripting,
+ com.aptana.projects
 Bundle-ActivationPolicy: lazy
 Export-Package: com.aptana.samples,
  com.aptana.samples.handlers,

--- a/plugins/com.aptana.samples/src/com/aptana/samples/ISampleListener.java
+++ b/plugins/com.aptana.samples/src/com/aptana/samples/ISampleListener.java
@@ -1,13 +1,13 @@
 /**
  * Aptana Studio
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the GNU Public License (GPL) v3 (with exceptions).
  * Please see the license.html included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.
  */
 package com.aptana.samples;
 
-import com.aptana.samples.model.SamplesReference;
+import com.aptana.samples.model.IProjectSample;
 
 public interface ISampleListener
 {
@@ -18,7 +18,7 @@ public interface ISampleListener
 	 * @param sample
 	 *            the added sample
 	 */
-	public void sampleAdded(SamplesReference sample);
+	public void sampleAdded(IProjectSample sample);
 
 	/**
 	 * Fired when a sample is removed.
@@ -26,5 +26,5 @@ public interface ISampleListener
 	 * @param sample
 	 *            the removed sample
 	 */
-	public void sampleRemoved(SamplesReference sample);
+	public void sampleRemoved(IProjectSample sample);
 }

--- a/plugins/com.aptana.samples/src/com/aptana/samples/ISamplesManager.java
+++ b/plugins/com.aptana.samples/src/com/aptana/samples/ISamplesManager.java
@@ -1,6 +1,6 @@
 /**
  * Aptana Studio
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the GNU Public License (GPL) v3 (with exceptions).
  * Please see the license.html included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.
@@ -9,8 +9,9 @@ package com.aptana.samples;
 
 import java.util.List;
 
+import com.aptana.samples.model.IProjectSample;
 import com.aptana.samples.model.SampleCategory;
-import com.aptana.samples.model.SamplesReference;
+import com.aptana.scripting.model.ProjectSampleElement;
 
 public interface ISamplesManager
 {
@@ -29,7 +30,7 @@ public interface ISamplesManager
 	 *            the id of the category
 	 * @return the list of samples that belongs to the category
 	 */
-	public List<SamplesReference> getSamplesForCategory(String categoryId);
+	public List<IProjectSample> getSamplesForCategory(String categoryId);
 
 	/**
 	 * Gets the sample with the specific id.
@@ -38,7 +39,7 @@ public interface ISamplesManager
 	 *            the id of the sample
 	 * @return the sample with the id
 	 */
-	public SamplesReference getSample(String id);
+	public IProjectSample getSample(String id);
 
 	/**
 	 * Adds a listener to get notified when a sample is added or removed.
@@ -55,4 +56,25 @@ public interface ISamplesManager
 	 *            the listener
 	 */
 	public void removeSampleListener(ISampleListener listener);
+
+	/**
+	 * Adds a sample to the sample manager
+	 * 
+	 * @param sampleElement
+	 *            sample defined in the bundles.
+	 */
+	public void addSample(ProjectSampleElement sampleElement);
+
+	/**
+	 * @param categoryId
+	 * @return the category based on the provided categoryId
+	 */
+	public SampleCategory getCategory(String categoryId);
+
+	/**
+	 * Adds a sample to the sample manager
+	 * 
+	 * @param sample
+	 */
+	public void addSample(IProjectSample sample);
 }

--- a/plugins/com.aptana.samples/src/com/aptana/samples/internal/SamplesManager.java
+++ b/plugins/com.aptana.samples/src/com/aptana/samples/internal/SamplesManager.java
@@ -1,6 +1,6 @@
 /**
  * Aptana Studio
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the GNU Public License (GPL) v3 (with exceptions).
  * Please see the license.html included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.
@@ -21,12 +21,14 @@ import java.util.Set;
 
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
 import org.osgi.framework.Bundle;
 
 import com.aptana.core.logging.IdeLog;
 import com.aptana.core.util.CollectionsUtil;
 import com.aptana.core.util.EclipseUtil;
+import com.aptana.core.util.FileUtil;
 import com.aptana.core.util.IConfigurationElementProcessor;
 import com.aptana.core.util.ResourceUtil;
 import com.aptana.core.util.StringUtil;
@@ -34,6 +36,7 @@ import com.aptana.samples.IDebugScopes;
 import com.aptana.samples.ISampleListener;
 import com.aptana.samples.ISamplesManager;
 import com.aptana.samples.SamplesPlugin;
+import com.aptana.samples.model.IProjectSample;
 import com.aptana.samples.model.SampleCategory;
 import com.aptana.samples.model.SamplesReference;
 import com.aptana.scripting.model.AbstractElement;
@@ -66,11 +69,11 @@ public class SamplesManager implements ISamplesManager
 	private static final String SAMPLES_SCRIPT = "project_samples.rb"; //$NON-NLS-1$
 
 	private Map<String, SampleCategory> categories;
-	private Map<String, List<SamplesReference>> sampleRefsByCategory;
-	private Map<String, SamplesReference> samplesById;
+	private Map<String, List<IProjectSample>> sampleRefsByCategory;
+	private Map<String, IProjectSample> samplesById;
 
-	private Map<String, List<SamplesReference>> bundleSamplesByCategory;
-	private Map<String, SamplesReference> bundleSamplesById;
+	private Map<String, List<IProjectSample>> bundleSamplesByCategory;
+	private Map<String, IProjectSample> bundleSamplesById;
 
 	private List<ProjectSampleElement> bundleSamples;
 
@@ -133,10 +136,10 @@ public class SamplesManager implements ISamplesManager
 	public SamplesManager()
 	{
 		categories = new HashMap<String, SampleCategory>();
-		sampleRefsByCategory = new HashMap<String, List<SamplesReference>>();
-		samplesById = new HashMap<String, SamplesReference>();
-		bundleSamplesByCategory = new HashMap<String, List<SamplesReference>>();
-		bundleSamplesById = Collections.synchronizedMap(new HashMap<String, SamplesReference>());
+		sampleRefsByCategory = new HashMap<String, List<IProjectSample>>();
+		samplesById = new HashMap<String, IProjectSample>();
+		bundleSamplesByCategory = new HashMap<String, List<IProjectSample>>();
+		bundleSamplesById = Collections.synchronizedMap(new HashMap<String, IProjectSample>());
 		bundleSamples = new ArrayList<ProjectSampleElement>();
 		sampleListeners = new ArrayList<ISampleListener>();
 
@@ -154,10 +157,10 @@ public class SamplesManager implements ISamplesManager
 		return sampleCategories;
 	}
 
-	public List<SamplesReference> getSamplesForCategory(String categoryId)
+	public List<IProjectSample> getSamplesForCategory(String categoryId)
 	{
-		List<SamplesReference> result = new ArrayList<SamplesReference>();
-		List<SamplesReference> samples = sampleRefsByCategory.get(categoryId);
+		List<IProjectSample> result = new ArrayList<IProjectSample>();
+		List<IProjectSample> samples = sampleRefsByCategory.get(categoryId);
 		if (samples != null)
 		{
 			result.addAll(samples);
@@ -170,9 +173,9 @@ public class SamplesManager implements ISamplesManager
 		return result;
 	}
 
-	public SamplesReference getSample(String id)
+	public IProjectSample getSample(String id)
 	{
-		SamplesReference sample = samplesById.get(id);
+		IProjectSample sample = samplesById.get(id);
 		return (sample == null) ? bundleSamplesById.get(id) : sample;
 	}
 
@@ -189,7 +192,33 @@ public class SamplesManager implements ISamplesManager
 		sampleListeners.remove(listener);
 	}
 
-	private void addSample(ProjectSampleElement sampleElement)
+	public void addSample(IProjectSample sample)
+	{
+		String categoryId = sample.getCategory().getId();
+		List<IProjectSample> samples = bundleSamplesByCategory.get(categoryId);
+		if (samples == null)
+		{
+			samples = new ArrayList<IProjectSample>();
+			bundleSamplesByCategory.put(categoryId, samples);
+		}
+		String id = sample.getId();
+		IProjectSample existingSample = bundleSamplesById.get(id);
+		if (existingSample != null)
+		{
+			samples.remove(existingSample);
+		}
+		samples.add(sample);
+		bundleSamplesById.put(id, sample);
+
+		fireSampleAdded(sample);
+	}
+
+	public SampleCategory getCategory(String categoryId)
+	{
+		return categories.get(categoryId);
+	}
+
+	public void addSample(ProjectSampleElement sampleElement)
 	{
 		String categoryId = sampleElement.getCategory();
 		SampleCategory category = categories.get(categoryId);
@@ -198,8 +227,10 @@ public class SamplesManager implements ISamplesManager
 			String id = sampleElement.getId();
 			String name = sampleElement.getDisplayName();
 			String location = sampleElement.getLocation();
-			boolean isRemote = !location.toLowerCase().endsWith(".zip"); //$NON-NLS-1$
-			if (!isRemote)
+			IPath destination = sampleElement.getDestinationPath();
+			File locationFile = new File(location);
+			boolean isRemote = !(FileUtil.isZipFile(locationFile) || new File(location).exists()); //$NON-NLS-1$
+			if (!isRemote && FileUtil.isZipFile(locationFile))
 			{
 				// retrieves the absolute location
 				location = (new File(sampleElement.getDirectory(), location)).getAbsolutePath();
@@ -207,24 +238,10 @@ public class SamplesManager implements ISamplesManager
 			String description = sampleElement.getDescription();
 			Map<String, URL> iconUrls = sampleElement.getIconUrls();
 			SamplesReference sample = new SamplesReference(category, id, name, location, isRemote, description,
-					iconUrls, null);
+					iconUrls, destination, null);
 			sample.setNatures(sampleElement.getNatures());
 
-			List<SamplesReference> samples = bundleSamplesByCategory.get(categoryId);
-			if (samples == null)
-			{
-				samples = new ArrayList<SamplesReference>();
-				bundleSamplesByCategory.put(categoryId, samples);
-			}
-			SamplesReference existingSample = bundleSamplesById.get(id);
-			if (existingSample != null)
-			{
-				samples.remove(existingSample);
-			}
-			samples.add(sample);
-			bundleSamplesById.put(id, sample);
-
-			fireSampleAdded(sample);
+			addSample(sample);
 		}
 		else
 		{
@@ -322,10 +339,10 @@ public class SamplesManager implements ISamplesManager
 				}
 			}
 
-			List<SamplesReference> samples = sampleRefsByCategory.get(categoryId);
+			List<IProjectSample> samples = sampleRefsByCategory.get(categoryId);
 			if (samples == null)
 			{
-				samples = new ArrayList<SamplesReference>();
+				samples = new ArrayList<IProjectSample>();
 				sampleRefsByCategory.put(categoryId, samples);
 			}
 
@@ -351,7 +368,7 @@ public class SamplesManager implements ISamplesManager
 			iconUrls.put(SamplesReference.DEFAULT_ICON_KEY, iconUrl);
 
 			SamplesReference samplesRef = new SamplesReference(category, id, name, path, isRemote, description,
-					iconUrls, element);
+					iconUrls, null, element);
 			samples.add(samplesRef);
 			samplesById.put(id, samplesRef);
 
@@ -414,15 +431,15 @@ public class SamplesManager implements ISamplesManager
 		bundleSamples = elements;
 
 		// removes the existing samples loaded from the rubles
-		Collection<SamplesReference> bundles = bundleSamplesById.values();
-		Collection<SamplesReference> samples;
+		Collection<IProjectSample> bundles = bundleSamplesById.values();
+		Collection<IProjectSample> samples;
 		synchronized (bundleSamplesById)
 		{
-			samples = new ArrayList<SamplesReference>(bundles);
+			samples = new ArrayList<IProjectSample>(bundles);
 			bundleSamplesByCategory.clear();
 			bundleSamplesById.clear();
 		}
-		for (SamplesReference sample : samples)
+		for (IProjectSample sample : samples)
 		{
 			fireSampleRemoved(sample);
 		}
@@ -434,7 +451,7 @@ public class SamplesManager implements ISamplesManager
 		}
 	}
 
-	private void fireSampleAdded(SamplesReference sample)
+	private void fireSampleAdded(IProjectSample sample)
 	{
 		if (IdeLog.isInfoEnabled(SamplesPlugin.getDefault(), IDebugScopes.MANAGER))
 		{
@@ -448,7 +465,7 @@ public class SamplesManager implements ISamplesManager
 		}
 	}
 
-	private void fireSampleRemoved(SamplesReference sample)
+	private void fireSampleRemoved(IProjectSample sample)
 	{
 		if (IdeLog.isInfoEnabled(SamplesPlugin.getDefault(), IDebugScopes.MANAGER))
 		{

--- a/plugins/com.aptana.samples/src/com/aptana/samples/model/IProjectSample.java
+++ b/plugins/com.aptana.samples/src/com/aptana/samples/model/IProjectSample.java
@@ -1,12 +1,21 @@
 /**
  * Aptana Studio
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the GNU Public License (GPL) v3 (with exceptions).
  * Please see the license.html included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.
  */
 package com.aptana.samples.model;
 
+import java.io.IOException;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+
+import com.aptana.projects.ProjectData;
 import com.aptana.samples.handlers.ISampleProjectHandler;
 
 public interface IProjectSample
@@ -36,4 +45,38 @@ public interface IProjectSample
 	 * @return a class that does any necessary post-processing after the project is created; could be null
 	 */
 	public ISampleProjectHandler getProjectHandler();
+
+	/**
+	 * Indicates destination path where the sample project data has to be copied or extracted.
+	 * 
+	 * @return
+	 */
+	public IPath getDestination();
+
+	/**
+	 * @return Category of the sample.
+	 */
+	public SampleCategory getCategory();
+
+	/**
+	 * @return unique id of the sample.
+	 */
+	public String getId();
+
+	/**
+	 * @return description of the sample.
+	 */
+	public String getDescription();
+
+	/**
+	 * Extract the contents of sample into newly created project.
+	 * 
+	 * @param project
+	 * @param projectData
+	 * @param monitor
+	 * @return
+	 * @throws IOException
+	 */
+	public IStatus createNewProject(IProject project, ProjectData projectData, IProgressMonitor monitor)
+			throws CoreException;
 }

--- a/plugins/com.aptana.scripting/src/com/aptana/scripting/model/ProjectSampleElement.java
+++ b/plugins/com.aptana.scripting/src/com/aptana/scripting/model/ProjectSampleElement.java
@@ -1,6 +1,6 @@
 /**
  * Aptana Studio
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the GNU Public License (GPL) v3 (with exceptions).
  * Please see the license.html included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.
@@ -12,6 +12,8 @@ import java.net.URL;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+
+import org.eclipse.core.runtime.IPath;
 
 import com.aptana.core.util.SourcePrinter;
 
@@ -25,6 +27,7 @@ public class ProjectSampleElement extends AbstractBundleElement
 	private String fLocation;
 	private String fDescription;
 	private String[] fProjectNatures;
+	private IPath fDestinationPath;
 	private Map<String, String> fIconPaths;
 	private Map<String, URL> fIconUrls;
 
@@ -36,6 +39,31 @@ public class ProjectSampleElement extends AbstractBundleElement
 		super(path);
 		fIconPaths = new HashMap<String, String>();
 		fIconUrls = new HashMap<String, URL>();
+	}
+
+	/**
+	 * @param sourcePath
+	 * @param id
+	 * @param displayName
+	 * @param categoryId
+	 * @param description
+	 * @param icon
+	 * @param destinationPath
+	 */
+	public ProjectSampleElement(String sourcePath, String id, String displayName, String categoryId,
+			String description, URL icon, IPath destinationPath, String[] natures)
+	{
+		super(sourcePath);
+		fLocation = sourcePath;
+		fSampleId = id;
+		fCategoryId = categoryId;
+		fDescription = description;
+		fDestinationPath = destinationPath;
+		fProjectNatures = natures;
+		fIconPaths = new HashMap<String, String>();
+		fIconUrls = new HashMap<String, URL>();
+		setDisplayName(displayName);
+		setIcon(DEFAULT_ICON, icon.toExternalForm());
 	}
 
 	/**
@@ -116,45 +144,9 @@ public class ProjectSampleElement extends AbstractBundleElement
 		return "project_sample"; //$NON-NLS-1$
 	}
 
-	/**
-	 * @param id
-	 *            the id of the sample
-	 */
-	public void setId(String id)
+	public IPath getDestinationPath()
 	{
-		fSampleId = id;
-	}
-
-	/**
-	 * @param description
-	 *            the description of the sample
-	 */
-	public void setDescription(String description)
-	{
-		fDescription = description;
-	}
-
-	/**
-	 * @param location
-	 *            a remote git url or a local zip location
-	 */
-	public void setLocation(String location)
-	{
-		fLocation = location;
-	}
-
-	/**
-	 * @param categoryId
-	 *            the id of the category the sample belongs in
-	 */
-	public void setCategory(String categoryId)
-	{
-		fCategoryId = categoryId;
-	}
-
-	public void setNatures(String[] natures)
-	{
-		fProjectNatures = natures;
+		return fDestinationPath;
 	}
 
 	public void setIcon(String defaultIcon)


### PR DESCRIPTION
Adding support to add the alloy samples dynamically during Studio startup based on the information from alloy info samples command.

The samples are available in Alloy installation directory and it contains only the contents of app folder, as it is the source code that is distinctive from the other samples. Since this is traditionally different from importing a local/remote sample project, the sample framework has been added support to allow creating a basic titanium project and then creating the sample specific project (alloy in this case) and it has provision to either extract or copy the contents of the sample location.

Since the import wizard does not go through the traditional new project wizard, the project data has not been initialized with the default values. In this case, this is hacked to initialized the specific details of the project data at various level (this is kind of a hack, should be changed?).

Additional refactoring has been done to support common project samples across various places.
