### PR TITLE
TISTUD-5231 Lazy load Samples UI plugin

### DIFF
--- a/plugins/com.aptana.portal.ui/src/com/aptana/portal/ui/dispatch/ActionControllerProxy.java
+++ b/plugins/com.aptana.portal.ui/src/com/aptana/portal/ui/dispatch/ActionControllerProxy.java
@@ -1,0 +1,112 @@
+/**
+ * Appcelerator Titanium Studio
+ * Copyright (c) 2013 by Appcelerator, Inc. All Rights Reserved.
+ * Proprietary and Confidential - This source code is not for redistribution
+ */
+
+package com.aptana.portal.ui.dispatch;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IConfigurationElement;
+
+import com.aptana.core.logging.IdeLog;
+import com.aptana.core.util.StringUtil;
+import com.aptana.portal.ui.PortalUIPlugin;
+
+/**
+ * Proxy class to the contributors of Action Controller.
+ * 
+ * @author pinnamuri
+ */
+public class ActionControllerProxy implements IActionController
+{
+
+	private IConfigurationElement element;
+	private IActionController contributorClass;
+	private static final String ATT_CLASS = "class"; //$NON-NLS-1$
+	private static final String ATT_CONFGURATION_PROCESSOR_ID = "configurationProcessor"; //$NON-NLS-1$
+
+	public ActionControllerProxy(IConfigurationElement element)
+	{
+		this.element = element;
+	}
+
+	private synchronized void loadElement() throws CoreException
+	{
+		if (contributorClass == null)
+		{
+			contributorClass = (IActionController) element.createExecutableExtension(ATT_CLASS);
+			// Set the value to the contributor immediately after it is instantiated.
+			contributorClass.setConfigurationProcessorId(element.getAttribute(ATT_CONFGURATION_PROCESSOR_ID));
+		}
+	}
+
+	public String[] getActions()
+	{
+		try
+		{
+			loadElement();
+			return contributorClass.getActions();
+		}
+		catch (CoreException e)
+		{
+			IdeLog.logError(PortalUIPlugin.getDefault(), e);
+		}
+		return new String[0];
+	}
+
+	public boolean hasAction(String action)
+	{
+		try
+		{
+			loadElement();
+			return contributorClass.hasAction(action);
+		}
+		catch (CoreException e)
+		{
+			IdeLog.logError(PortalUIPlugin.getDefault(), e);
+		}
+		return false;
+	}
+
+	public Object invokeAction(String action, Object args)
+	{
+		try
+		{
+			loadElement();
+			return contributorClass.invokeAction(action, args);
+		}
+		catch (CoreException e)
+		{
+			IdeLog.logError(PortalUIPlugin.getDefault(), e);
+		}
+		return null;
+	}
+
+	public void setConfigurationProcessorId(String id)
+	{
+		try
+		{
+			loadElement();
+			contributorClass.setConfigurationProcessorId(id);
+		}
+		catch (CoreException e)
+		{
+			IdeLog.logError(PortalUIPlugin.getDefault(), e);
+		}
+	}
+
+	public String getConfigurationProcessorId()
+	{
+		try
+		{
+			loadElement();
+			return contributorClass.getConfigurationProcessorId();
+		}
+		catch (CoreException e)
+		{
+			IdeLog.logError(PortalUIPlugin.getDefault(), e);
+		}
+		return StringUtil.EMPTY;
+	}
+}

--- a/plugins/com.aptana.portal.ui/src/com/aptana/portal/ui/dispatch/BrowserInteractionRegistry.java
+++ b/plugins/com.aptana.portal.ui/src/com/aptana/portal/ui/dispatch/BrowserInteractionRegistry.java
@@ -10,13 +10,12 @@ package com.aptana.portal.ui.dispatch;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.Platform;
 
-import com.aptana.core.logging.IdeLog;
 import com.aptana.portal.ui.PortalUIPlugin;
 import com.aptana.portal.ui.dispatch.browserNotifications.AbstractBrowserNotification;
