### PR TITLE
TISTUD-5417 Inconsistent PATH lookup for Node and other components

### DIFF
--- a/plugins/com.aptana.editor.js/src/com/aptana/editor/js/preferences/NodePreferencePage.java
+++ b/plugins/com.aptana.editor.js/src/com/aptana/editor/js/preferences/NodePreferencePage.java
@@ -45,6 +45,7 @@ import com.aptana.core.util.TarUtil;
 import com.aptana.editor.js.JSPlugin;
 import com.aptana.ide.core.io.downloader.DownloadManager;
 import com.aptana.js.core.JSCorePlugin;
+import com.aptana.js.core.node.INodeJS;
 import com.aptana.js.core.node.INodeJSService;
 import com.aptana.js.core.preferences.IPreferenceConstants;
 import com.aptana.ui.util.UIUtils;
@@ -251,14 +252,14 @@ public class NodePreferencePage extends FieldEditorPreferencePage implements IWo
 	{
 		super.initialize();
 
-		IPath path = getDetectedPath();
-		sfe.setStringValue(path == null ? Messages.NodePreferencePage_NotDetected : path.toOSString());
+		INodeJS path = getDetectedPath();
+		sfe.setStringValue(path == null ? Messages.NodePreferencePage_NotDetected : path.getPath().toOSString());
 		sfe.setEnabled(false, fep);
 	}
 
-	private IPath getDetectedPath()
+	private INodeJS getDetectedPath()
 	{
-		return getNodeService().find();
+		return getNodeService().detectInstall();
 	}
 
 	protected INodeJSService getNodeService()

--- a/plugins/com.aptana.js.core/src/com/aptana/js/core/JSCorePlugin.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/core/JSCorePlugin.java
@@ -12,11 +12,11 @@ import org.eclipse.core.runtime.Plugin;
 import org.osgi.framework.BundleContext;
 import org.osgi.util.tracker.ServiceTracker;
 
+import com.aptana.js.core.node.INodeJS;
 import com.aptana.js.core.node.INodeJSService;
 import com.aptana.js.core.node.INodePackageManager;
 import com.aptana.js.internal.core.index.JSMetadataLoader;
 import com.aptana.js.internal.core.node.NodeJSService;
-import com.aptana.js.internal.core.node.NodePackageManager;
 
 /**
  * @author cwilliams
@@ -29,7 +29,6 @@ public class JSCorePlugin extends Plugin
 	private static JSCorePlugin PLUGIN;
 
 	private INodeJSService fNodeService;
-	private INodePackageManager fNpm;
 
 	private ServiceTracker proxyTracker;
 
@@ -69,7 +68,6 @@ public class JSCorePlugin extends Plugin
 		{
 			proxyTracker = null;
 			fNodeService = null;
-			fNpm = null;
 			PLUGIN = null;
 			super.stop(context);
 		}
@@ -84,13 +82,19 @@ public class JSCorePlugin extends Plugin
 		return fNodeService;
 	}
 
-	public synchronized INodePackageManager getNodePackageManager()
+	/**
+	 * Returns the NPM instance tied to the Node instance user has set up (or we detected if they didn't).
+	 * 
+	 * @return
+	 */
+	public INodePackageManager getNodePackageManager()
 	{
-		if (fNpm == null)
+		INodeJS nodeJS = getNodeJSService().getValidExecutable();
+		if (nodeJS == null)
 		{
-			fNpm = new NodePackageManager();
+			return null;
 		}
-		return fNpm;
+		return nodeJS.getNPM();
 	}
 
 	public IProxyService getProxyService()

--- a/plugins/com.aptana.js.core/src/com/aptana/js/core/node/INodeJS.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/core/node/INodeJS.java
@@ -1,0 +1,86 @@
+/**
+ * Aptana Studio
+ * Copyright (c) 2013 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the GNU Public License (GPL) v3 (with exceptions).
+ * Please see the license.html included with this distribution for details.
+ * Any modifications to this file must keep this entire header intact.
+ */
+package com.aptana.js.core.node;
+
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IStatus;
+
+import com.aptana.core.util.ProcessUtil;
+
+/**
+ * This represents an installation of NodeJS. There may be multiple installs on the user's machine. Just because you
+ * have an instance does not guarantee the path exists or that it meets our minimum required version.
+ * 
+ * @author cwilliams
+ */
+public interface INodeJS
+{
+	public static final String MIN_NODE_VERSION = "0.8.13"; //$NON-NLS-1$
+
+	/**
+	 * Error codes returned by {@link #validate()}
+	 */
+	public static final int ERR_DOES_NOT_EXIST = 1;
+	public static final int ERR_NOT_EXECUTABLE = 2;
+	public static final int ERR_INVALID_VERSION = 3;
+
+	/**
+	 * Returns an instance of NPM running under this node install.
+	 * 
+	 * @return
+	 */
+	public INodePackageManager getNPM();
+
+	/**
+	 * Path to the NodeJS installation.
+	 * 
+	 * @return
+	 */
+	public IPath getPath();
+
+	/**
+	 * @return
+	 */
+	public String getVersion();
+
+	/**
+	 * Does the actual binary exist at the path we're pointing to?
+	 * 
+	 * @return
+	 */
+	public boolean exists();
+
+	/**
+	 * Validates this install of NodeJS. Will return OK if the install exists and meets required minimum version.
+	 * 
+	 * @return
+	 */
+	public IStatus validate();
+
+	/**
+	 * Run something under NodeJS. Under the hood calls out to
+	 * {@link ProcessUtil#runInBackground(String, IPath, Map, String...)}
+	 * 
+	 * @param args
+	 * @return
+	 */
+	public IStatus runInBackground(String... args);
+
+	/**
+	 * Run something under NodeJS. Under the hood calls out to
+	 * {@link ProcessUtil#runInBackground(String, IPath, Map, String...)}
+	 * 
+	 * @param env
+	 * @param args
+	 * @return
+	 */
+	public IStatus runInBackground(IPath workingDir, Map<String, String> environment, List<String> args);
+}

