### PR TITLE
TISTUD-5101 Improve Github PR submission

### DIFF
--- a/plugins/com.aptana.git.core/src/com/aptana/git/core/github/IGithubPullRequest.java
+++ b/plugins/com.aptana.git.core/src/com/aptana/git/core/github/IGithubPullRequest.java
@@ -1,0 +1,27 @@
+/**
+ * Aptana Studio
+ * Copyright (c) 2013 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the GNU Public License (GPL) v3 (with exceptions).
+ * Please see the license.html included with this distribution for details.
+ * Any modifications to this file must keep this entire header intact.
+ */
+package com.aptana.git.core.github;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+/**
+ * @author cwilliams
+ */
+public interface IGithubPullRequest
+{
+
+	public URL getURL() throws MalformedURLException;
+
+	public int getNumber();
+
+	public String getTitle();
+
+	public String getBody();
+
+}

--- a/plugins/com.aptana.git.core/src/com/aptana/git/core/github/IGithubRepository.java
+++ b/plugins/com.aptana.git.core/src/com/aptana/git/core/github/IGithubRepository.java
@@ -47,10 +47,10 @@ public interface IGithubRepository
 	 *            required
 	 * @param body
 	 *            optional
-	 * @param repo 
+	 * @param repo
 	 * @return
 	 */
-	public IStatus createPullRequest(String title, String body, GitRepository repo);
+	public IGithubPullRequest createPullRequest(String title, String body, GitRepository repo) throws CoreException;
 
 	public String getDefaultBranch();
 }

--- a/plugins/com.aptana.git.core/src/com/aptana/git/internal/core/github/GithubPullRequest.java
+++ b/plugins/com.aptana.git.core/src/com/aptana/git/internal/core/github/GithubPullRequest.java
@@ -1,0 +1,58 @@
+/**
+ * Aptana Studio
+ * Copyright (c) 2013 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the GNU Public License (GPL) v3 (with exceptions).
+ * Please see the license.html included with this distribution for details.
+ * Any modifications to this file must keep this entire header intact.
+ */
+package com.aptana.git.internal.core.github;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.json.simple.JSONObject;
+
+import com.aptana.git.core.github.IGithubPullRequest;
+
+/**
+ * @author cwilliams
+ */
+class GithubPullRequest implements IGithubPullRequest
+{
+
+	/**
+	 * Keys used in JSON describing the pull request.
+	 */
+	private static final String URL = "url"; //$NON-NLS-1$
+	private static final String NUMBER = "number"; //$NON-NLS-1$
+	private static final String TITLE = "title"; //$NON-NLS-1$
+	private static final String BODY = "body"; //$NON-NLS-1$
+
+	private JSONObject json;
+
+	GithubPullRequest(JSONObject json)
+	{
+		this.json = json;
+	}
+
+	public URL getURL() throws MalformedURLException
+	{
+		return new URL((String) json.get(URL));
+	}
+
+	public int getNumber()
+	{
+		return (Integer) json.get(NUMBER);
+	}
+
+	public String getTitle()
+	{
+		return (String) json.get(TITLE);
+	}
+
+	public String getBody()
+	{
+		return (String) json.get(BODY);
+	}
+
+}

--- a/plugins/com.aptana.git.ui/src/com/aptana/git/ui/dialogs/CreatePullRequestDialog.java
+++ b/plugins/com.aptana.git.ui/src/com/aptana/git/ui/dialogs/CreatePullRequestDialog.java
@@ -12,9 +12,13 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.StatusDialog;
 import org.eclipse.jface.layout.GridDataFactory;
+import org.eclipse.jface.layout.GridLayoutFactory;
+import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.ModifyEvent;
 import org.eclipse.swt.events.ModifyListener;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
@@ -24,6 +28,7 @@ import org.eclipse.swt.widgets.Text;
 
 import com.aptana.core.util.StringUtil;
 import com.aptana.git.ui.GitUIPlugin;
