### PR TITLE
TISTUD-5168 Proxy settings not used when downloading APM module from AWS S3 bucket

### DIFF
--- a/plugins/com.aptana.core.epl/META-INF/MANIFEST.MF
+++ b/plugins/com.aptana.core.epl/META-INF/MANIFEST.MF
@@ -7,7 +7,8 @@ Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: J2SE-1.5
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ecf;visibility:=reexport,
- org.eclipse.ecf.filetransfer;visibility:=reexport
+ org.eclipse.ecf.filetransfer;visibility:=reexport,
+ org.eclipse.ecf.provider.filetransfer
 Export-Package: com.aptana.core.epl,
  com.aptana.core.epl.downloader,
  com.aptana.core.epl.util,

--- a/plugins/com.aptana.core.epl/src/com/aptana/core/epl/downloader/FileReader.java
+++ b/plugins/com.aptana.core.epl/src/com/aptana/core/epl/downloader/FileReader.java
@@ -33,6 +33,7 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubProgressMonitor;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.ecf.core.security.IConnectContext;
+import org.eclipse.ecf.core.util.Proxy;
 import org.eclipse.ecf.filetransfer.FileTransferJob;
 import org.eclipse.ecf.filetransfer.IFileRangeSpecification;
 import org.eclipse.ecf.filetransfer.IFileTransferListener;
@@ -49,6 +50,7 @@ import org.eclipse.ecf.filetransfer.identity.FileCreateException;
 import org.eclipse.ecf.filetransfer.identity.FileIDFactory;
 import org.eclipse.ecf.filetransfer.identity.IFileID;
 import org.eclipse.ecf.filetransfer.service.IRetrieveFileTransferFactory;
+import org.eclipse.ecf.provider.filetransfer.util.ProxySetupHelper;
 import org.eclipse.osgi.util.NLS;
 
 import com.aptana.core.epl.CoreEPLPlugin;
@@ -417,6 +419,10 @@ public final class FileReader extends FileTransferJob implements IFileTransferLi
 		IRetrieveFileTransferContainerAdapter adapter = factory.newInstance();
 
 		adapter.setConnectContextForAuthentication(connectContext);
+
+		// Set the proxy settings for download if Studio is configured with proxy.
+		Proxy proxy = ProxySetupHelper.getProxy(uri.toASCIIString());
+		adapter.setProxy(proxy);
 
 		this.exception = null;
 		this.closeStreamWhenFinished = closeStreamOnFinish;


### PR DESCRIPTION
DownloadManager does not use proxy settings while transferring a remote file into local file system. Only HttpURLConnection grabs the proxy settings from Eclipse before it initiates the connection.

The fix here is to set the proxy settings to adapters used by download manager to route the connections through the configured proxy server.