--- a/plugins/com.aptana.js.core/src/com/aptana/js/core/node/INodeJSService.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/core/node/INodeJSService.java
@@ -12,10 +12,16 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 
 /**
+ * This is a service that handles installing NodeJS itself, checking if it's installed, detecting existing
+ * installations, Verifying valid executables, listening for installs, etcs.
+ * 
  * @author cwilliams
  */
 public interface INodeJSService
 {
+
+	// FIXME We need to introduce the conecpt of an INodeJSInstall or INodeJSExecutable. User may have multiple versions
+	// installed!
 
 	public static interface Listener
 	{
@@ -26,48 +32,34 @@ public interface INodeJSService
 	public static final String LINUX_DOCS_URL = "http://go.aptana.com/Installing+Node.js"; //$NON-NLS-1$
 	public static final String UPGRADE_URL = "http://go.aptana.com/Upgrading+Node.js"; //$NON-NLS-1$
 
-	public static final String MIN_NODE_VERSION = "0.8.13"; //$NON-NLS-1$
 	public static final String NODE = "node"; //$NON-NLS-1$
 
 	/**
-	 * Error codes returned by {@link #acceptBinary(IPath)}
-	 */
-	public static final int ERR_DOES_NOT_EXIST = 1;
-	public static final int ERR_NOT_EXECUTABLE = 2;
-	public static final int ERR_INVALID_VERSION = 3;
-
-	/**
-	 * Determines if the given path points to a valid nodejs executable (exists, can be run, is in the supported version
-	 * range).
-	 * 
-	 * @param path
-	 * @return {@link IStatus}
-	 */
-	public IStatus acceptBinary(IPath path);
-
-	/**
-	 * Searches PATH find the node executable and return it's {@link IPath}. This is not guaranteed to be a valid
-	 * version. Please check using {@link #acceptBinary(IPath)}
+	 * Searches PATH find the node executable and return it. This is not guaranteed to be a valid version. Please check
+	 * using {@link INodeJS#validate()}. This value should really only be used to display the detected version! Use
+	 * {@link #getValidExecutable()} to get the install to use for commands! May return null if no install detected!
 	 * 
 	 * @return
 	 */
-	public IPath find();
+	public INodeJS detectInstall();
 
 	/**
-	 * Returns the path saved in the user's preferences. This is not guaranteed to be a valid version. Please check
-	 * using {@link #acceptBinary(IPath)}
+	 * Returns the NodeJS install that user set path to in preferences. This is not guaranteed to be a valid version.
+	 * Please check using {@link INodeJS#validate()}. To actually run commands against executable use
+	 * {@link #getValidExecutable()}
 	 * 
 	 * @return
 	 */
-	public IPath getSavedPath();
+	public INodeJS getInstallFromPreferences();
 
 	/**
-	 * Attempts to return the {@link #getSavedPath()} if it passes {@link #acceptBinary(IPath)}. Otherwise, attempts to
-	 * return path from {@link #find()} if that passes {@link #acceptBinary(IPath)}.
+	 * Attempts to return the {@link #getInstallFromPreferences()} if it passes validation. Otherwise, attempts to
+	 * return path from {@link #detectInstall()} if that passes validation. This is what should be used to execute node
+	 * commands.
 	 * 
 	 * @return
 	 */
-	public IPath getValidExecutable();
+	public INodeJS getValidExecutable();
 
 	/**
 	 * Downloads and then installs NodeJS for the user on Windows and Mac.
@@ -90,12 +82,18 @@ public interface INodeJSService
 	 */
 	public IStatus validateSourcePath(IPath path);
 
-	public String getVersion(IPath path);
-
 	/**
 	 * Checks whether NodeJS is already installed on the machine.
 	 * 
 	 * @return true if NodeJS is already available on the machine.
 	 */
 	public boolean isInstalled();
+
+	/**
+	 * Calls {@link INodeJS#validate()} for the path.
+	 * 
+	 * @param fromOSString
+	 * @return
+	 */
+	public IStatus acceptBinary(IPath nodeJSBinary);
 }

--- a/plugins/com.aptana.js.core/src/com/aptana/js/core/node/INodePackageManager.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/core/node/INodePackageManager.java
@@ -93,8 +93,6 @@ public interface INodePackageManager
 
 	public String getLatestVersionAvailable(String packageName) throws CoreException;
 
-	public IPath findNPM();
-
 	public String getConfigValue(String key) throws CoreException;
 
 	/**
@@ -128,11 +126,12 @@ public interface INodePackageManager
 	 * 
 	 * @param monitor
 	 * @return
+	 * @throws CoreException
 	 */
-	public IStatus cleanNpmCache(IProgressMonitor monitor);
+	public IStatus cleanNpmCache(IProgressMonitor monitor) throws CoreException;
 
 	/**
-	 * Uninstalls a npm package.
+	 * Uninstalls an npm package.
 	 * 
 	 * @param packageName
 	 * @param displayName
@@ -142,8 +141,42 @@ public interface INodePackageManager
 	 * @return
 	 * @throws CoreException
 	 */
-	IStatus uninstall(String packageName, String displayName, boolean global, char[] password, IProgressMonitor monitor)
-			throws CoreException;
+	public IStatus uninstall(String packageName, String displayName, boolean global, char[] password,
+			IProgressMonitor monitor) throws CoreException;
+
+	/**
+	 * Does the NPM path/install we're pointing to exist?
+	 * 
+	 * @return
+	 */
+	public boolean exists();
+
+	/**
+	 * The path to the NPM binary script
+	 * 
+	 * @return
+	 */
+	public IPath getPath();
+
+	/**
+	 * return the version of NPM.
+	 * 
+	 * @return
+	 * @throws CoreException
+	 *             if NPM isn't actually installed, or grabbing the version failed.
+	 */
+	public String getVersion() throws CoreException;
+
+	/**
+	 * A way to generically launch commands under NPM. Use sparingly. Ideally we'd have methods to invoke whatever
+	 * command you're hacking by using this.
+	 * 
+	 * @param args
+	 * @return
+	 * @throws CoreException
+	 *             May throw a CoreException to indicate that the NPM path is bad.
+	 */
+	public IStatus runInBackground(String... args) throws CoreException;
 
 	// TODO Update
 }