+import com.aptana.theme.ThemePlugin;
 
 /**
  * @author cwilliams
@@ -36,19 +41,53 @@ public class CreatePullRequestDialog extends StatusDialog
 
 	private Text titleText;
 	private String title;
+	private String base;
+	private String head;
 
-	public CreatePullRequestDialog(final Shell parentShell, String defaultTitle, String defaultBody)
+	public CreatePullRequestDialog(final Shell parentShell, String defaultTitle, String defaultBody, String base,
+			String head)
 	{
 		super(parentShell);
 		setTitle(Messages.CreatePullRequestDialog_Title);
 		this.title = defaultTitle;
 		this.body = defaultBody;
+		this.base = base;
+		this.head = head;
 	}
 
 	@Override
 	protected Control createDialogArea(Composite parent)
 	{
 		Composite composite = (Composite) super.createDialogArea(parent);
+
+		// --- Overview of the two endpoints this PR is for
+		Composite overview = new Composite(composite, SWT.NONE);
+		overview.setLayout(GridLayoutFactory.fillDefaults().numColumns(4).create());
+
+		// icon
+		Label icon = new Label(overview, SWT.NONE);
+		icon.setImage(GitUIPlugin.getImage("icons/obj16/pull_request.gif")); //$NON-NLS-1$
+
+		Color lightBlue = ThemePlugin.getDefault().getColorManager().getColor(new RGB(209, 227, 237));
+		// base
+		Label baseLabel = new Label(overview, SWT.WRAP);
+		baseLabel.setText(base);
+		baseLabel.setFont(JFaceResources.getTextFont());
+		baseLabel.setBackground(lightBlue);
+
+		// ...
+		Label ellipsis = new Label(overview, SWT.WRAP);
+		ellipsis.setText(" ... "); //$NON-NLS-1$
+		ellipsis.setFont(JFaceResources.getTextFont());
+		ellipsis.setEnabled(false);
+
+		// head
+		Label headLabel = new Label(overview, SWT.WRAP);
+		headLabel.setText(head);
+		headLabel.setFont(JFaceResources.getTextFont());
+		headLabel.setBackground(lightBlue);
+
+		// ------- END OVERVIEW --------------------------
 
 		// Title
 		Label titleLabel = new Label(composite, SWT.WRAP);
@@ -77,7 +116,7 @@ public class CreatePullRequestDialog extends StatusDialog
 
 		bodyText = new Text(composite, SWT.MULTI | SWT.BORDER | SWT.H_SCROLL | SWT.V_SCROLL);
 		bodyText.setText(body);
-		GridDataFactory.fillDefaults().hint(SWT.DEFAULT, 300).applyTo(bodyText);
+		GridDataFactory.fillDefaults().hint(400, 300).applyTo(bodyText);
 		bodyText.addModifyListener(new ModifyListener()
 		{
 			public void modifyText(ModifyEvent e)

--- a/plugins/com.aptana.git.ui/src/com/aptana/git/ui/internal/actions/messages.properties
+++ b/plugins/com.aptana.git.ui/src/com/aptana/git/ui/internal/actions/messages.properties
@@ -29,7 +29,7 @@ CreatePullRequestHandler_NoRepoErr=No git repository selected
 CreatePullRequestHandler_NotLoggedInErr=User is not logged into their Github account
 CreatePullRequestHandler_RemoteOriginDoesntExistErr=Remote 'origin' not set up
 CreatePullRequestHandler_RepoAPIErr=Unable to get repository details from github API
-CreatePullRequestHandler_SuccessMsg=Successfully generated pull request.
+CreatePullRequestHandler_SuccessMsg=Successfully generated pull request <a href="{0}">#{1}</a>.
 DisconnectHandler_Job_Title=Disconnecting {0}
 DisconnectProviderOperation_DisconnectJob_Title=Disconnecting Git team provider
 PullAction_RefreshJob_Title=Refresh resources


### PR DESCRIPTION
- Add overview section to dialog showing the two endpoints the PR would be fore
- set a preferred width for the body text control
- submit the PR in a user job
- grab the returned JSON and generate a model object holding it
- Use the PR model object to populate a more helpful toast for success which allows user to click to open browser on PR they just submitted.
