### PR TITLE
TISTUD-5431 Node Package Installer: application npm install location is incorrect

### DIFF
--- a/plugins/com.aptana.js.core/src/com/aptana/js/internal/core/node/Messages.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/internal/core/node/Messages.java
@@ -35,6 +35,7 @@ public class Messages extends NLS
 	public static String NodePackageManager_FailedToDetermineLatestVersion;
 	public static String NodePackageManager_FailedUninstallError;
 	public static String NodePackageManager_InstallingTaskName;
+	public static String NodePackageManager_PasswordPrompt;
 	public static String NodePackageManager_SudoPrompt;
 
 	static

--- a/plugins/com.aptana.js.core/src/com/aptana/js/internal/core/node/NodePackageManager.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/internal/core/node/NodePackageManager.java
@@ -144,6 +144,15 @@ public class NodePackageManager implements INodePackageManager
 				if (npmStatus.isOK())
 				{
 					String prefix = npmStatus.getMessage();
+
+					// If the sudo cache is timed out, then the password prompt and other details might appear in the
+					// console. So we should strip them off to get the real npm prefix value.
+					String passwordPrompt = StringUtil.makeFormLabel(Messages.NodePackageManager_PasswordPrompt);
+					if (prefix.contains(passwordPrompt))
+					{
+						prefix = prefix.substring(prefix.indexOf(passwordPrompt) + passwordPrompt.length());
+					}
+
 					// Set the global prefix path only if it is not the default value.
 					if (!prefixPath.toOSString().equals(prefix))
 					{
@@ -223,8 +232,8 @@ public class NodePackageManager implements INodePackageManager
 	{
 		List<String> sudoArgs = getNpmSudoArgs(global);
 		sudoArgs.addAll(args);
-		return ProcessUtil.run(CollectionsUtil.getFirstElement(sudoArgs), workingDirectory, password, ShellExecutable.getEnvironment(), monitor,
-				CollectionsUtil.toArray(sudoArgs, 1, sudoArgs.size()));
+		return ProcessUtil.run(CollectionsUtil.getFirstElement(sudoArgs), workingDirectory, password,
+				ShellExecutable.getEnvironment(), monitor, CollectionsUtil.toArray(sudoArgs, 1, sudoArgs.size()));
 	}
 
 	/**

--- a/plugins/com.aptana.js.core/src/com/aptana/js/internal/core/node/messages.properties
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/internal/core/node/messages.properties
@@ -21,3 +21,4 @@ NodePackageManager_FailedToDetermineInstalledVersion=Failed to determine install
 NodePackageManager_FailedToDetermineLatestVersion=Failed to determine the latest published version of package ''{0}''
 NodePackageManager_InstallingTaskName=Installing {0}
 NodePackageManager_SudoPrompt=Titanium Studio would like to install {0}.
+NodePackageManager_PasswordPrompt=Password


### PR DESCRIPTION
If the npm config prefix command contains the additional password prompt information, strip it off and get the original path of npm config prefix.