--- a/plugins/com.aptana.js.core/src/com/aptana/js/internal/core/JSDiagnosticLog.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/internal/core/JSDiagnosticLog.java
@@ -8,13 +8,13 @@
 package com.aptana.js.internal.core;
 
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IStatus;
 
 import com.aptana.core.ShellExecutable;
 import com.aptana.core.diagnostic.IDiagnosticLog;
 import com.aptana.core.util.FileUtil;
-import com.aptana.core.util.ProcessUtil;
 import com.aptana.js.core.JSCorePlugin;
+import com.aptana.js.core.node.INodeJS;
 import com.aptana.js.core.node.INodeJSService;
 import com.aptana.js.core.node.INodePackageManager;
 
@@ -26,66 +26,68 @@ public class JSDiagnosticLog implements IDiagnosticLog
 		StringBuilder buf = new StringBuilder();
 
 		INodeJSService service = JSCorePlugin.getDefault().getNodeJSService();
-		IPath path = service.getValidExecutable();
+		INodeJS nodeJS = service.getValidExecutable();
 
-		String version = service.getVersion(path);
+		String version = nodeJS.getVersion();
 		if (version == null)
 		{
 			version = "Not installed"; //$NON-NLS-1$
 		}
-		buf.append("Node.JS Version: ").append(version).append(FileUtil.NEW_LINE); //$NON-NLS-1$ //$NON-NLS-2$
+		buf.append("Node.JS Version: ").append(version).append(FileUtil.NEW_LINE); //$NON-NLS-1$
 
-		INodePackageManager npm = JSCorePlugin.getDefault().getNodePackageManager();
-		IPath npmPath = npm.findNPM();
+		INodePackageManager npm = nodeJS.getNPM();
 		String pathString = "Not installed"; //$NON-NLS-1$
-		if (npmPath != null)
+		if (npm.exists())
 		{
-			pathString = npmPath.toOSString();
+			pathString = npm.getPath().toOSString();
 		}
