### PR TITLE
TISTUD-5434 Avoid installing npm packages globally

### DIFF
--- a/plugins/com.aptana.js.core/src/com/aptana/js/core/node/INodePackageManager.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/core/node/INodePackageManager.java
@@ -7,6 +7,8 @@
  */
 package com.aptana.js.core.node;
 
+import java.io.FileFilter;
+import java.util.List;
 import java.util.Set;
 
 import org.eclipse.core.runtime.CoreException;
@@ -177,6 +179,18 @@ public interface INodePackageManager
 	 *             May throw a CoreException to indicate that the NPM path is bad.
 	 */
 	public IStatus runInBackground(String... args) throws CoreException;
+
+	/**
+	 * Search for the npm package installed locally based on the search locations.
+	 * 
+	 * @param executableName
+	 * @param appendExtension
+	 * @param searchLocations
+	 * @param fileFilter
+	 * @return
+	 */
+	public IPath findNpmPackagePath(String executableName, boolean appendExtension, List<IPath> searchLocations,
+			FileFilter fileFilter);
 
 	// TODO Update
 }


### PR DESCRIPTION
- Installs npm packages locally without global flag.
- On Mac : If the npm install itself is moved to .titanium folder, then it fails to query the package installation versions. However, if npm is installed to /usr/local, then it can install the npm packages to local directory such as '/Users/<user_name>/.titanium'. Since the npm package installs has to be access for all Studio installations and they have to persist across Studio re-installation, the location is chosen to be ('/Users/<user_name>/.titanium') 
- On Windows : Whatever is the current working directory, local npm packages are always installed under C:\Users<user>. Though we are under in a different local directory, it queries and installs from the user home directory. Well, since the local npm packages manages are known to node all the time, it works well with querying the version and the installation.