+import com.aptana.portal.ui.dispatch.browserNotifications.BrowserNotificationProxy;
 
 /**
  * A registry class for the browser-interaction extensions that were registered through the 'browserInteractions'
@@ -31,8 +30,6 @@ public class BrowserInteractionRegistry
 	private static final String TAG_NOTIFICATION = "browserNotification"; //$NON-NLS-1$
 	private static final String ATT_ID = "id"; //$NON-NLS-1$
 	private static final String ATT_CLASS = "class"; //$NON-NLS-1$
-	private static final String ATT_NOTIFICATION_TARGET = "notificationTarget"; //$NON-NLS-1$
-	private static final String ATT_CONFGURATION_PROCESSOR_ID = "configurationProcessor"; //$NON-NLS-1$
 
 	private static BrowserInteractionRegistry instance = null;
 	private Map<String, IActionController> controllers = new HashMap<String, IActionController>();
@@ -159,25 +156,15 @@ public class BrowserInteractionRegistry
 			{
 				return;
 			}
-			try
+			if (isControllerElement)
 			{
-				if (isControllerElement)
-				{
-					IActionController actionController = (IActionController) element.createExecutableExtension(ATT_CLASS);
-					actionController.setConfigurationProcessorId(element.getAttribute(ATT_CONFGURATION_PROCESSOR_ID));
-					controllers.put(id, actionController);
-				}
-				else
-				{
-					AbstractBrowserNotification notification = (AbstractBrowserNotification) element
-							.createExecutableExtension(ATT_CLASS);
-					notifiers.put(id, notification);
-					notification.setNotificationTargets(element.getAttribute(ATT_NOTIFICATION_TARGET));
-				}
+				IActionController actionController = new ActionControllerProxy(element);
+				controllers.put(id, actionController);
 			}
-			catch (CoreException e)
+			else
 			{
-				IdeLog.logError(PortalUIPlugin.getDefault(), "Failed creating a browser action contoller extension", e); //$NON-NLS-1$
+				AbstractBrowserNotification notification = new BrowserNotificationProxy(element);
+				notifiers.put(id, notification);
 			}
 		}
 	}

--- a/plugins/com.aptana.portal.ui/src/com/aptana/portal/ui/dispatch/browserNotifications/BrowserNotificationProxy.java
+++ b/plugins/com.aptana.portal.ui/src/com/aptana/portal/ui/dispatch/browserNotifications/BrowserNotificationProxy.java
@@ -1,0 +1,135 @@
+/**
+ * Appcelerator Titanium Studio
+ * Copyright (c) 2013 by Appcelerator, Inc. All Rights Reserved.
+ * Proprietary and Confidential - This source code is not for redistribution
+ */
+
+package com.aptana.portal.ui.dispatch.browserNotifications;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IConfigurationElement;
+
+import com.aptana.core.logging.IdeLog;
+import com.aptana.portal.ui.PortalUIPlugin;
+
+/**
+ * Proxy class to the contributors of Browser notifications.
+ * 
+ * @author pinnamuri
+ */
+public class BrowserNotificationProxy extends AbstractBrowserNotification
+{
+
+	private IConfigurationElement element;
+	private AbstractBrowserNotification contributorClass;
+	private static final String ATT_CLASS = "class"; //$NON-NLS-1$
+	private static final String ATT_NOTIFICATION_TARGET = "notificationTarget"; //$NON-NLS-1$
+
+	public BrowserNotificationProxy(IConfigurationElement element)
+	{
+		this.element = element;
+	}
+
+	@Override
+	public void start()
+	{
+		try
+		{
+			loadElement();
+			contributorClass.start();
+
+		}
+		catch (CoreException e)
+		{
+			IdeLog.logError(PortalUIPlugin.getDefault(), e);
+		}
+	}
+
+	@Override
+	public List<String> getNotificationTargets()
+	{
+		try
+		{
+			loadElement();
+			return contributorClass.getNotificationTargets();
+
+		}
+		catch (CoreException e)
+		{
+			IdeLog.logError(PortalUIPlugin.getDefault(), e);
+		}
+		return Collections.emptyList();
+	}
+
+	@Override
+	public void setNotificationTargets(String targets)
+	{
+		try
+		{
+			loadElement();
+			contributorClass.setNotificationTargets(targets);
+		}
+		catch (CoreException e)
+		{
+			IdeLog.logError(PortalUIPlugin.getDefault(), e);
+		}
+
+	}
+
+	private synchronized void loadElement() throws CoreException
+	{
+		if (contributorClass == null)
+		{
+			contributorClass = (AbstractBrowserNotification) element.createExecutableExtension(ATT_CLASS);
+			contributorClass.setNotificationTargets(element.getAttribute(ATT_NOTIFICATION_TARGET));
+		}
+	}
+
+	@Override
+	protected void notifyTargets(String eventId, String eventType, String data)
+	{
+		try
+		{
+			loadElement();
+			contributorClass.notifyTargets(eventId, eventType, data);
+		}
+		catch (CoreException e)
+		{
+			IdeLog.logError(PortalUIPlugin.getDefault(), e);
+		}
+	}
+
+	@Override
+	protected void notifyTargets(String eventId, String eventType, String data, boolean notifyInUIThread)
+	{
+		try
+		{
+			loadElement();
+			contributorClass.notifyTargets(eventId, eventType, data, notifyInUIThread);
+		}
+		catch (CoreException e)
+		{
+			IdeLog.logError(PortalUIPlugin.getDefault(), e);
+		}
+
+	}
+
+	@Override
+	public void stop()
+	{
+		try
+		{
+			loadElement();
+			contributorClass.stop();
+
+		}
+		catch (CoreException e)
+		{
+			IdeLog.logError(PortalUIPlugin.getDefault(), e);
+		}
+	}
+
+}


### PR DESCRIPTION
Implemented Proxy classes for the browserInteractions extension and the contributors are loaded lazily only when the methods are invoked. However, though it defers loading the plugin until certain time, but when the dashboard is opened, it starts samples listener, that causes Samples UI plugin still to be loaded.