-		buf.append("NPM Path: ").append(pathString).append(FileUtil.NEW_LINE); //$NON-NLS-1$ //$NON-NLS-2$
-		if (npmPath != null)
+		buf.append("NPM Path: ").append(pathString).append(FileUtil.NEW_LINE); //$NON-NLS-1$
+		if (npm.exists())
 		{
-			String npmVersion = ProcessUtil.outputForCommand(npmPath.toOSString(), null,
-					ShellExecutable.getEnvironment(), "-v"); //$NON-NLS-1$
-			buf.append("NPM Version: ").append(npmVersion).append(FileUtil.NEW_LINE); //$NON-NLS-1$
-
-			String highLevelPackages = getInstalledNpmPackages(npmPath);
-			buf.append(highLevelPackages);
-			buf.append(FileUtil.NEW_LINE);
-
-			// Step1 : Get the installed version of a npm package - try to get titanium
-			String npmVersionOutput = ProcessUtil.outputForCommand(npmPath.toOSString(), null,
-					ShellExecutable.getEnvironment(), INodePackageManager.GLOBAL_ARG, "ls", "titanium"); //$NON-NLS-1$ //$NON-NLS-2$
-			buf.append("npm -g ls titanium: ").append(npmVersionOutput).append(FileUtil.NEW_LINE); //$NON-NLS-1$ //$NON-NLS-2$
-
-			// Step2: If Step1 fails for any reason, find the installed version of a package from the detailed list of
-			// all npm packages.
-			// The original command (npm -g ls -p) is slightly different than this one, but the content and intent is
-			// the same.
-			String listOutput = ProcessUtil.outputForCommand(npmPath.toOSString(), null,
-					ShellExecutable.getEnvironment(), INodePackageManager.GLOBAL_ARG, "list"); //$NON-NLS-1$
-			buf.append("Packages: ").append(listOutput).append(FileUtil.NEW_LINE); //$NON-NLS-1$ //$NON-NLS-2$
-
-			// NPM config prefix values.
-			buf.append("NPM_CONFIG_PREFIX env value: " + ShellExecutable.getEnvironment().get("NPM_CONFIG_PREFIX")) //$NON-NLS-1$ //$NON-NLS-2$
-					.append(FileUtil.NEW_LINE);
 			try
 			{
+				String npmVersion = npm.getVersion();
+				buf.append("NPM Version: ").append(npmVersion).append(FileUtil.NEW_LINE); //$NON-NLS-1$
+
+				String highLevelPackages = getInstalledNpmPackages(npm);
+				buf.append(highLevelPackages);
+				buf.append(FileUtil.NEW_LINE);
+
+				// Step1 : Get the installed version of a npm package - try to get titanium
+				IStatus titaniumStatus = npm.runInBackground(INodePackageManager.GLOBAL_ARG, "ls", "titanium"); //$NON-NLS-1$ //$NON-NLS-2$
+				String npmVersionOutput = titaniumStatus.getMessage();
+				buf.append("npm -g ls titanium: ").append(npmVersionOutput).append(FileUtil.NEW_LINE); //$NON-NLS-1$
+
+				// Step2: If Step1 fails for any reason, find the installed version of a package from the detailed list
+				// of
+				// all npm packages.
+				// The original command (npm -g ls -p) is slightly different than this one, but the content and intent
+				// is
+				// the same.
+				IStatus listStatus = npm.runInBackground(INodePackageManager.GLOBAL_ARG, "list"); //$NON-NLS-1$
+				String listOutput = listStatus.getMessage();
+				buf.append("Packages: ").append(listOutput).append(FileUtil.NEW_LINE); //$NON-NLS-1$
+
+				// NPM config prefix values.
+				buf.append("NPM_CONFIG_PREFIX env value: " + ShellExecutable.getEnvironment().get("NPM_CONFIG_PREFIX")) //$NON-NLS-1$ //$NON-NLS-2$
+						.append(FileUtil.NEW_LINE);
+
 				String configPrefixValue = JSCorePlugin.getDefault().getNodePackageManager().getConfigValue("prefix"); //$NON-NLS-1$
 				buf.append("Npm config prefix value : ").append(configPrefixValue).append(FileUtil.NEW_LINE); //$NON-NLS-1$
 			}
 			catch (CoreException ignore)
 			{
+				// Shouldn't happen so long as we guarded to enforce NPM exists.
 			}
 
 		}
 		return buf.toString();
 	}
 
