### PR TITLE
TISTUD-4335 published url on windows and Java 7

### DIFF
--- a/plugins/com.aptana.core/src/com/aptana/core/util/ProcessUtil.java
+++ b/plugins/com.aptana.core/src/com/aptana/core/util/ProcessUtil.java
@@ -275,7 +275,7 @@ public class ProcessUtil
 				List<String> argsList = CollectionsUtil.newList(arguments);
 				CollectionsUtil.addToList(argsList, ">", outFile.getAbsolutePath(), "2>", errFile.getAbsolutePath()); //$NON-NLS-1$ //$NON-NLS-2$
 				Process p;
-				if (!isJava7)
+				if (isJava7)
 				{
 					List<String> commands = new ArrayList<String>(Arrays.asList(arguments));
 					commands.add(0, command);


### PR DESCRIPTION
Redirecting the output of ACS commands does not work on Java7 Windows.

Added hack to use reflection to invoke Java 7 API calls to allow process builder to invoke redirectError and redirectOutput calls whenever we are running ACS on Windows and Java 7.