-	private String getInstalledNpmPackages(IPath npmPath)
+	private String getInstalledNpmPackages(INodePackageManager npm) throws CoreException
 	{
-		String listOutput = ProcessUtil.outputForCommand(npmPath.toOSString(), null, ShellExecutable.getEnvironment(),
-				INodePackageManager.GLOBAL_ARG, "list", "--depth=0"); //$NON-NLS-1$ //$NON-NLS-2$
+		IStatus status = npm.runInBackground(INodePackageManager.GLOBAL_ARG, "list", "--depth=0"); //$NON-NLS-1$ //$NON-NLS-2$
+		String listOutput = status.getMessage();
 
 		// Hack : An issue in npm list command show errors or warnings because of depth option. Filter them out of the
 		// output.

--- a/plugins/com.aptana.js.core/src/com/aptana/js/internal/core/build/NodeJSSourceContributor.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/internal/core/build/NodeJSSourceContributor.java
@@ -34,7 +34,7 @@ public class NodeJSSourceContributor implements IBuildPathContributor
 
 		// Add paths for NPM packages
 		INodePackageManager npm = getNodePackageManager();
-		if (npm != null && npm.findNPM() != null)
+		if (npm != null && npm.exists())
 		{
 			try
 			{

--- a/plugins/com.aptana.js.core/src/com/aptana/js/internal/core/node/NodeJS.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/internal/core/node/NodeJS.java
@@ -1,0 +1,109 @@
+/**
+ * Aptana Studio
+ * Copyright (c) 2013 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the GNU Public License (GPL) v3 (with exceptions).
+ * Please see the license.html included with this distribution for details.
+ * Any modifications to this file must keep this entire header intact.
+ */
+package com.aptana.js.internal.core.node;
+
+import java.text.MessageFormat;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+
+import com.aptana.core.ShellExecutable;
+import com.aptana.core.util.ProcessUtil;
+import com.aptana.core.util.VersionUtil;
+import com.aptana.js.core.JSCorePlugin;
+import com.aptana.js.core.node.INodeJS;
+import com.aptana.js.core.node.INodePackageManager;
+
+/**
+ * @author cwilliams
+ */
+public class NodeJS implements INodeJS
+{
+
+	private final IPath path;
+
+	NodeJS(IPath path)
+	{
+		// TODO Enforce non-null?
+		this.path = path;
+	}
+
+	public INodePackageManager getNPM()
+	{
+		return new NodePackageManager(this);
+	}
+
+	public IPath getPath()
+	{
+		return path;
+	}
+
+	public String getVersion()
+	{
+		if (path == null)
+		{
+			return null;
+		}
+		return ProcessUtil.outputForCommand(path.toOSString(), null, "-v"); //$NON-NLS-1$
+	}
+
+	public boolean exists()
+	{
+		return path != null && path.toFile().isFile();
+	}
+
+	public IStatus runInBackground(String... args)
+	{
+		return ProcessUtil.runInBackground(getPath().toOSString(), null, ShellExecutable.getEnvironment(), args);
+	}
+
+	public IStatus runInBackground(IPath workingDir, Map<String, String> environment, List<String> args)
+	{
+		return ProcessUtil.runInBackground(getPath().toOSString(), workingDir, environment,
+				args.toArray(new String[args.size()]));
+	}
+
+	public IStatus validate()
+	{
+		if (path == null)
+		{
+			return new Status(Status.ERROR, JSCorePlugin.PLUGIN_ID, Messages.NodeJSService_NullPathError);
+		}
+
+		if (!exists())
+		{
+			return new Status(Status.ERROR, JSCorePlugin.PLUGIN_ID, ERR_DOES_NOT_EXIST, MessageFormat.format(
+					Messages.NodeJSService_FileDoesntExistError, path), null);
+		}
+
+		String version = getVersion();
+		if (version == null)
+		{
+			return new Status(Status.ERROR, JSCorePlugin.PLUGIN_ID, ERR_NOT_EXECUTABLE, MessageFormat.format(
+					Messages.NodeJSService_CouldntGetVersionError, path), null);
+		}
+
+		int index = version.indexOf('v');
+		if (index != -1)
+		{
+			version = version.substring(index + 1); // eliminate 'v'
+		}
+
+		if (VersionUtil.compareVersions(version, MIN_NODE_VERSION) >= 0)
+		{
+			return Status.OK_STATUS;
+		}
+
+		return new Status(Status.ERROR, JSCorePlugin.PLUGIN_ID, ERR_INVALID_VERSION, MessageFormat.format(
+				Messages.NodeJSService_InvalidVersionError, path, version, MIN_NODE_VERSION), null);
+	}
+
+}

--- a/plugins/com.aptana.js.core/src/com/aptana/js/internal/core/node/NodePackageManager.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/internal/core/node/NodePackageManager.java
@@ -44,6 +44,7 @@ import com.aptana.core.util.ProcessStatus;
 import com.aptana.core.util.ProcessUtil;
 import com.aptana.core.util.StringUtil;
 import com.aptana.js.core.JSCorePlugin;
+import com.aptana.js.core.node.INodeJS;
 import com.aptana.js.core.node.INodePackageManager;
 
 /**
@@ -83,16 +84,6 @@ public class NodePackageManager implements INodePackageManager
 	private static final Pattern VERSION_PATTERN = Pattern.compile("([0-9]+\\.[0-9]+\\.[0-9]+)"); //$NON-NLS-1$
 
 	/**
-	 * Common install location for Windows
-	 */
-	private static final String APPDATA_NPM = "%APPDATA%\\npm"; //$NON-NLS-1$
-
-	/**
-	 * Coommon install location for Mac/Linux
-	 */
-	private static final String USR_LOCAL_BIN_NPM = "/usr/local/bin/npm"; //$NON-NLS-1$
-
-	/**
 	 * Binary script name.
 	 */
 	private static final String NPM = "npm"; //$NON-NLS-1$
@@ -106,12 +97,61 @@ public class NodePackageManager implements INodePackageManager
 	private static final String CONFIG = "config"; //$NON-NLS-1$
 	private static final String GET = "get"; //$NON-NLS-1$
 
-	private IPath npmPath;
-
 	/**
 	 * Cached value for NPM's "prefix" config value (where modules get installed).
 	 */
 	private IPath fConfigPrefixPath;
+
+	/**
+	 * The installation of Node we're tied to.
+	 */
+	private final INodeJS nodeJS;
+
+	/**
+	 * Where the NPM binary script should live.
+	 */
+	private final IPath npmPath;
+
+	public NodePackageManager(INodeJS nodeJS)
+	{
+		this.nodeJS = nodeJS;
+
+		// TODO Is there any way a user can install NPM in non-standard location relative to node?
+
+		// Windows "npm" script is a sh script that tries to execute $basedir/node_modules/npm/bin/npm-cli.js under
+		// "$basedir/node.exe" if it exists.
+		// So for Windows, it would appear we'd need to run:
+		// /path/to/node.exe /path/to/node/node_modules/npm/bin/npm-cli.js <args>
+		if (PlatformUtil.isWindows())
+		{
+			npmPath = nodeJS.getPath().removeLastSegments(1).append(NODE_MODULES).append(NPM).append(BIN)
+					.append("npm-cli.js"); //$NON-NLS-1$
+		}
+		else
+		{
+			// For Mac/Linux, we just need to run:
+			// /path/to/node /path/to/npm <args>
+			npmPath = nodeJS.getPath().removeLastSegments(1).append(NPM);
+		}
+	}
+
+	/**
+	 * A method that grabs the path to the NPM script to run under node. If the file doesn't exist we throw a
+	 * CoreException.
+	 * 
+	 * @return
+	 * @throws CoreException
+	 */
+	private IPath checkedNPMPath() throws CoreException
+	{
+		if (exists())
+		{
+			return npmPath;
+		}
+
+		throw new CoreException(new Status(IStatus.ERROR, JSCorePlugin.PLUGIN_ID,
+				Messages.NodePackageManager_ERR_NPMNotInstalled));
+	}
 
 	/*
 	 * (non-Javadoc)
@@ -215,25 +255,33 @@ public class NodePackageManager implements INodePackageManager
 			// Set the global npm prefix path to its original value.
 			if (!StringUtil.isEmpty(globalPrefixPath))
 			{
-				setGlobalPrefixPath(password, workingDirectory, monitor, globalPrefixPath);
+				try
+				{
+					setGlobalPrefixPath(password, workingDirectory, monitor, globalPrefixPath);
+				}
+				catch (CoreException e)
+				{
+					return e.getStatus();
+				}
 			}
 		}
 	}
 
 	private IStatus setGlobalPrefixPath(char[] password, IPath workingDirectory, IProgressMonitor monitor,
-			String globalPrefixPath)
+			String globalPrefixPath) throws CoreException
 	{
 		List<String> args = CollectionsUtil.newList(CONFIG, "set", PREFIX, globalPrefixPath); //$NON-NLS-1$
 		return runNpmConfig(args, password, true, workingDirectory, monitor);
 	}
 
 	private IStatus runNpmConfig(List<String> args, char[] password, boolean global, IPath workingDirectory,
-			IProgressMonitor monitor)
+			IProgressMonitor monitor) throws CoreException
 	{
 		List<String> sudoArgs = getNpmSudoArgs(global);
 		sudoArgs.addAll(args);
 		return ProcessUtil.run(CollectionsUtil.getFirstElement(sudoArgs), workingDirectory, password,
-				ShellExecutable.getEnvironment(), monitor, CollectionsUtil.toArray(sudoArgs, 1, sudoArgs.size()));
+				ShellExecutable.getEnvironment(workingDirectory), monitor,
+				CollectionsUtil.toArray(sudoArgs, 1, sudoArgs.size()));
 	}
 
 	/**
@@ -297,52 +345,18 @@ public class NodePackageManager implements INodePackageManager
 		return builder.toString();
 	}
 
-	public IPath findNPM()
-	{
-		if (npmPath == null)
-		{
-			List<IPath> commonLocations;
-			if (PlatformUtil.isWindows())
-			{
-				commonLocations = CollectionsUtil.newList(Path.fromOSString(PlatformUtil
-						.expandEnvironmentStrings(APPDATA_NPM)));
-				IPath nodePath = JSCorePlugin.getDefault().getNodeJSService().getValidExecutable();
-				if (nodePath != null)
-				{
-					nodePath = nodePath.removeLastSegments(1);// Remove file extension.
-					commonLocations.add(nodePath);
-					ShellExecutable.updatePathEnvironment(PlatformUtil.expandEnvironmentStrings(APPDATA_NPM));
-				}
-			}
-			else
-			{
-				commonLocations = CollectionsUtil.newList(Path.fromOSString(USR_LOCAL_BIN_NPM));
-			}
-			IPath path = ExecutableUtil.find(NPM, true, commonLocations);
-			if (path != null && path.toFile().exists())
-			{
-				npmPath = path;
-			}
-		}
-		return npmPath;
-	}
-
 	public Set<String> list(boolean global) throws CoreException
 	{
-		IPath npmPath = findNPM();
-		if (npmPath == null)
-		{
-			throw new CoreException(new Status(IStatus.ERROR, JSCorePlugin.PLUGIN_ID,
-					Messages.NodePackageManager_ERR_NPMNotInstalled));
-		}
-		List<String> args = CollectionsUtil.newList(PARSEABLE_ARG, LIST);
+		IStatus status;
 		if (global)
 		{
-			args.add(0, GLOBAL_ARG);
+			status = runInBackground(GLOBAL_ARG, PARSEABLE_ARG, LIST);
+		}
+		else
+		{
+			status = runInBackground(PARSEABLE_ARG, LIST);
 		}
 
-		IStatus status = ProcessUtil.runInBackground(npmPath.toOSString(), null, ShellExecutable.getEnvironment(),
-				args.toArray(new String[args.size()]));
 		if (!status.isOK())
 		{
 			throw new CoreException(new Status(IStatus.ERROR, JSCorePlugin.PLUGIN_ID,
@@ -407,14 +421,7 @@ public class NodePackageManager implements INodePackageManager
 
 	public IPath getModulesPath(String packageName) throws CoreException
 	{
-		IPath npmPath = findNPM();
-		if (npmPath == null)
-		{
-			throw new CoreException(new Status(IStatus.ERROR, JSCorePlugin.PLUGIN_ID,
-					Messages.NodePackageManager_ERR_NPMNotInstalled));
-		}
-		IStatus status = ProcessUtil.runInBackground(npmPath.toOSString(), null, ShellExecutable.getEnvironment(),
-				PARSEABLE_ARG, LIST, packageName, GLOBAL_ARG);
+		IStatus status = runInBackground(PARSEABLE_ARG, LIST, packageName, GLOBAL_ARG);
 		if (!status.isOK())
 		{
 			throw new CoreException(new Status(IStatus.ERROR, JSCorePlugin.PLUGIN_ID, MessageFormat.format(
@@ -432,19 +439,13 @@ public class NodePackageManager implements INodePackageManager
 
 	public String getInstalledVersion(String packageName, boolean global, IPath workingDir) throws CoreException
 	{
-		IPath npmPath = findNPM();
-		if (npmPath == null)
-		{
-			throw new CoreException(new Status(IStatus.ERROR, JSCorePlugin.PLUGIN_ID,
-					Messages.NodePackageManager_ERR_NPMNotInstalled));
-		}
-		List<String> args = CollectionsUtil.newList("ls", packageName, COLOR, FALSE); //$NON-NLS-1$
+		IPath npmPath = checkedNPMPath();
+		List<String> args = CollectionsUtil.newList(npmPath.toOSString(), "ls", packageName, COLOR, FALSE); //$NON-NLS-1$
 		if (global)
 		{
 			args.add(GLOBAL_ARG);
 		}
-		IStatus status = ProcessUtil.runInBackground(npmPath.toOSString(), workingDir,
-				ShellExecutable.getEnvironment(), args.toArray(new String[args.size()]));
+		IStatus status = nodeJS.runInBackground(workingDir, ShellExecutable.getEnvironment(), args);
 		if (!status.isOK())
 		{
 			throw new CoreException(new Status(IStatus.ERROR, JSCorePlugin.PLUGIN_ID, MessageFormat.format(
@@ -469,18 +470,13 @@ public class NodePackageManager implements INodePackageManager
 	{
 		// get the latest version
 		// npm view titanium version
-		IPath npmPath = findNPM();
-		if (npmPath == null)
-		{
-			throw new CoreException(new Status(IStatus.ERROR, JSCorePlugin.PLUGIN_ID,
-					Messages.NodePackageManager_ERR_NPMNotInstalled));
-		}
+		IPath npmPath = checkedNPMPath();
+
 		Map<String, String> env = ShellExecutable.getEnvironment();
-		List<String> args = CollectionsUtil.newList("view", packageName, "version");//$NON-NLS-1$ //$NON-NLS-2$
+		List<String> args = CollectionsUtil.newList(npmPath.toOSString(), "view", packageName, "version");//$NON-NLS-1$ //$NON-NLS-2$
 		args.addAll(proxySettings(env));
 
-		IStatus status = ProcessUtil.runInBackground(npmPath.toOSString(), null, env,
-				args.toArray(new String[args.size()]));
+		IStatus status = nodeJS.runInBackground(null, env, args);
 		if (!status.isOK())
 		{
 			throw new CoreException(new Status(IStatus.ERROR, JSCorePlugin.PLUGIN_ID, MessageFormat.format(
@@ -498,14 +494,7 @@ public class NodePackageManager implements INodePackageManager
 	public String getConfigValue(String key) throws CoreException
 	{
 		// npm config get <key>
-		IPath npmPath = findNPM();
-		if (npmPath == null)
-		{
-			throw new CoreException(new Status(IStatus.ERROR, JSCorePlugin.PLUGIN_ID,
-					Messages.NodePackageManager_ERR_NPMNotInstalled));
-		}
-		IStatus status = ProcessUtil.runInBackground(npmPath.toOSString(), null, ShellExecutable.getEnvironment(),
-				CONFIG, GET, key); //$NON-NLS-1$ //$NON-NLS-2$
+		IStatus status = runInBackground(CONFIG, GET, key);
 		if (!status.isOK())
 		{
 			throw new CoreException(new Status(IStatus.ERROR, JSCorePlugin.PLUGIN_ID, MessageFormat.format(
@@ -520,12 +509,6 @@ public class NodePackageManager implements INodePackageManager
 	{
 		SubMonitor sub = SubMonitor.convert(monitor,
 				MessageFormat.format(Messages.NodePackageManager_InstallingTaskName, displayName), 100);
-		IPath npmPath = findNPM();
-		if (npmPath == null)
-		{
-			throw new CoreException(new Status(IStatus.ERROR, JSCorePlugin.PLUGIN_ID,
-					Messages.NodePackageManager_ERR_NPMNotInstalled));
-		}
 		try
 		{
 			List<String> args = getNpmSudoArgs(global);
@@ -583,8 +566,9 @@ public class NodePackageManager implements INodePackageManager
 		}
 	}
 
-	private List<String> getNpmSudoArgs(boolean global)
+	private List<String> getNpmSudoArgs(boolean global) throws CoreException
 	{
+		IPath npmPath = checkedNPMPath();
 		List<String> args = new ArrayList<String>(8);
 		if (global)
 		{
@@ -594,11 +578,13 @@ public class NodePackageManager implements INodePackageManager
 				args.add("-S"); //$NON-NLS-1$
 				args.add("--"); //$NON-NLS-1$
 			}
+			args.add(nodeJS.getPath().toOSString());
 			args.add(npmPath.toOSString());
 			args.add(GLOBAL_ARG);
 		}
 		else
 		{
+			args.add(nodeJS.getPath().toOSString());
 			args.add(npmPath.toOSString());
 		}
 		return args;
@@ -685,8 +671,35 @@ public class NodePackageManager implements INodePackageManager
 		return fConfigPrefixPath;
 	}
 
-	public IStatus cleanNpmCache(IProgressMonitor monitor)
+	public IStatus cleanNpmCache(IProgressMonitor monitor) throws CoreException
 	{
-		return ProcessUtil.runInBackground(NPM, null, "cache", "clean"); //$NON-NLS-1$ //$NON-NLS-2$
+		return runInBackground("cache", "clean"); //$NON-NLS-1$ //$NON-NLS-2$
+	}
+
+	public String getVersion() throws CoreException
+	{
+		IStatus status = runInBackground("-v"); //$NON-NLS-1$
+		if (!status.isOK())
+		{
+			throw new CoreException(status);
+		}
+		return status.getMessage();
+	}
+
+	public boolean exists()
+	{
+		return npmPath.toFile().isFile();
+	}
+
+	public IPath getPath()
+	{
+		return npmPath;
+	}
+
+	public IStatus runInBackground(String... args) throws CoreException
+	{
+		List<String> newArgs = CollectionsUtil.newList(args);
+		newArgs.add(0, checkedNPMPath().toOSString());
+		return nodeJS.runInBackground(null, null, newArgs);
 	}
 }


### PR DESCRIPTION
TISTUD-5417 Inconsistent PATH lookup for Node and other components
- Refactor so INodePackageManager is tied to an INodeJS installation and we explicitly execute npm commands underneath that node install
- Break out an INodeJS interface and impl to represent a NodeJS install, ove some functionality from INodeJSService there.
- Renamed some INodeJSService methods to make more explicit what they return.
- Update callers to use new API
