### PR TITLE
TISTUD-5504 Disable the Studio updates from the Eclipse update popup

### DIFF
--- a/features/com.aptana.feature/feature.xml
+++ b/features/com.aptana.feature/feature.xml
@@ -562,6 +562,13 @@
          unpack="false"/>
 
    <plugin
+         id="org.eclipse.equinox.p2.director"
+         download-size="0"
+         install-size="0"
+         version="2.4.0.v20130526-0335"
+         unpack="false"/>
+
+   <plugin
          id="com.aptana.buildpath.core"
          download-size="0"
          install-size="0"

--- a/plugins/org.eclipse.equinox.p2.director/.api_description
+++ b/plugins/org.eclipse.equinox.p2.director/.api_description
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<component name="org.eclipse.equinox.p2.director_2.3.0.v20130526-0335" version="1.2">
+    <plugin id="org.eclipse.equinox.p2.director_2.3.0.v20130526-0335"/>
+    <package name="org.eclipse.equinox.p2.planner" visibility="1">
+        <type name="IPlanner" restrictions="3">
+            <method name="updatesFor" restrictions="8" signature="(Lorg/eclipse/equinox/p2/metadata/IInstallableUnit;Lorg/eclipse/equinox/p2/engine/ProvisioningContext;Lorg/eclipse/core/runtime/IProgressMonitor;)Lorg/eclipse/equinox/p2/query/IQueryResult;"/>
+        </type>
+        <type name="IProfileChangeRequest" restrictions="3"/>
+        <type name="ProfileInclusionRules" restrictions="6"/>
+    </package>
+</component>

--- a/plugins/org.eclipse.equinox.p2.director/.classpath
+++ b/plugins/org.eclipse.equinox.p2.director/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src/"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/plugins/org.eclipse.equinox.p2.director/.project
+++ b/plugins/org.eclipse.equinox.p2.director/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.equinox.p2.director</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/plugins/org.eclipse.equinox.p2.director/.settings/org.eclipse.jdt.core.prefs
+++ b/plugins/org.eclipse.equinox.p2.director/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,7 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.5
+org.eclipse.jdt.core.compiler.compliance=1.5
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.5

--- a/plugins/org.eclipse.equinox.p2.director/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.equinox.p2.director/META-INF/MANIFEST.MF
@@ -1,0 +1,205 @@
+Manifest-Version: 1.0
+Bundle-Localization: plugin
+Service-Component: OSGI-INF/director.xml, OSGI-INF/planner.xml
+Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Built-By: e4Build
+Bundle-SymbolicName: org.eclipse.equinox.p2.director;singleton:=true
+Eclipse-SourceReferences: scm:git:git://git.eclipse.org/gitroot/equino
+ x/rt.equinox.p2.git;path="bundles/org.eclipse.equinox.p2.director";ta
+ g="I20130526-0051";commitId=fc958e5370b322d44ad3a807091617cf7d73545b
+Bundle-Activator: org.eclipse.equinox.internal.p2.director.DirectorAct
+ ivator
+Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.3.0,4.0.
+ 0)",org.eclipse.core.jobs;bundle-version="[3.3.0,4.0.0)",org.eclipse.
+ equinox.p2.metadata;bundle-version="[2.0.0,3.0.0)",org.sat4j.core;bun
+ dle-version="[2.3.5,3.0.0)",org.sat4j.pb;bundle-version="[2.3.5,3.0.0
+ )"
+Bundle-Version: 2.3.0.v20130526-0335
+Export-Package: org.eclipse.equinox.internal.p2.director; x-friends:="
+ org.eclipse.equinox.p2.operations,  org.eclipse.equinox.p2.repository
+ .tools,  org.eclipse.pde.core,  org.eclipse.equinox.p2.reconciler.dro
+ pins,  org.eclipse.equinox.p2.ui,  org.eclipse.equinox.p2.director.ap
+ p",org.eclipse.equinox.internal.p2.rollback;x-internal:=true,org.ecli
+ pse.equinox.internal.provisional.p2.director; x-friends:="org.eclipse
+ .equinox.p2.console,  org.eclipse.equinox.p2.director.app,  org.eclip
+ se.equinox.p2.operations,  org.eclipse.equinox.p2.ui.admin,  org.ecli
+ pse.equinox.p2.installer",org.eclipse.equinox.p2.planner;version="2.0
+ .0"
+Build-Jdk: 1.7.0_11
+Bundle-ClassPath: .
+Bundle-ActivationPolicy: lazy
+Bundle-Vendor: %providerName
+Bundle-Name: %pluginName
+Archiver-Version: Plexus Archiver
+Created-By: Apache Maven
+Import-Package: org.eclipse.equinox.internal.p2.core.helpers,org.eclip
+ se.equinox.internal.provisional.configurator,org.eclipse.equinox.p2.c
+ ore;version="[2.0.0,3.0.0)",org.eclipse.equinox.p2.core.spi;version="
+ [2.0.0,3.0.0)",org.eclipse.equinox.p2.engine;version="[2.0.0,3.0.0)",
+ org.eclipse.equinox.p2.engine.query;version="[2.0.0,3.0.0)",org.eclip
+ se.osgi.util;version="1.0.0",org.osgi.framework;version="1.3.0"
+Bundle-ManifestVersion: 2
+
+Name: org/eclipse/equinox/internal/p2/rollback/FormerState.class
+SHA1-Digest: S1WAKihq2kiGNnqR9n39ZGkoOv8=
+
+Name: org/eclipse/equinox/internal/p2/director/SimpleDirector.class
+SHA1-Digest: 6zlqowfRXMvw8Vhdw7ga6PphEjA=
+
+Name: org/eclipse/equinox/internal/p2/director/ApplicablePatchQuery.cl
+ ass
+SHA1-Digest: V5C8i3dauz8q5oH686xzYItdkaw=
+
+Name: org/eclipse/equinox/internal/p2/director/PermissiveSlicer.class
+SHA1-Digest: hu73mvkFdNa86cKEQ6nCoR6vSk8=
+
+Name: org/eclipse/equinox/internal/p2/director/Slicer.class
+SHA1-Digest: A4BPw+DmgOocTTVpiHJp9pquBnY=
+
+Name: org/eclipse/equinox/internal/p2/director/InfiniteProgress.class
+SHA1-Digest: REQ+kcvaG6NoSnF69xw46LYA3aQ=
+
+Name: org/eclipse/equinox/internal/p2/director/Projector.class
+SHA1-Digest: c0AoBUFEr1REhpZbzR05tIgW9yU=
+
+Name: org/eclipse/equinox/p2/planner/IProfileChangeRequest.class
+SHA1-Digest: hsyseSBlTcY63h+Gk1lsQNqxueA=
+
+Name: org/eclipse/equinox/internal/p2/director/OptimizationFunction.cl
+ ass
+SHA1-Digest: oXama2xs0q++Rq5k/+MZuVCBk9w=
+
+Name: org/eclipse/equinox/internal/p2/director/SimplePlanner.class
+SHA1-Digest: 6cCIzllpW/GL6AbaqdE5r9YjyQo=
+
+Name: plugin.properties
+SHA1-Digest: L1t8uCWmBiRKoxVUC+iFblpx824=
+
+Name: org/eclipse/equinox/internal/p2/director/UserDefinedOptimization
+ Function$FakeExplanation.class
+SHA1-Digest: NLFchKGATzeEnn1UfglmTsF0DVE=
+
+Name: org/eclipse/equinox/internal/p2/director/UserDefinedOptimization
+ Function.class
+SHA1-Digest: DERtwlwRhYX4PzfgozC4xyP4EVI=
+
+Name: org/eclipse/equinox/internal/provisional/p2/director/IDirector.c
+ lass
+SHA1-Digest: wiGD5QoU4jANYXLXzxqKeknFtpU=
+
+Name: org/eclipse/equinox/internal/p2/director/Projector$ExplanationJo
+ b.class
+SHA1-Digest: AOqpBEYbBzpU9FUuUpIkZwcCiDs=
+
+Name: org/eclipse/equinox/internal/p2/director/OperationGenerator.clas
+ s
+SHA1-Digest: JKNLLZsQqpWjART2JQ0jzGOwXCk=
+
+Name: org/eclipse/equinox/internal/p2/director/Explanation$IUToInstall
+ .class
+SHA1-Digest: BN8MtdkurzToxPibwcgdMWZK4MA=
+
+Name: org/eclipse/equinox/internal/p2/director/Explanation$NotInstalla
+ bleRoot.class
+SHA1-Digest: UvSm3ERNDBc4fb809UtOeEKUWJk=
+
+Name: org/eclipse/equinox/internal/p2/director/AttachmentHelper.class
+SHA1-Digest: Zn5SN4O7YmylzkdnLzLz2ydbG6g=
+
+Name: org/eclipse/equinox/internal/p2/director/Projector$Pending.class
+SHA1-Digest: 8cds6qTJH1mj4lIzqyeYA8xqxGM=
+
+Name: org/eclipse/equinox/internal/p2/director/DirectorComponent.class
+SHA1-Digest: m3fZ4+qbnX9ZBJ3GT3PEOeg7mkM=
+
+Name: org/eclipse/equinox/internal/provisional/p2/director/RequestStat
+ us.class
+SHA1-Digest: T4pCAnH3aHxGTSdxzWzN6Y0vOcU=
+
+Name: org/eclipse/equinox/internal/provisional/p2/director/PlannerStat
+ us.class
+SHA1-Digest: TpLamNIqrOV1TcSsg9Vh71XNlAo=
+
+Name: org/eclipse/equinox/internal/p2/director/Explanation$PatchedHard
+ Requirement.class
+SHA1-Digest: ZXTnDxyDFkT32SrOw2Bjjxzl6+0=
+
+Name: OSGI-INF/planner.xml
+SHA1-Digest: mULn1V2dhBZNG2WSGEvaLQ2zZ3c=
+
+Name: org/eclipse/equinox/internal/p2/director/Explanation.class
+SHA1-Digest: WUddgNNleTWAOsDT4Yn3i3XNmJ4=
+
+Name: .api_description
+SHA1-Digest: 3yG9kf7JiFQS8Yl5/5QQD8ai3yw=
+
+Name: OSGI-INF/director.xml
+SHA1-Digest: lzc+OGdyMFYroQ0Rrb7XN8f9AQU=
+
+Name: about.html
+SHA1-Digest: ejOZra0kypGLQQ2bJtGTX+LI8tU=
+
+Name: org/eclipse/equinox/internal/p2/director/Projector$AbstractVaria
+ ble.class
+SHA1-Digest: S44Ar3iRf/5DPMm5LykgDAkqxPU=
+
+Name: org/eclipse/equinox/internal/p2/director/Explanation$Singleton.c
+ lass
+SHA1-Digest: krZP9b4wWwiCMut4B1u2fTLfUh8=
+
+Name: org/eclipse/equinox/internal/provisional/p2/director/PlannerStat
+ us$1.class
+SHA1-Digest: No66IGnrWIlzbHmBXqrkBRkT3Yg=
+
+Name: org/eclipse/equinox/p2/planner/ProfileInclusionRules.class
+SHA1-Digest: HJo3LHVhIco50RZqaTw4DkOh3cE=
+
+Name: org/eclipse/equinox/internal/p2/director/Explanation$IUInstalled
+ .class
+SHA1-Digest: f5lwXwD2nm7IywHD/duL3cqoRlE=
+
+Name: org/eclipse/equinox/internal/p2/director/PlannerComponent.class
+SHA1-Digest: zGU0dN2Kh6DIqBwSg6h5S6w9Ubk=
+
+Name: org/eclipse/equinox/p2/planner/IPlanner.class
+SHA1-Digest: a+LqFJhcDemBv9ebj2PKbTR0mLg=
+
+Name: org/eclipse/equinox/internal/p2/director/Messages.class
+SHA1-Digest: fNysUvYzSGMycKL9kqg7d1OE/2Q=
+
+Name: org/eclipse/equinox/internal/p2/director/Explanation$1.class
+SHA1-Digest: LNKQ9sPGfqdYeK9pk4+iuZpO+Uk=
+
+Name: org/eclipse/equinox/internal/p2/director/Explanation$MissingIU.c
+ lass
+SHA1-Digest: VHrC65CBwiP6owq2YLEUpC/U0K8=
+
+Name: org/eclipse/equinox/internal/p2/director/Explanation$MissingGree
+ dyIU.class
+SHA1-Digest: N/MGQ0BaETZOEQJrIYlkkqkhxKM=
+
+Name: org/eclipse/equinox/internal/p2/director/DirectorActivator.class
+SHA1-Digest: je72r/D4/z/ToKMvbkpQzG8G6BE=
+
+Name: org/eclipse/equinox/internal/p2/director/messages.properties
+SHA1-Digest: SCaiaDkFT83gIoqinyWTOBdRh7w=
+
+Name: org/eclipse/equinox/internal/p2/director/Explanation$HardRequire
+ ment.class
+SHA1-Digest: Q+mysp19XOv/aSoNnAIkN5XRawo=
+
+Name: org/eclipse/equinox/internal/provisional/p2/director/PlanExecuti
+ onHelper.class
+SHA1-Digest: n3jObfQOkUeuV6dBKVCXeROMB1U=
+
+Name: org/eclipse/equinox/internal/p2/director/ProfileChangeRequest.cl
+ ass
+SHA1-Digest: HGOAuLWlfQt8Quw+gDH9ZWXAeyk=
+
+Name: org/eclipse/equinox/internal/p2/director/QueryableArray.class
+SHA1-Digest: CWwIbupIlHoyWHxZFgeR5vJewaU=
+
+Name: org/eclipse/equinox/internal/p2/director/SimplePlanner$Everythin
+ gOptionalProfile.class
+SHA1-Digest: GXsL4cWYXOIs7mHKtpPZyDRCxrM=
+

--- a/plugins/org.eclipse.equinox.p2.director/OSGI-INF/director.xml
+++ b/plugins/org.eclipse.equinox.p2.director/OSGI-INF/director.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" name="org.eclipse.equinox.p2.director">
+   <implementation class="org.eclipse.equinox.internal.p2.director.DirectorComponent"/>
+   <service>
+      <provide interface="org.eclipse.equinox.p2.core.spi.IAgentServiceFactory"/>
+   </service>
+   <property name="p2.agent.servicename" type="String" value="org.eclipse.equinox.internal.provisional.p2.director.IDirector"/>
+</scr:component>

--- a/plugins/org.eclipse.equinox.p2.director/OSGI-INF/planner.xml
+++ b/plugins/org.eclipse.equinox.p2.director/OSGI-INF/planner.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" name="org.eclipse.equinox.p2.planner">
+   <implementation class="org.eclipse.equinox.internal.p2.director.PlannerComponent"/>
+   <service>
+      <provide interface="org.eclipse.equinox.p2.core.spi.IAgentServiceFactory"/>
+   </service>
+   <property name="p2.agent.servicename" type="String" value="org.eclipse.equinox.p2.planner.IPlanner"/>
+</scr:component>

--- a/plugins/org.eclipse.equinox.p2.director/about.html
+++ b/plugins/org.eclipse.equinox.p2.director/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+ 
+<p>June 2, 2006</p>	
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise 
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available 
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is 
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was 
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/plugins/org.eclipse.equinox.p2.director/build.properties
+++ b/plugins/org.eclipse.equinox.p2.director/build.properties
@@ -1,0 +1,7 @@
+source.. = src/
+bin.includes = META-INF/,\
+               .,\
+               plugin.properties,\
+               about.html,\
+               OSGI-INF/,\
+               .api_description

--- a/plugins/org.eclipse.equinox.p2.director/plugin.properties
+++ b/plugins/org.eclipse.equinox.p2.director/plugin.properties
@@ -1,0 +1,12 @@
+###############################################################################
+#  Copyright (c) 2007, 2009 IBM Corporation and others.
+#  All rights reserved. This program and the accompanying materials
+#  are made available under the terms of the Eclipse Public License v1.0
+#  which accompanies this distribution, and is available at
+#  http://www.eclipse.org/legal/epl-v10.html
+# 
+#  Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+pluginName = Equinox Provisioning Director
+providerName = Eclipse.org - Equinox

--- a/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/director/ApplicablePatchQuery.java
+++ b/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/director/ApplicablePatchQuery.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ *  Copyright (c) 2008, 2010 IBM Corporation and others.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ * 
+ *  Contributors:
+ *      IBM Corporation - initial API and implementation
+ *      Cloudsmith Inc. - converted into expression based query
+ *******************************************************************************/
+package org.eclipse.equinox.internal.p2.director;
+
+import org.eclipse.equinox.p2.query.ExpressionMatchQuery;
+
+import org.eclipse.equinox.p2.metadata.IInstallableUnit;
+import org.eclipse.equinox.p2.metadata.IInstallableUnitPatch;
+import org.eclipse.equinox.p2.metadata.expression.ExpressionUtil;
+import org.eclipse.equinox.p2.metadata.expression.IExpression;
+
+/**
+ * A query that accepts any patch that applies to a given installable unit.
+ */
+public class ApplicablePatchQuery extends ExpressionMatchQuery<IInstallableUnit> {
+	private static final IExpression applicablePatches = ExpressionUtil.parse(//
+			"applicabilityScope.empty || applicabilityScope.exists(rqArr | rqArr.all(rq | $0 ~= rq))"); //$NON-NLS-1$
+
+	/**
+	 * Creates a new patch query on the given installable unit. Patches that can
+	 * be applied to this unit will be accepted as matches by the query.
+	 * @param iu The unit to compare patches against
+	 */
+	public ApplicablePatchQuery(IInstallableUnit iu) {
+		super(IInstallableUnitPatch.class, applicablePatches, iu);
+	}
+}

--- a/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/director/AttachmentHelper.java
+++ b/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/director/AttachmentHelper.java
@@ -1,0 +1,112 @@
+/*******************************************************************************
+ *  Copyright (c) 2009, 2010 IBM Corporation and others.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ * 
+ *  Contributors:
+ *      IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.equinox.internal.p2.director;
+
+import java.util.*;
+import org.eclipse.equinox.p2.metadata.*;
+import org.eclipse.equinox.p2.query.QueryUtil;
+
+public class AttachmentHelper {
+	private static final IInstallableUnitFragment[] NO_FRAGMENTS = new IInstallableUnitFragment[0];
+
+	public static Collection<IInstallableUnit> attachFragments(Iterator<IInstallableUnit> toAttach, Map<IInstallableUnitFragment, List<IInstallableUnit>> fragmentsToIUs) {
+		Map<IInstallableUnit, IInstallableUnitFragment[]> fragmentBindings = new HashMap<IInstallableUnit, IInstallableUnitFragment[]>();
+		//Build a map inverse of the one provided in input (host --> List of fragments)
+		Map<IInstallableUnit, List<IInstallableUnitFragment>> iusToFragment = new HashMap<IInstallableUnit, List<IInstallableUnitFragment>>(fragmentsToIUs.size());
+		for (Map.Entry<IInstallableUnitFragment, List<IInstallableUnit>> mapping : fragmentsToIUs.entrySet()) {
+			IInstallableUnitFragment fragment = mapping.getKey();
+			List<IInstallableUnit> existingMatches = mapping.getValue();
+
+			for (IInstallableUnit host : existingMatches) {
+				List<IInstallableUnitFragment> potentialFragments = iusToFragment.get(host);
+				if (potentialFragments == null) {
+					potentialFragments = new ArrayList<IInstallableUnitFragment>();
+					iusToFragment.put(host, potentialFragments);
+				}
+				potentialFragments.add(fragment);
+			}
+		}
+
+		for (Map.Entry<IInstallableUnit, List<IInstallableUnitFragment>> entry : iusToFragment.entrySet()) {
+			IInstallableUnit hostIU = entry.getKey();
+			List<IInstallableUnitFragment> potentialIUFragments = entry.getValue();
+			ArrayList<IInstallableUnitFragment> applicableFragments = new ArrayList<IInstallableUnitFragment>();
+			for (IInstallableUnitFragment potentialFragment : potentialIUFragments) {
+				if (hostIU.equals(potentialFragment))
+					continue;
+
+				// Check to make sure the host meets the requirements of the fragment
+				Collection<IRequirement> reqsFromFragment = potentialFragment.getHost();
+				boolean match = true;
+				boolean requirementMatched = false;
+				for (Iterator<IRequirement> iterator = reqsFromFragment.iterator(); iterator.hasNext() && match == true;) {
+					IRequirement reqs = iterator.next();
+					requirementMatched = false;
+					if (hostIU.satisfies(reqs))
+						requirementMatched = true;
+					if (requirementMatched == false) {
+						match = false;
+						break;
+					}
+
+				}
+				if (match) {
+					applicableFragments.add(potentialFragment);
+				}
+			}
+
+			IInstallableUnitFragment theFragment = null;
+			int specificityLevel = 0;
+			LinkedList<IInstallableUnitFragment> fragments = new LinkedList<IInstallableUnitFragment>();
+			for (IInstallableUnitFragment fragment : applicableFragments) {
+				if (isTranslation(fragment)) {
+					fragments.add(fragment);
+					continue;
+				}
+				if (fragment.getHost().size() > specificityLevel) {
+					theFragment = fragment;
+					specificityLevel = fragment.getHost().size();
+				}
+			}
+			if (theFragment != null)
+				fragments.addFirst(theFragment);
+			if (!fragments.isEmpty())
+				fragmentBindings.put(hostIU, fragments.toArray(new IInstallableUnitFragment[fragments.size()]));
+		}
+		//build the collection of resolved IUs
+		Collection<IInstallableUnit> result = new HashSet<IInstallableUnit>();
+		while (toAttach.hasNext()) {
+			IInstallableUnit iu = toAttach.next();
+			if (iu == null)
+				continue;
+			//just return fragments as they are
+			if (QueryUtil.isFragment(iu)) {
+				result.add(iu);
+				continue;
+			}
+			//return a new IU that combines the IU with its bound fragments
+			IInstallableUnitFragment[] fragments = fragmentBindings.get(iu);
+			if (fragments == null)
+				fragments = NO_FRAGMENTS;
+			result.add(MetadataFactory.createResolvedInstallableUnit(iu, fragments));
+		}
+		return result;
+	}
+
+	private static boolean isTranslation(IInstallableUnitFragment fragment) {
+		for (IProvidedCapability capability : fragment.getProvidedCapabilities()) {
+			// TODO make the constant in the TranslationSupport class public and use it
+			if ("org.eclipse.equinox.p2.localization".equals(capability.getNamespace())) //$NON-NLS-1$
+				return true;
+		}
+		return false;
+	}
+}

--- a/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/director/DirectorActivator.java
+++ b/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/director/DirectorActivator.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2007 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.equinox.internal.p2.director;
+
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+
+public class DirectorActivator implements BundleActivator {
+	public static final String PI_DIRECTOR = "org.eclipse.equinox.p2.director"; //$NON-NLS-1$
+	public static BundleContext context;
+
+	public void start(BundleContext ctx) throws Exception {
+		context = ctx;
+	}
+
+	public void stop(BundleContext ctx) throws Exception {
+		DirectorActivator.context = null;
+	}
+
+}

--- a/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/director/DirectorComponent.java
+++ b/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/director/DirectorComponent.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2009-2010 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *     Sonatype, Inc. - ongoing development
+ *******************************************************************************/
+package org.eclipse.equinox.internal.p2.director;
+
+import org.eclipse.equinox.p2.planner.IPlanner;
+
+import org.eclipse.equinox.p2.core.IProvisioningAgent;
+import org.eclipse.equinox.p2.core.spi.IAgentServiceFactory;
+import org.eclipse.equinox.p2.engine.IEngine;
+
+public class DirectorComponent implements IAgentServiceFactory {
+
+	public Object createService(IProvisioningAgent agent) {
+		IEngine engine = (IEngine) agent.getService(IEngine.SERVICE_NAME);
+		IPlanner planner = (IPlanner) agent.getService(IPlanner.SERVICE_NAME);
+		return new SimpleDirector(engine, planner);
+	}
+
+}

--- a/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/director/Explanation.java
+++ b/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/director/Explanation.java
@@ -1,0 +1,320 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2010 Daniel Le Berre and others. All rights reserved. This
+ * program and the accompanying materials are made available under the terms of
+ * the Eclipse Public License v1.0 which accompanies this distribution, and is
+ * available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors: 
+ *   Daniel Le Berre - initial API and implementation
+ *   IBM - ongoing development
+ ******************************************************************************/
+package org.eclipse.equinox.internal.p2.director;
+
+import java.util.Arrays;
+import org.eclipse.core.runtime.*;
+import org.eclipse.equinox.p2.metadata.*;
+import org.eclipse.osgi.util.NLS;
+
+public abstract class Explanation implements Comparable<Explanation> {
+
+	public static class PatchedHardRequirement extends Explanation {
+		public final IInstallableUnit iu;
+		public final IInstallableUnitPatch patch;
+		public final IRequirement req;
+
+		public PatchedHardRequirement(IInstallableUnit iu, IInstallableUnitPatch patch) {
+			this.iu = iu;
+			this.req = null;
+			this.patch = patch;
+		}
+
+		public PatchedHardRequirement(IInstallableUnit iu, IRequirement req, IInstallableUnitPatch patch) {
+			this.iu = iu;
+			this.req = req;
+			this.patch = patch;
+		}
+
+		public int orderValue() {
+			return 6;
+		}
+
+		public IStatus toStatus() {
+			MultiStatus result = new MultiStatus(DirectorActivator.PI_DIRECTOR, 1, Messages.Explanation_unsatisfied, null);
+			final String fromString = patch.toString() + ' ' + getUserReadableName(iu);
+			result.add(new Status(IStatus.ERROR, DirectorActivator.PI_DIRECTOR, NLS.bind(Messages.Explanation_fromPatch, fromString)));
+			result.add(new Status(IStatus.ERROR, DirectorActivator.PI_DIRECTOR, NLS.bind(Messages.Explanation_to, req)));
+			return result;
+		}
+
+		public String toString() {
+			return NLS.bind(Messages.Explanation_patchedHardDependency, new Object[] {patch, iu, req});
+		}
+
+		@Override
+		public int shortAnswer() {
+			return Explanation.VIOLATED_PATCHED_HARD_REQUIREMENT;
+		}
+
+	}
+
+	public static class HardRequirement extends Explanation {
+		public final IInstallableUnit iu;
+		public final IRequirement req;
+
+		public HardRequirement(IInstallableUnit iu, IRequirement req) {
+			this.iu = iu;
+			this.req = req;
+		}
+
+		public int orderValue() {
+			return 5;
+		}
+
+		public IStatus toStatus() {
+			MultiStatus result = new MultiStatus(DirectorActivator.PI_DIRECTOR, 1, Messages.Explanation_unsatisfied, null);
+			result.add(new Status(IStatus.ERROR, DirectorActivator.PI_DIRECTOR, NLS.bind(Messages.Explanation_from, getUserReadableName(iu))));
+			result.add(new Status(IStatus.ERROR, DirectorActivator.PI_DIRECTOR, NLS.bind(Messages.Explanation_to, req)));
+			return result;
+		}
+
+		public String toString() {
+			return NLS.bind(Messages.Explanation_hardDependency, iu, req);
+		}
+
+		@Override
+		public int shortAnswer() {
+			return VIOLATED_HARD_REQUIREMENT;
+		}
+	}
+
+	public static class IUInstalled extends Explanation {
+		public final IInstallableUnit iu;
+
+		public IUInstalled(IInstallableUnit iu) {
+			this.iu = iu;
+		}
+
+		public int orderValue() {
+			return 2;
+		}
+
+		public String toString() {
+			return NLS.bind(Messages.Explanation_alreadyInstalled, iu);
+		}
+
+		public IStatus toStatus() {
+			return new Status(IStatus.ERROR, DirectorActivator.PI_DIRECTOR, NLS.bind(Messages.Explanation_alreadyInstalled, getUserReadableName(iu)));
+		}
+
+		@Override
+		public int shortAnswer() {
+			return IU_INSTALLED;
+		}
+	}
+
+	public static class IUToInstall extends Explanation {
+		public final IInstallableUnit iu;
+
+		public IUToInstall(IInstallableUnit iu) {
+			this.iu = iu;
+		}
+
+		public int orderValue() {
+			return 1;
+		}
+
+		public String toString() {
+			return NLS.bind(Messages.Explanation_toInstall, iu);
+		}
+
+		public IStatus toStatus() {
+			return new Status(IStatus.ERROR, DirectorActivator.PI_DIRECTOR, NLS.bind(Messages.Explanation_toInstall, getUserReadableName(iu)));
+		}
+
+		@Override
+		public int shortAnswer() {
+			return IU_TO_INSTALL;
+		}
+	}
+
+	public static class NotInstallableRoot extends Explanation {
+		public final IRequirement req;
+
+		public NotInstallableRoot(IRequirement req) {
+			this.req = req;
+		}
+
+		public String toString() {
+			return NLS.bind(Messages.Explanation_missingRootFilter, req);
+		}
+
+		public IStatus toStatus() {
+			return new Status(IStatus.ERROR, DirectorActivator.PI_DIRECTOR, NLS.bind(Messages.Explanation_missingRootFilter, req));
+		}
+
+		protected int orderValue() {
+			return 2;
+		}
+
+		@Override
+		public int shortAnswer() {
+			return NON_INSTALLABLE_ROOT;
+		}
+	}
+
+	public static class MissingIU extends Explanation {
+		public final IInstallableUnit iu;
+		public final IRequirement req;
+		public boolean isEntryPoint;
+
+		public MissingIU(IInstallableUnit iu, IRequirement req, boolean isEntryPoint) {
+			this.iu = iu;
+			this.req = req;
+			this.isEntryPoint = isEntryPoint;
+		}
+
+		public int orderValue() {
+			return 3;
+		}
+
+		public int shortAnswer() {
+			return MISSING_REQUIREMENT;
+		}
+
+		public String toString() {
+			if (isEntryPoint) {
+				return NLS.bind(Messages.Explanation_missingRootRequired, req);
+			}
+			if (req.getFilter() == null) {
+				return NLS.bind(Messages.Explanation_missingRequired, iu, req);
+			}
+			return NLS.bind(Messages.Explanation_missingRequiredFilter, new Object[] {req.getFilter(), iu, req});
+		}
+
+		public IStatus toStatus() {
+			if (isEntryPoint) {
+				return new Status(IStatus.ERROR, DirectorActivator.PI_DIRECTOR, NLS.bind(Messages.Explanation_missingRootRequired, req));
+			}
+			if (req.getFilter() == null) {
+				return new Status(IStatus.ERROR, DirectorActivator.PI_DIRECTOR, NLS.bind(Messages.Explanation_missingRequired, getUserReadableName(iu), req));
+			}
+			return new Status(IStatus.ERROR, DirectorActivator.PI_DIRECTOR, NLS.bind(Messages.Explanation_missingRequiredFilter, new Object[] {req.getFilter(), getUserReadableName(iu), req}));
+		}
+	}
+
+	public static class MissingGreedyIU extends Explanation {
+		public final IInstallableUnit iu;
+
+		public MissingGreedyIU(IInstallableUnit iu) {
+			this.iu = iu;
+		}
+
+		public int orderValue() {
+			return 3;
+		}
+
+		public int shortAnswer() {
+			return MISSING_REQUIREMENT;
+		}
+
+		public String toString() {
+			return NLS.bind(Messages.Explanation_missingNonGreedyRequired, iu);
+		}
+
+		public IStatus toStatus() {
+			return new Status(IStatus.ERROR, DirectorActivator.PI_DIRECTOR, NLS.bind(Messages.Explanation_missingNonGreedyRequired, getUserReadableName(iu)));
+		}
+	}
+
+	public static class Singleton extends Explanation {
+		public final IInstallableUnit[] ius;
+
+		public Singleton(IInstallableUnit[] ius) {
+			this.ius = ius;
+		}
+
+		public int orderValue() {
+			return 4;
+		}
+
+		public int shortAnswer() {
+			return VIOLATED_SINGLETON_CONSTRAINT;
+		}
+
+		public IStatus toStatus() {
+			MultiStatus result = new MultiStatus(DirectorActivator.PI_DIRECTOR, 1, NLS.bind(Messages.Explanation_singleton, ""), null); //$NON-NLS-1$
+			for (int i = 0; i < ius.length; i++)
+				result.add(new Status(IStatus.ERROR, DirectorActivator.PI_DIRECTOR, getUserReadableName(ius[i])));
+			return result;
+		}
+
+		public String toString() {
+			return NLS.bind(Messages.Explanation_singleton, Arrays.asList(ius));
+		}
+
+	}
+
+	public static final Explanation OPTIONAL_REQUIREMENT = new Explanation() {
+
+		public int orderValue() {
+			return 6;
+		}
+
+		public String toString() {
+			return Messages.Explanation_optionalDependency;
+		}
+
+		@Override
+		public int shortAnswer() {
+			return OTHER_REASON;
+		}
+	};
+
+	public static final int MISSING_REQUIREMENT = 1;
+	public static final int VIOLATED_SINGLETON_CONSTRAINT = 2;
+	public static final int IU_INSTALLED = 3;
+	public static final int IU_TO_INSTALL = 4;
+	public static final int VIOLATED_HARD_REQUIREMENT = 5;
+	public static final int VIOLATED_PATCHED_HARD_REQUIREMENT = 6;
+	public static final int NON_INSTALLABLE_ROOT = 7;
+	public static final int OTHER_REASON = 100;
+
+	protected Explanation() {
+		super();
+	}
+
+	public int compareTo(Explanation exp) {
+		if (this.orderValue() == exp.orderValue()) {
+			return this.toString().compareTo(exp.toString());
+		}
+		return this.orderValue() - exp.orderValue();
+	}
+
+	protected abstract int orderValue();
+
+	abstract public int shortAnswer();
+
+	/**
+	 * Returns a representation of this explanation as a status object.
+	 */
+	public IStatus toStatus() {
+		return new Status(IStatus.ERROR, DirectorActivator.PI_DIRECTOR, toString());
+	}
+
+	protected String getUserReadableName(IInstallableUnit iu) {
+		if (iu == null)
+			return ""; //$NON-NLS-1$
+		String result = getLocalized(iu);
+		if (result == null)
+			return iu.toString();
+		return result + ' ' + iu.getVersion() + " (" + iu.toString() + ')'; //$NON-NLS-1$
+	}
+
+	private String getLocalized(IInstallableUnit iu) {
+		String value = iu.getProperty(IInstallableUnit.PROP_NAME);
+		if (value == null || value.length() <= 1 || value.charAt(0) != '%')
+			return value;
+		final String actualKey = value.substring(1); // Strip off the %
+		return iu.getProperty("df_LT." + actualKey); //$NON-NLS-1$
+	}
+}

--- a/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/director/InfiniteProgress.java
+++ b/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/director/InfiniteProgress.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2009 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.equinox.internal.p2.director;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.ProgressMonitorWrapper;
+
+/**
+ * This class provides a simulation of progress. This is useful
+ * for situations where computing the amount of work to do in advance
+ * is too costly.  The monitor will accept any number of calls to
+ * {@link #worked(int)}, and will scale the actual reported work appropriately
+ * so that the progress never quite completes.
+ */
+class InfiniteProgress extends ProgressMonitorWrapper {
+	/*
+	 * Fields for progress monitoring algorithm.
+	 * Initially, give progress for every 4 resources, double
+	 * this value at halfway point, then reset halfway point
+	 * to be half of remaining work.  (this gives an infinite
+	 * series that converges at total work after an infinite
+	 * number of resources).
+	 */
+	private int totalWork;
+	private int currentIncrement = 4;
+	private int halfWay;
+	private int nextProgress = currentIncrement;
+	private int worked = 0;
+
+	protected InfiniteProgress(IProgressMonitor monitor) {
+		super(monitor);
+	}
+
+	public void beginTask(String name, int work) {
+		super.beginTask(name, work);
+		this.totalWork = work;
+		this.halfWay = totalWork / 2;
+	}
+
+	public void worked(int work) {
+		if (--nextProgress <= 0) {
+			//we have exhausted the current increment, so report progress
+			super.worked(1);
+			worked++;
+			if (worked >= halfWay) {
+				//we have passed the current halfway point, so double the
+				//increment and reset the halfway point.
+				currentIncrement *= 2;
+				halfWay += (totalWork - halfWay) / 2;
+			}
+			//reset the progress counter to another full increment
+			nextProgress = currentIncrement;
+		}
+	}
+
+}

--- a/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/director/Messages.java
+++ b/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/director/Messages.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ *  Copyright (c) 2007, 2010 IBM Corporation and others.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ * 
+ *  Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.equinox.internal.p2.director;
+
+import org.eclipse.osgi.util.NLS;
+
+public class Messages extends NLS {
+	private static final String BUNDLE_NAME = "org.eclipse.equinox.internal.p2.director.messages"; //$NON-NLS-1$
+
+	static {
+		// initialize resource bundles
+		NLS.initializeMessages(BUNDLE_NAME, Messages.class);
+	}
+
+	private Messages() {
+		// Do not instantiate
+	}
+
+	public static String Director_Task_installer_plan;
+	public static String Director_Task_Installing;
+	public static String Director_Task_Updating;
+	public static String Director_Task_Resolving_Dependencies;
+	public static String Director_Unsatisfied_Dependencies;
+	public static String Director_error_applying_configuration;
+	public static String Director_For_Target;
+	public static String Director_For_Target_Unselect_Required;
+
+	public static String Explanation_alreadyInstalled;
+	public static String Explanation_from;
+	public static String Explanation_fromPatch;
+	public static String Explanation_hardDependency;
+	public static String Explanation_patchedHardDependency;
+	public static String Explanation_missingRequired;
+	public static String Explanation_missingRootRequired;
+	public static String Explanation_missingNonGreedyRequired;
+	public static String Explanation_missingRequiredFilter;
+	public static String Explanation_missingRootFilter;
+	public static String Explanation_optionalDependency;
+	public static String Explanation_rootMissing;
+	public static String Explanation_rootSingleton;
+	public static String Explanation_singleton;
+	public static String Explanation_to;
+	public static String Explanation_toInstall;
+	public static String Explanation_unsatisfied;
+
+	public static String Planner_Timeout;
+	public static String Planner_Problems_resolving_plan;
+	public static String Planner_Unsatisfiable_problem;
+	public static String Planner_Unsatisfied_dependency;
+	public static String Planner_NoSolution;
+	public static String Planner_Unexpected_problem;
+	public static String Planner_actions_and_software_incompatible;
+	public static String Planner_can_not_install_preq;
+	public static String Planner_no_profile_registry;
+	public static String Planner_profile_out_of_sync;
+	public static String RequestStatus_message;
+	public static String Planner_no_installer_agent;
+
+}

--- a/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/director/OperationGenerator.java
+++ b/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/director/OperationGenerator.java
@@ -1,0 +1,166 @@
+/*******************************************************************************
+ *  Copyright (c) 2007, 2010 IBM Corporation and others.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ * 
+ *  Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.equinox.internal.p2.director;
+
+import java.util.*;
+import org.eclipse.equinox.p2.engine.IProvisioningPlan;
+import org.eclipse.equinox.p2.metadata.*;
+import org.eclipse.equinox.p2.query.*;
+
+public class OperationGenerator {
+	private static final IInstallableUnit NULL_IU = MetadataFactory.createResolvedInstallableUnit(MetadataFactory.createInstallableUnit(new MetadataFactory.InstallableUnitDescription()), new IInstallableUnitFragment[0]);
+	private final IProvisioningPlan plan;
+
+	public OperationGenerator(IProvisioningPlan plan) {
+		this.plan = plan;
+	}
+
+	public void generateOperation(Collection<IInstallableUnit> from_, Collection<IInstallableUnit> to_) {
+		Collection<IInstallableUnit> intersection = new HashSet<IInstallableUnit>(from_);
+		intersection.retainAll(to_);
+
+		HashSet<IInstallableUnit> tmpFrom = new HashSet<IInstallableUnit>(from_);
+		HashSet<IInstallableUnit> tmpTo = new HashSet<IInstallableUnit>(to_);
+		tmpFrom.removeAll(intersection);
+		tmpTo.removeAll(intersection);
+
+		List<IInstallableUnit> from = new ArrayList<IInstallableUnit>(tmpFrom);
+		Collections.sort(from);
+
+		List<IInstallableUnit> to = new ArrayList<IInstallableUnit>(tmpTo);
+		Collections.sort(to);
+
+		generateUpdates(from, to);
+		generateInstallUninstall(from, to);
+		generateConfigurationChanges(to_, intersection);
+	}
+
+	//This generates operations that are causing the IUs to be reconfigured.
+	private void generateConfigurationChanges(Collection<IInstallableUnit> to_, Collection<IInstallableUnit> intersection) {
+		if (intersection.size() == 0)
+			return;
+		//We retain from each set the things that are the same.
+		//Note that despite the fact that they are the same, a different CU can be attached.
+		//The objects contained in the intersection are the one that were originally in the from collection.
+		TreeSet<IInstallableUnit> to = new TreeSet<IInstallableUnit>(to_);
+		for (IInstallableUnit fromIU : intersection) {
+			IInstallableUnit toIU = to.tailSet(fromIU).first();
+			generateConfigurationOperation(fromIU, toIU);
+		}
+
+	}
+
+	private void generateConfigurationOperation(IInstallableUnit fromIU, IInstallableUnit toIU) {
+		Collection<IInstallableUnitFragment> fromFragments = fromIU.getFragments();
+		Collection<IInstallableUnitFragment> toFragments = toIU.getFragments();
+		if (fromFragments == toFragments)
+			return;
+		//Check to see if the two arrays are equals independently of the order of the fragments
+		if (fromFragments.size() == toFragments.size() && fromFragments.containsAll(toFragments))
+			return;
+		plan.updateInstallableUnit(fromIU, toIU);
+	}
+
+	private void generateInstallUninstall(List<IInstallableUnit> from, List<IInstallableUnit> to) {
+		int toIdx = 0;
+		int fromIdx = 0;
+		while (fromIdx != from.size() && toIdx != to.size()) {
+			IInstallableUnit fromIU = from.get(fromIdx);
+			IInstallableUnit toIU = to.get(toIdx);
+			int comparison = toIU.compareTo(fromIU);
+			if (comparison < 0) {
+				plan.addInstallableUnit(toIU);
+				toIdx++;
+			} else if (comparison == 0) {
+				toIdx++;
+				fromIdx++;
+				//				System.out.println("same " + fromIU);
+			} else {
+				plan.removeInstallableUnit(fromIU);
+				fromIdx++;
+			}
+		}
+		if (fromIdx != from.size()) {
+			for (int i = fromIdx; i < from.size(); i++) {
+				plan.removeInstallableUnit(from.get(i));
+			}
+		}
+		if (toIdx != to.size()) {
+			for (int i = toIdx; i < to.size(); i++) {
+				plan.addInstallableUnit(to.get(i));
+			}
+		}
+	}
+
+	private void generateUpdates(List<IInstallableUnit> from, List<IInstallableUnit> to) {
+		if (to.isEmpty() || from.isEmpty())
+			return;
+
+		Set<IInstallableUnit> processed = new HashSet<IInstallableUnit>();
+		Set<IInstallableUnit> removedFromTo = new HashSet<IInstallableUnit>();
+
+		QueryableArray indexedFromElements = new QueryableArray(from.toArray(new IInstallableUnit[from.size()]));
+		for (int toIdx = 0; toIdx < to.size(); toIdx++) {
+			IInstallableUnit iuTo = to.get(toIdx);
+			if (iuTo.getId().equals(next(to, toIdx).getId())) { //This handle the case where there are multiple versions of the same IU in the target. Eg we are trying to update from A 1.0.0 to A 1.1.1 and A 1.2.2
+				toIdx = skip(to, iuTo, toIdx) - 1;
+				//System.out.println("Can't update " + iuTo + " because another iu with same id is in the target state");
+				continue;
+			}
+			if (iuTo.getUpdateDescriptor() == null)
+				continue;
+
+			//TODO we eventually need to handle the case where an IU is a merge of several others.
+
+			IQuery<IInstallableUnit> updateQuery = QueryUtil.createMatchQuery(iuTo.getUpdateDescriptor().getIUsBeingUpdated().iterator().next(), new Object[0]);
+			iuTo.getUpdateDescriptor().getIUsBeingUpdated();
+			IQueryResult<IInstallableUnit> updates = indexedFromElements.query(updateQuery, null);
+
+			if (updates.isEmpty()) { //Nothing to update from.
+				continue;
+			}
+			Iterator<IInstallableUnit> updatesIterator = updates.iterator();
+			IInstallableUnit iuFrom = updatesIterator.next();
+			if (updatesIterator.hasNext()) { //There are multiple IUs to update from
+				//System.out.println("Can't update  " + iuTo + " because there are multiple IUs to update from (" + toString(iusFrom) + ')');
+				continue;
+			}
+			if (iuTo.equals(iuFrom)) {
+				from.remove(iuFrom);
+				//				fromIdIndexList.remove(iuFrom);
+				removedFromTo.add(iuTo);
+				continue;
+			}
+			plan.updateInstallableUnit(iuFrom, iuTo);
+			from.remove(iuFrom);
+			//			fromIdIndexList.remove(iuFrom);
+			processed.add(iuTo);
+		}
+		to.removeAll(processed);
+		to.removeAll(removedFromTo);
+	}
+
+	private IInstallableUnit next(List<IInstallableUnit> l, int i) {
+		i++;
+		if (i >= l.size())
+			return NULL_IU;
+		return l.get(i);
+	}
+
+	private int skip(List<IInstallableUnit> c, IInstallableUnit id, int idx) {
+		int i = idx;
+		for (; i < c.size(); i++) {
+			if (!id.getId().equals(c.get(i).getId()))
+				return i;
+		}
+		return i;
+	}
+}

--- a/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/director/OptimizationFunction.java
+++ b/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/director/OptimizationFunction.java
@@ -1,0 +1,150 @@
+/*******************************************************************************
+ * Copyright (c) 2013 Rapicorp Inc. and others. All rights reserved. This
+ * program and the accompanying materials are made available under the terms of
+ * the Eclipse Public License v1.0 which accompanies this distribution, and is
+ * available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors: 
+ *   Rapicorp, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.eclipse.equinox.internal.p2.director;
+
+import java.math.BigInteger;
+import java.util.*;
+import java.util.Map.Entry;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.equinox.internal.p2.core.helpers.CollectionUtils;
+import org.eclipse.equinox.internal.p2.director.Projector.AbstractVariable;
+import org.eclipse.equinox.p2.metadata.*;
+import org.eclipse.equinox.p2.query.*;
+import org.sat4j.pb.tools.WeightedObject;
+
+public class OptimizationFunction {
+
+	private IQueryable<IInstallableUnit> picker;
+	private IInstallableUnit selectionContext;
+	protected Map<String, Map<Version, IInstallableUnit>> slice; //The IUs that have been considered to be part of the problem
+	private int numberOfInstalledIUs; //TODO this should be renamed to consideredIUs or sliceSize
+	private IQueryable<IInstallableUnit> lastState;
+	private List<AbstractVariable> optionalRequirementVariable;
+
+	public OptimizationFunction(IQueryable<IInstallableUnit> lastState, List<AbstractVariable> abstractVariables, List<AbstractVariable> optionalRequirementVariable, IQueryable<IInstallableUnit> picker, IInstallableUnit selectionContext, Map<String, Map<Version, IInstallableUnit>> slice) {
+		this.lastState = lastState;
+		this.optionalRequirementVariable = optionalRequirementVariable;
+		this.picker = picker;
+		this.selectionContext = selectionContext;
+		this.slice = slice;
+	}
+
+	//Create an optimization function favoring the highest version of each IU
+	public List<WeightedObject<? extends Object>> createOptimizationFunction(IInstallableUnit metaIu, Collection<IInstallableUnit> newRoots) {
+		numberOfInstalledIUs = sizeOf(lastState);
+		List<WeightedObject<? extends Object>> weightedObjects = new ArrayList<WeightedObject<? extends Object>>();
+
+		Set<IInstallableUnit> transitiveClosure; //The transitive closure of the IUs we are adding (this also means updating)
+		if (newRoots.isEmpty()) {
+			transitiveClosure = CollectionUtils.emptySet();
+		} else {
+			IQueryable<IInstallableUnit> queryable = new Slicer(picker, selectionContext, false).slice(newRoots.toArray(new IInstallableUnit[newRoots.size()]), new NullProgressMonitor());
+			if (queryable == null) {
+				transitiveClosure = CollectionUtils.emptySet();
+			} else {
+				transitiveClosure = queryable.query(QueryUtil.ALL_UNITS, new NullProgressMonitor()).toSet();
+			}
+		}
+
+		Set<Entry<String, Map<Version, IInstallableUnit>>> s = slice.entrySet();
+		final BigInteger POWER = BigInteger.valueOf(numberOfInstalledIUs > 0 ? numberOfInstalledIUs + 1 : 2);
+
+		BigInteger maxWeight = POWER;
+		for (Entry<String, Map<Version, IInstallableUnit>> entry : s) {
+			List<IInstallableUnit> conflictingEntries = new ArrayList<IInstallableUnit>(entry.getValue().values());
+			if (conflictingEntries.size() == 1) {
+				//Only one IU exists with the namespace.
+				IInstallableUnit iu = conflictingEntries.get(0);
+				if (iu != metaIu) {
+					weightedObjects.add(WeightedObject.newWO(iu, POWER));
+				}
+				continue;
+			}
+
+			// Set the weight such that things that are already installed are not updated
+			Collections.sort(conflictingEntries, Collections.reverseOrder());
+			BigInteger weight = POWER;
+			// have we already found a version that is already installed?
+			boolean foundInstalled = false;
+			// have we already found a version that is in the new roots?
+			boolean foundRoot = false;
+			for (IInstallableUnit iu : conflictingEntries) {
+				if (!foundRoot && isInstalled(iu) && !transitiveClosure.contains(iu)) {
+					foundInstalled = true;
+					weightedObjects.add(WeightedObject.newWO(iu, BigInteger.ONE));
+				} else if (!foundInstalled && !foundRoot && isRoot(iu, newRoots)) {
+					foundRoot = true;
+					weightedObjects.add(WeightedObject.newWO(iu, BigInteger.ONE));
+				} else {
+					weightedObjects.add(WeightedObject.newWO(iu, weight));
+				}
+				weight = weight.multiply(POWER);
+			}
+			if (weight.compareTo(maxWeight) > 0)
+				maxWeight = weight;
+		}
+
+		// no need to add one here, since maxWeight is strictly greater than the
+		// maximal weight used so far.
+		maxWeight = maxWeight.multiply(POWER).multiply(BigInteger.valueOf(s.size()));
+
+		// Add the optional variables
+		BigInteger optionalVarWeight = maxWeight.negate();
+		for (AbstractVariable var : optionalRequirementVariable) {
+			weightedObjects.add(WeightedObject.newWO(var, optionalVarWeight));
+		}
+
+		maxWeight = maxWeight.multiply(POWER).add(BigInteger.ONE);
+
+		//Now we deal the optional IUs,
+		BigInteger optionalWeight = maxWeight.negate();
+		long countOptional = 1;
+		List<IInstallableUnit> requestedPatches = new ArrayList<IInstallableUnit>();
+		Collection<IRequirement> reqs = metaIu.getRequirements();
+		for (IRequirement req : reqs) {
+			if (req.getMin() > 0 || !req.isGreedy())
+				continue;
+			IQueryResult<IInstallableUnit> matches = picker.query(QueryUtil.createMatchQuery(req.getMatches()), null);
+			for (Iterator<IInstallableUnit> iterator = matches.iterator(); iterator.hasNext();) {
+				IInstallableUnit match = iterator.next();
+				if (match instanceof IInstallableUnitPatch) {
+					requestedPatches.add(match);
+					countOptional = countOptional + 1;
+				}
+			}
+		}
+
+		// and we make sure that patches are always favored
+		BigInteger patchWeight = maxWeight.multiply(POWER).multiply(BigInteger.valueOf(countOptional)).negate();
+		for (Iterator<IInstallableUnit> iterator = requestedPatches.iterator(); iterator.hasNext();) {
+			weightedObjects.add(WeightedObject.newWO(iterator.next(), patchWeight));
+		}
+		return weightedObjects;
+	}
+
+	protected boolean isInstalled(IInstallableUnit iu) {
+		return !lastState.query(QueryUtil.createIUQuery(iu), null).isEmpty();
+	}
+
+	private boolean isRoot(IInstallableUnit iu, Collection<IInstallableUnit> newRoots) {
+		return newRoots.contains(iu);
+	}
+
+	/**
+	 * Efficiently compute the size of a queryable
+	 */
+	private int sizeOf(IQueryable<IInstallableUnit> installedIUs) {
+		IQueryResult<IInstallableUnit> qr = installedIUs.query(QueryUtil.createIUAnyQuery(), null);
+		if (qr instanceof Collector<?>)
+			return ((Collector<?>) qr).size();
+		return qr.toUnmodifiableSet().size();
+	}
+
+}

--- a/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/director/PermissiveSlicer.java
+++ b/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/director/PermissiveSlicer.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2010 IBM Corporation and others. All rights reserved. This
+ * program and the accompanying materials are made available under the terms of
+ * the Eclipse Public License v1.0 which accompanies this distribution, and is
+ * available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors: IBM Corporation - initial API and implementation
+ ******************************************************************************/
+package org.eclipse.equinox.internal.p2.director;
+
+import java.util.Map;
+import org.eclipse.equinox.internal.p2.metadata.RequiredCapability;
+import org.eclipse.equinox.p2.metadata.IInstallableUnit;
+import org.eclipse.equinox.p2.metadata.IRequirement;
+import org.eclipse.equinox.p2.query.IQueryable;
+
+public class PermissiveSlicer extends Slicer {
+	private boolean includeOptionalDependencies; //Cause optional dependencies not be followed as part of the
+	private boolean everythingGreedy;
+	private boolean considerFilter;
+	private boolean considerOnlyStrictDependency;
+	private boolean evalFilterTo;
+	private boolean onlyFilteredRequirements;
+
+	public PermissiveSlicer(IQueryable<IInstallableUnit> input, Map<String, String> context, boolean includeOptionalDependencies, boolean everythingGreedy, boolean evalFilterTo, boolean considerOnlyStrictDependency, boolean onlyFilteredRequirements) {
+		super(input, context, true);
+		this.considerFilter = (context != null && context.size() > 1) ? true : false;
+		this.includeOptionalDependencies = includeOptionalDependencies;
+		this.everythingGreedy = everythingGreedy;
+		this.evalFilterTo = evalFilterTo;
+		this.considerOnlyStrictDependency = considerOnlyStrictDependency;
+		this.onlyFilteredRequirements = onlyFilteredRequirements;
+	}
+
+	protected boolean isApplicable(IInstallableUnit iu) {
+		if (considerFilter)
+			return super.isApplicable(iu);
+		if (iu.getFilter() == null)
+			return true;
+		return evalFilterTo;
+	}
+
+	protected boolean isApplicable(IRequirement req) {
+		//Every filter in this method needs to continue except when the filter does not pass
+		if (!includeOptionalDependencies)
+			if (req.getMin() == 0)
+				return false;
+
+		if (considerOnlyStrictDependency) {
+			if (!RequiredCapability.isVersionStrict(req.getMatches()))
+				return false;
+		}
+
+		//deal with filters
+		if (considerFilter) {
+			if (onlyFilteredRequirements && req.getFilter() == null) {
+				return false;
+			}
+			return super.isApplicable(req);
+		}
+		if (req.getFilter() == null) {
+			if (onlyFilteredRequirements)
+				return false;
+			return true;
+		}
+		return evalFilterTo;
+	}
+
+	protected boolean isGreedy(IRequirement req) {
+		if (everythingGreedy) {
+			return true;
+		}
+		return super.isGreedy(req);
+	}
+}

--- a/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/director/PlannerComponent.java
+++ b/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/director/PlannerComponent.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2010 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.equinox.internal.p2.director;
+
+import org.eclipse.equinox.p2.core.IProvisioningAgent;
+import org.eclipse.equinox.p2.core.spi.IAgentServiceFactory;
+
+/**
+ * A service factory that provides planner implementations
+ */
+public class PlannerComponent implements IAgentServiceFactory {
+
+	public Object createService(IProvisioningAgent agent) {
+		return new SimplePlanner(agent);
+	}
+}

--- a/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/director/ProfileChangeRequest.java
+++ b/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/director/ProfileChangeRequest.java
@@ -1,0 +1,279 @@
+/*******************************************************************************
+ *  Copyright (c) 2008, 2010 IBM Corporation and others.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ * 
+ *  Contributors:
+ *      IBM Corporation - initial API and implementation
+ *     Sonatype, Inc. - ongoing development
+ *******************************************************************************/
+package org.eclipse.equinox.internal.p2.director;
+
+import java.util.*;
+import org.eclipse.equinox.internal.p2.core.helpers.CollectionUtils;
+import org.eclipse.equinox.p2.core.IProvisioningAgent;
+import org.eclipse.equinox.p2.engine.IProfile;
+import org.eclipse.equinox.p2.engine.IProfileRegistry;
+import org.eclipse.equinox.p2.metadata.IInstallableUnit;
+import org.eclipse.equinox.p2.metadata.IRequirement;
+import org.eclipse.equinox.p2.planner.IPlanner;
+import org.eclipse.equinox.p2.planner.IProfileChangeRequest;
+
+/**
+ * @noreference This class was unintentionally left in the provisional API package and
+ * 	is intended to be made internal in Eclipse 3.7. Clients should create and manipulate 
+ * 	profile change requests via the API {@link IPlanner#createChangeRequest(IProfile)}
+ * 	and methods on {@link IProfileChangeRequest}.
+ */
+public class ProfileChangeRequest implements Cloneable, IProfileChangeRequest {
+
+	private final IProfile profile;
+	private ArrayList<IInstallableUnit> iusToRemove = null; // list of ius to remove
+	private ArrayList<IInstallableUnit> iusToAdd = null; // list of ius to add
+	private ArrayList<String> propertiesToRemove = null; // list of keys for properties to be removed
+	private HashMap<String, String> propertiesToAdd = null; // map of key->value for properties to be added
+	private HashMap<IInstallableUnit, Map<String, String>> iuPropertiesToAdd = null; // map iu->map of key->value pairs for properties to be added for an iu
+	private HashMap<IInstallableUnit, List<String>> iuPropertiesToRemove = null; // map of iu->list of property keys to be removed for an iu
+	private ArrayList<IRequirement> additionalRequirements;
+
+	public static ProfileChangeRequest createByProfileId(IProvisioningAgent agent, String profileId) {
+		IProfileRegistry profileRegistry = (IProfileRegistry) agent.getService(IProfileRegistry.SERVICE_NAME);
+		if (profileRegistry == null)
+			throw new IllegalStateException(Messages.Planner_no_profile_registry);
+		IProfile profile = profileRegistry.getProfile(profileId);
+		if (profile == null)
+			throw new IllegalArgumentException("Profile id " + profileId + " is not registered."); //$NON-NLS-1$//$NON-NLS-2$
+		return new ProfileChangeRequest(profile);
+	}
+
+	public ProfileChangeRequest(IProfile profile) {
+		this.profile = profile;
+	}
+
+	public void setProfile(IProfile profile) {
+		if (profile == null)
+			throw new IllegalArgumentException("Profile cannot be null."); //$NON-NLS-1$
+	}
+
+	public IProfile getProfile() {
+		return profile;
+	}
+
+	public Map<String, String> getProfileProperties() {
+		Map<String, String> result = new HashMap<String, String>(profile.getProperties());
+		if (propertiesToRemove != null) {
+			for (String key : propertiesToRemove) {
+				result.remove(key);
+			}
+		}
+		if (propertiesToAdd != null)
+			result.putAll(propertiesToAdd);
+
+		return result;
+	}
+
+	//done
+	/* (non-Javadoc)
+	 * @see org.eclipse.equinox.internal.provisional.p2.director.IPCR#addInstallableUnit(org.eclipse.equinox.p2.metadata.IInstallableUnit)
+	 */
+	public void add(IInstallableUnit toInstall) {
+		if (iusToAdd == null)
+			iusToAdd = new ArrayList<IInstallableUnit>();
+		iusToAdd.add(toInstall);
+	}
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.equinox.internal.provisional.p2.director.IPCR#addInstallableUnits(java.util.Collection)
+	 */
+	public void addAll(Collection<IInstallableUnit> toInstall) {
+		for (IInstallableUnit iu : toInstall)
+			add(iu);
+	}
+
+	public void addInstallableUnits(IInstallableUnit... toInstall) {
+		for (int i = 0; i < toInstall.length; i++)
+			add(toInstall[i]);
+	}
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.equinox.internal.provisional.p2.director.IPCR#removeInstallableUnit(org.eclipse.equinox.p2.metadata.IInstallableUnit)
+	 */
+	public void remove(IInstallableUnit toUninstall) {
+		if (iusToRemove == null)
+			iusToRemove = new ArrayList<IInstallableUnit>();
+		iusToRemove.add(toUninstall);
+	}
+
+	public void removeInstallableUnits(IInstallableUnit[] toUninstall) {
+		for (int i = 0; i < toUninstall.length; i++)
+			remove(toUninstall[i]);
+	}
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.equinox.internal.provisional.p2.director.IPCR#removeInstallableUnits(java.util.Collection)
+	 */
+	public void removeAll(Collection<IInstallableUnit> toUninstall) {
+		for (IInstallableUnit iu : toUninstall)
+			remove(iu);
+	}
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.equinox.internal.provisional.p2.director.IPCR#setProfileProperty(java.lang.String, java.lang.String)
+	 */
+	public void setProfileProperty(String key, String value) {
+		if (propertiesToAdd == null)
+			propertiesToAdd = new HashMap<String, String>();
+		propertiesToAdd.put(key, value);
+	}
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.equinox.internal.provisional.p2.director.IPCR#removeProfileProperty(java.lang.String)
+	 */
+	public void removeProfileProperty(String key) {
+		if (propertiesToRemove == null)
+			propertiesToRemove = new ArrayList<String>(1);
+		propertiesToRemove.add(key);
+	}
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.equinox.internal.provisional.p2.director.IPCR#setInstallableUnitProfileProperty(org.eclipse.equinox.p2.metadata.IInstallableUnit, java.lang.String, java.lang.String)
+	 */
+	public void setInstallableUnitProfileProperty(IInstallableUnit iu, String key, String value) {
+		if (iuPropertiesToAdd == null)
+			iuPropertiesToAdd = new HashMap<IInstallableUnit, Map<String, String>>();
+		Map<String, String> properties = iuPropertiesToAdd.get(iu);
+		if (properties == null) {
+			properties = new HashMap<String, String>();
+			iuPropertiesToAdd.put(iu, properties);
+		}
+		properties.put(key, value);
+	}
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.equinox.internal.provisional.p2.director.IPCR#removeInstallableUnitProfileProperty(org.eclipse.equinox.p2.metadata.IInstallableUnit, java.lang.String)
+	 */
+	public void removeInstallableUnitProfileProperty(IInstallableUnit iu, String key) {
+		if (iuPropertiesToRemove == null)
+			iuPropertiesToRemove = new HashMap<IInstallableUnit, List<String>>();
+		List<String> keys = iuPropertiesToRemove.get(iu);
+		if (keys == null) {
+			keys = new ArrayList<String>();
+			iuPropertiesToRemove.put(iu, keys);
+		}
+		if (!keys.contains(key))
+			keys.add(key);
+	}
+
+	public Collection<IInstallableUnit> getRemovals() {
+		if (iusToRemove == null)
+			return CollectionUtils.emptyList();
+		return Collections.unmodifiableList(iusToRemove);
+	}
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.equinox.internal.provisional.p2.director.IPCR#getAddedInstallableUnits()
+	 */
+	public Collection<IInstallableUnit> getAdditions() {
+		if (iusToAdd == null)
+			return CollectionUtils.emptyList();
+		return Collections.unmodifiableList(iusToAdd);
+	}
+
+	// String [key, key, key] names of properties to remove
+	public String[] getPropertiesToRemove() {
+		if (propertiesToRemove == null)
+			return new String[0];
+		return propertiesToRemove.toArray(new String[propertiesToRemove.size()]);
+	}
+
+	// map of key value pairs
+	public Map<String, String> getPropertiesToAdd() {
+		if (propertiesToAdd == null)
+			return CollectionUtils.emptyMap();
+		return propertiesToAdd;
+	}
+
+	// map of iu->list of property keys to be removed for an iu	
+	public Map<IInstallableUnit, List<String>> getInstallableUnitProfilePropertiesToRemove() {
+		if (iuPropertiesToRemove == null)
+			return CollectionUtils.emptyMap();
+		return iuPropertiesToRemove;
+	}
+
+	// TODO This can be represented and returned in whatever way makes most sense for planner/engine
+	// map iu->map of key->value pairs for properties to be added for an iu
+	public Map<IInstallableUnit, Map<String, String>> getInstallableUnitProfilePropertiesToAdd() {
+		if (iuPropertiesToAdd == null)
+			return CollectionUtils.emptyMap();
+		return iuPropertiesToAdd;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.equinox.internal.provisional.p2.director.IPCR#setInstallableUnitInclusionRules(org.eclipse.equinox.p2.metadata.IInstallableUnit, java.lang.String)
+	 */
+	public void setInstallableUnitInclusionRules(IInstallableUnit iu, String value) {
+		setInstallableUnitProfileProperty(iu, SimplePlanner.INCLUSION_RULES, value);
+	}
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.equinox.internal.provisional.p2.director.IPCR#removeInstallableUnitInclusionRules(org.eclipse.equinox.p2.metadata.IInstallableUnit)
+	 */
+	public void removeInstallableUnitInclusionRules(IInstallableUnit iu) {
+		removeInstallableUnitProfileProperty(iu, SimplePlanner.INCLUSION_RULES);
+	}
+
+	@SuppressWarnings("unchecked")
+	public Object clone() {
+		ProfileChangeRequest result = new ProfileChangeRequest(profile);
+		result.iusToRemove = iusToRemove == null ? null : (ArrayList<IInstallableUnit>) iusToRemove.clone();
+		result.iusToAdd = iusToAdd == null ? null : (ArrayList<IInstallableUnit>) iusToAdd.clone();
+		result.propertiesToRemove = propertiesToRemove == null ? null : (ArrayList<String>) propertiesToRemove.clone();
+		result.propertiesToAdd = propertiesToAdd == null ? null : (HashMap<String, String>) propertiesToAdd.clone();
+		result.iuPropertiesToAdd = iuPropertiesToAdd == null ? null : (HashMap<IInstallableUnit, Map<String, String>>) iuPropertiesToAdd.clone();
+		result.iuPropertiesToRemove = iuPropertiesToRemove == null ? null : (HashMap<IInstallableUnit, List<String>>) iuPropertiesToRemove.clone();
+		result.additionalRequirements = additionalRequirements == null ? null : (ArrayList<IRequirement>) additionalRequirements.clone();
+		return result;
+	}
+
+	public String toString() {
+		StringBuffer result = new StringBuffer(1000);
+		result.append("==Profile change request for "); //$NON-NLS-1$
+		result.append(profile.getProfileId());
+		result.append('\n');
+		if (iusToAdd != null) {
+			result.append("==Additions=="); //$NON-NLS-1$
+			result.append('\n');
+			for (IInstallableUnit iu : iusToAdd) {
+				result.append('\t');
+				result.append(iu);
+				result.append('\n');
+			}
+		}
+		if (iusToRemove != null) {
+			result.append("==Removals=="); //$NON-NLS-1$
+			result.append('\n');
+			for (IInstallableUnit iu : iusToRemove) {
+				result.append('\t');
+				result.append(iu);
+				result.append('\n');
+			}
+		}
+		return result.toString();
+	}
+
+	public void addExtraRequirements(Collection<IRequirement> requirements) {
+		if (additionalRequirements == null)
+			additionalRequirements = new ArrayList<IRequirement>(requirements.size());
+		additionalRequirements.addAll(requirements);
+	}
+
+	public Collection<IRequirement> getExtraRequirements() {
+		return additionalRequirements;
+	}
+
+	public void clearExtraRequirements() {
+		additionalRequirements = null;
+	}
+}

--- a/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/director/Projector.java
+++ b/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/director/Projector.java
@@ -1,0 +1,1106 @@
+/*******************************************************************************
+ * Copyright (c) 2007, 2013 IBM Corporation and others. All rights reserved. This
+ * program and the accompanying materials are made available under the terms of
+ * the Eclipse Public License v1.0 which accompanies this distribution, and is
+ * available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors: 
+ *   IBM Corporation - initial API and implementation
+ *   Daniel Le Berre - Fix in the encoding and the optimization function
+ *   Alban Browaeys - Optimized string concatenation in bug 251357
+ *   Jed Anderson - switch from opb files to API calls to DependencyHelper in bug 200380
+ *   Sonatype, Inc. - ongoing development
+ *   Rapicorp, Inc. - split the optimization function
+ *   Red Hat, Inc. - support for remediation page
+ ******************************************************************************/
+package org.eclipse.equinox.internal.p2.director;
+
+import java.util.*;
+import java.util.Map.Entry;
+import org.eclipse.core.runtime.*;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.equinox.internal.p2.core.helpers.CollectionUtils;
+import org.eclipse.equinox.internal.p2.core.helpers.Tracing;
+import org.eclipse.equinox.internal.p2.director.Explanation.NotInstallableRoot;
+import org.eclipse.equinox.internal.p2.metadata.IRequiredCapability;
+import org.eclipse.equinox.internal.p2.metadata.InstallableUnit;
+import org.eclipse.equinox.p2.metadata.*;
+import org.eclipse.equinox.p2.metadata.expression.IMatchExpression;
+import org.eclipse.equinox.p2.query.*;
+import org.eclipse.osgi.util.NLS;
+import org.sat4j.minisat.restarts.LubyRestarts;
+import org.sat4j.pb.*;
+import org.sat4j.pb.core.PBSolverResolution;
+import org.sat4j.pb.tools.*;
+import org.sat4j.specs.*;
+
+/**
+ * This class is the interface between SAT4J and the planner. It produces a
+ * boolean satisfiability problem, invokes the solver, and converts the solver result
+ * back into information understandable by the planner.
+ */
+public class Projector {
+	/**
+	 * The name of a Java system property specifying the timeout to set in the SAT solver.
+	 * Note this value is not a time, but rather a conflict count. Essentially the solver
+	 * will give up on a particular solution path when this number of conflicts is reached.
+	 */
+	private static final String PROP_PROJECTOR_TIMEOUT = "eclipse.p2.projector.timeout"; //$NON-NLS-1$
+	/**
+	 * The default SAT solver timeout (in number of conflicts). See bug 372529 for discussion.
+	 */
+	private static final int DEFAULT_SOLVER_TIMEOUT = 10000;
+	static boolean DEBUG = Tracing.DEBUG_PLANNER_PROJECTOR;
+	private static boolean DEBUG_ENCODING = Tracing.DEBUG_PLANNER_PROJECTOR_ENCODING;
+	private IQueryable<IInstallableUnit> picker;
+	private QueryableArray patches;
+
+	private List<AbstractVariable> allOptionalAbstractRequirements;
+	private List<AbstractVariable> abstractVariables;
+
+	private Map<String, Map<Version, IInstallableUnit>> slice; //The IUs that have been considered to be part of the problem
+
+	private IInstallableUnit selectionContext;
+
+	DependencyHelper<Object, Explanation> dependencyHelper;
+	private Collection<IInstallableUnit> solution;
+	private Collection<Object> assumptions;
+
+	private MultiStatus result;
+
+	private Collection<IInstallableUnit> alreadyInstalledIUs;
+	private IQueryable<IInstallableUnit> lastState;
+
+	private boolean considerMetaRequirements;
+	private IInstallableUnit entryPoint;
+	private Map<IInstallableUnitFragment, Set<IInstallableUnit>> fragments = new HashMap<IInstallableUnitFragment, Set<IInstallableUnit>>();
+
+	//Non greedy things
+	private Set<IInstallableUnit> nonGreedyIUs; //All the IUs that would satisfy non greedy dependencies
+	private Map<IInstallableUnit, AbstractVariable> nonGreedyVariables = new HashMap<IInstallableUnit, AbstractVariable>();
+	private Map<AbstractVariable, List<Object>> nonGreedyProvider = new HashMap<AbstractVariable, List<Object>>(); //Keeps track of all the "object" that provide an IU that is non greedly requested  
+
+	private boolean emptyBecauseFiltered;
+	private boolean userDefinedFunction;
+
+	static class AbstractVariable {
+		//		private String name;
+
+		public AbstractVariable(String name) {
+			//						this.name = name;
+		}
+
+		public AbstractVariable() {
+			// TODO Auto-generated constructor stub
+		}
+
+		public String toString() {
+			return "AbstractVariable: " + hashCode(); //$NON-NLS-1$
+			//			return name == null ? "AbstractVariable: " + hashCode() : name; //$NON-NLS-1$
+		}
+	}
+
+	/**
+	 * Job for computing SAT failure explanation in the background.
+	 */
+	class ExplanationJob extends Job {
+		private Set<Explanation> explanation;
+
+		public ExplanationJob() {
+			super(Messages.Planner_NoSolution);
+			//explanations cannot be canceled directly, so don't show it to the user
+			setSystem(true);
+		}
+
+		public boolean belongsTo(Object family) {
+			return family == ExplanationJob.this;
+		}
+
+		protected void canceling() {
+			super.canceling();
+			dependencyHelper.stopExplanation();
+		}
+
+		public Set<Explanation> getExplanationResult() {
+			return explanation;
+		}
+
+		protected IStatus run(IProgressMonitor monitor) {
+			long start = 0;
+			if (DEBUG) {
+				start = System.currentTimeMillis();
+				Tracing.debug("Determining cause of failure: " + start); //$NON-NLS-1$
+			}
+			try {
+				explanation = dependencyHelper.why();
+				if (DEBUG) {
+					long stop = System.currentTimeMillis();
+					Tracing.debug("Explanation found: " + (stop - start)); //$NON-NLS-1$
+					Tracing.debug("Explanation:"); //$NON-NLS-1$
+					for (Explanation ex : explanation) {
+						Tracing.debug(ex.toString());
+					}
+				}
+			} catch (TimeoutException e) {
+				if (DEBUG)
+					Tracing.debug("Timeout while computing explanations"); //$NON-NLS-1$
+			} finally {
+				//must never have a null result, because caller is waiting on result to be non-null
+				if (explanation == null)
+					explanation = CollectionUtils.emptySet();
+			}
+			synchronized (this) {
+				ExplanationJob.this.notify();
+			}
+			return Status.OK_STATUS;
+		}
+
+	}
+
+	public Projector(IQueryable<IInstallableUnit> q, Map<String, String> context, Set<IInstallableUnit> nonGreedyIUs, boolean considerMetaRequirements) {
+		picker = q;
+		slice = new HashMap<String, Map<Version, IInstallableUnit>>();
+		selectionContext = InstallableUnit.contextIU(context);
+		abstractVariables = new ArrayList<AbstractVariable>();
+		allOptionalAbstractRequirements = new ArrayList<AbstractVariable>();
+		result = new MultiStatus(DirectorActivator.PI_DIRECTOR, IStatus.OK, Messages.Planner_Problems_resolving_plan, null);
+		assumptions = new ArrayList<Object>();
+		this.nonGreedyIUs = nonGreedyIUs;
+		this.considerMetaRequirements = considerMetaRequirements;
+	}
+
+	@SuppressWarnings("unchecked")
+	public void encode(IInstallableUnit entryPointIU, IInstallableUnit[] alreadyExistingRoots, IQueryable<IInstallableUnit> installedIUs, Collection<IInstallableUnit> newRoots, IProgressMonitor monitor) {
+		alreadyInstalledIUs = Arrays.asList(alreadyExistingRoots);
+		lastState = installedIUs;
+		this.entryPoint = entryPointIU;
+		try {
+			long start = 0;
+			if (DEBUG) {
+				start = System.currentTimeMillis();
+				Tracing.debug("Start projection: " + start); //$NON-NLS-1$
+			}
+			IPBSolver solver;
+			if (DEBUG_ENCODING) {
+				solver = new UserFriendlyPBStringSolver<Object>();
+			} else {
+				if (userDefinedFunction) {
+					PBSolverResolution mysolver = SolverFactory.newCompetPBResLongWLMixedConstraintsObjectiveExpSimp();
+					mysolver.setSimplifier(mysolver.SIMPLE_SIMPLIFICATION);
+					mysolver.setRestartStrategy(new LubyRestarts(512));
+					solver = mysolver;
+				} else {
+					solver = SolverFactory.newEclipseP2();
+				}
+			}
+			int timeout = DEFAULT_SOLVER_TIMEOUT;
+			String timeoutString = null;
+			try {
+				// allow the user to specify a longer timeout. 
+				// only set the value if it is a positive integer larger than the default.
+				// see https://bugs.eclipse.org/336967
+				timeoutString = DirectorActivator.context.getProperty(PROP_PROJECTOR_TIMEOUT);
+				if (timeoutString != null)
+					timeout = Math.max(timeout, Integer.parseInt(timeoutString));
+			} catch (Exception e) {
+				// intentionally catch all errors (npe, number format, etc)
+				// print out to syserr and fall through
+				System.err.println("Ignoring user-specified 'eclipse.p2.projector.timeout' value of: " + timeoutString); //$NON-NLS-1$
+				e.printStackTrace();
+			}
+			if (userDefinedFunction)
+				solver.setTimeoutOnConflicts(timeout / 4);
+			else
+				solver.setTimeoutOnConflicts(timeout);
+
+			IQueryResult<IInstallableUnit> queryResult = picker.query(QueryUtil.createIUAnyQuery(), null);
+			if (DEBUG_ENCODING) {
+				dependencyHelper = new LexicoHelper<Object, Explanation>(solver, false);
+				((UserFriendlyPBStringSolver<Object>) solver).setMapping(dependencyHelper.getMappingToDomain());
+			} else {
+				if (userDefinedFunction)
+					dependencyHelper = new SteppedTimeoutLexicoHelper<Object, Explanation>(solver);
+				else
+					dependencyHelper = new DependencyHelper<Object, Explanation>(solver);
+			}
+			List<IInstallableUnit> iusToOrder = new ArrayList<IInstallableUnit>(queryResult.toSet());
+			Collections.sort(iusToOrder);
+			for (Iterator<IInstallableUnit> iusToEncode = iusToOrder.iterator(); iusToEncode.hasNext();) {
+				if (monitor.isCanceled()) {
+					result.merge(Status.CANCEL_STATUS);
+					throw new OperationCanceledException();
+				}
+				IInstallableUnit iuToEncode = iusToEncode.next();
+				if (iuToEncode != entryPointIU) {
+					processIU(iuToEncode, false);
+				}
+			}
+			createMustHave(entryPointIU, alreadyExistingRoots);
+
+			createConstraintsForSingleton();
+
+			createConstraintsForNonGreedy();
+
+			createOptimizationFunction(entryPointIU, newRoots);
+			if (DEBUG) {
+				long stop = System.currentTimeMillis();
+				Tracing.debug("Projection complete: " + (stop - start)); //$NON-NLS-1$
+			}
+			if (DEBUG_ENCODING) {
+				System.out.println(solver.toString());
+			}
+		} catch (IllegalStateException e) {
+			result.add(new Status(IStatus.ERROR, DirectorActivator.PI_DIRECTOR, e.getMessage(), e));
+		} catch (ContradictionException e) {
+			result.add(new Status(IStatus.ERROR, DirectorActivator.PI_DIRECTOR, Messages.Planner_Unsatisfiable_problem));
+		}
+	}
+
+	private void createConstraintsForNonGreedy() throws ContradictionException {
+		for (IInstallableUnit iu : nonGreedyIUs) {
+			AbstractVariable var = getNonGreedyVariable(iu);
+			List<Object> providers = nonGreedyProvider.get(var);
+			if (providers == null || providers.size() == 0) {
+				dependencyHelper.setFalse(var, new Explanation.MissingGreedyIU(iu));
+			} else {
+				createImplication(var, providers, Explanation.OPTIONAL_REQUIREMENT);//FIXME
+			}
+		}
+
+	}
+
+	private void createOptimizationFunction(IInstallableUnit entryPointIU, Collection<IInstallableUnit> newRoots) {
+		if (!userDefinedFunction) {
+			createStandardOptimizationFunction(entryPointIU, newRoots);
+		} else {
+			createUserDefinedOptimizationFunction(entryPointIU, newRoots);
+		}
+	}
+
+	//Create an optimization function favoring the highest version of each IU
+	private void createStandardOptimizationFunction(IInstallableUnit entryPointIU, Collection<IInstallableUnit> newRoots) {
+		List<WeightedObject<? extends Object>> weights = new OptimizationFunction(lastState, abstractVariables, allOptionalAbstractRequirements, picker, selectionContext, slice).createOptimizationFunction(entryPointIU, newRoots);
+		createObjectiveFunction(weights);
+	}
+
+	private void createUserDefinedOptimizationFunction(IInstallableUnit entryPointIU, Collection<IInstallableUnit> newRoots) {
+		List<WeightedObject<? extends Object>> weights = new UserDefinedOptimizationFunction(lastState, abstractVariables, allOptionalAbstractRequirements, picker, selectionContext, slice, dependencyHelper, alreadyInstalledIUs).createOptimizationFunction(entryPointIU, newRoots);
+		createObjectiveFunction(weights);
+	}
+
+	private void createObjectiveFunction(List<WeightedObject<? extends Object>> weightedObjects) {
+		if (weightedObjects == null)
+			return;
+		if (DEBUG) {
+			StringBuffer b = new StringBuffer();
+			for (WeightedObject<? extends Object> object : weightedObjects) {
+				if (b.length() > 0)
+					b.append(", "); //$NON-NLS-1$
+				b.append(object.getWeight());
+				b.append(' ');
+				b.append(object.thing);
+			}
+			Tracing.debug("objective function: " + b); //$NON-NLS-1$
+		}
+		@SuppressWarnings("unchecked")
+		WeightedObject<Object>[] array = (WeightedObject<Object>[]) weightedObjects.toArray(new WeightedObject<?>[weightedObjects.size()]);
+		dependencyHelper.setObjectiveFunction(array);
+	}
+
+	private void createMustHave(IInstallableUnit iu, IInstallableUnit[] alreadyExistingRoots) throws ContradictionException {
+		processIU(iu, true);
+		if (DEBUG) {
+			Tracing.debug(iu + "=1"); //$NON-NLS-1$
+		}
+		// dependencyHelper.setTrue(variable, new Explanation.IUToInstall(iu));
+		assumptions.add(iu);
+	}
+
+	private void createNegation(IInstallableUnit iu, IRequirement req) throws ContradictionException {
+		if (DEBUG) {
+			Tracing.debug(iu + "=0"); //$NON-NLS-1$
+		}
+		dependencyHelper.setFalse(iu, new Explanation.MissingIU(iu, req, iu == this.entryPoint));
+	}
+
+	// Check whether the requirement is applicable
+	private boolean isApplicable(IRequirement req) {
+		IMatchExpression<IInstallableUnit> filter = req.getFilter();
+		return filter == null || filter.isMatch(selectionContext);
+	}
+
+	private boolean isApplicable(IInstallableUnit iu) {
+		IMatchExpression<IInstallableUnit> filter = iu.getFilter();
+		return filter == null || filter.isMatch(selectionContext);
+	}
+
+	private void expandNegatedRequirement(IRequirement req, IInstallableUnit iu, List<AbstractVariable> optionalAbstractRequirements, boolean isRootIu) throws ContradictionException {
+		if (!isApplicable(req))
+			return;
+		List<IInstallableUnit> matches = getApplicableMatches(req);
+		if (matches.isEmpty()) {
+			return;
+		}
+		Explanation explanation;
+		if (isRootIu) {
+			IInstallableUnit reqIu = matches.get(0);
+			if (alreadyInstalledIUs.contains(reqIu)) {
+				explanation = new Explanation.IUInstalled(reqIu);
+			} else {
+				explanation = new Explanation.IUToInstall(reqIu);
+			}
+		} else {
+			explanation = new Explanation.HardRequirement(iu, req);
+		}
+		createNegationImplication(iu, matches, explanation);
+	}
+
+	private void determinePotentialHostsForFragment(IInstallableUnit iu) {
+		// determine matching hosts only for fragments
+		if (!(iu instanceof IInstallableUnitFragment))
+			return;
+
+		IInstallableUnitFragment fragment = (IInstallableUnitFragment) iu;
+		// for each host requirement, find matches and remember them 
+		for (IRequirement req : fragment.getHost()) {
+			List<IInstallableUnit> matches = getApplicableMatches(req);
+			rememberHostMatches((IInstallableUnitFragment) iu, matches);
+		}
+	}
+
+	private void expandRequirement(IRequirement req, IInstallableUnit iu, List<AbstractVariable> optionalAbstractRequirements, boolean isRootIu) throws ContradictionException {
+		if (req.getMax() == 0) {
+			expandNegatedRequirement(req, iu, optionalAbstractRequirements, isRootIu);
+			return;
+		}
+		if (!isApplicable(req))
+			return;
+		List<IInstallableUnit> matches = getApplicableMatches(req);
+		determinePotentialHostsForFragment(iu);
+		if (req.getMin() > 0) {
+			if (matches.isEmpty()) {
+				if (iu == entryPoint && emptyBecauseFiltered) {
+					dependencyHelper.setFalse(iu, new NotInstallableRoot(req));
+				} else {
+					missingRequirement(iu, req);
+				}
+			} else {
+				if (req.isGreedy()) {
+					IInstallableUnit reqIu = matches.get(0);
+					Explanation explanation;
+					if (isRootIu) {
+						if (alreadyInstalledIUs.contains(reqIu)) {
+							explanation = new Explanation.IUInstalled(reqIu);
+						} else {
+							explanation = new Explanation.IUToInstall(reqIu);
+						}
+					} else {
+						explanation = new Explanation.HardRequirement(iu, req);
+					}
+					createImplication(iu, matches, explanation);
+					IInstallableUnit current;
+					for (Iterator<IInstallableUnit> it = matches.iterator(); it.hasNext();) {
+						current = it.next();
+						if (nonGreedyIUs.contains(current)) {
+							addNonGreedyProvider(getNonGreedyVariable(current), iu);
+						}
+					}
+				} else {
+					List<Object> newConstraint = new ArrayList<Object>(matches.size());
+					IInstallableUnit current;
+					for (Iterator<IInstallableUnit> it = matches.iterator(); it.hasNext();) {
+						current = it.next();
+						newConstraint.add(getNonGreedyVariable(current));
+					}
+					createImplication(new Object[] {iu}, newConstraint, new Explanation.HardRequirement(iu, req)); // FIXME
+				}
+			}
+		} else {
+			if (!matches.isEmpty()) {
+				IInstallableUnit current;
+				AbstractVariable abs;
+				if (req.isGreedy()) {
+					abs = getAbstractVariable(req);
+					createImplication(new Object[] {abs, iu}, matches, Explanation.OPTIONAL_REQUIREMENT);
+					for (Iterator<IInstallableUnit> it = matches.iterator(); it.hasNext();) {
+						current = it.next();
+						if (nonGreedyIUs.contains(current)) {
+							addNonGreedyProvider(getNonGreedyVariable(current), abs);
+						}
+					}
+					optionalAbstractRequirements.add(abs);
+				} else {
+					abs = getAbstractVariable(req, false);
+					List<Object> newConstraint = new ArrayList<Object>();
+					for (Iterator<IInstallableUnit> it = matches.iterator(); it.hasNext();) {
+						current = it.next();
+						newConstraint.add(getNonGreedyVariable(current));
+					}
+					createImplication(new Object[] {abs, iu}, newConstraint, Explanation.OPTIONAL_REQUIREMENT);
+				}
+			}
+		}
+	}
+
+	private void addNonGreedyProvider(AbstractVariable nonGreedyVariable, Object o) {
+		List<Object> providers = nonGreedyProvider.get(nonGreedyVariable);
+		if (providers == null) {
+			providers = new ArrayList<Object>();
+			nonGreedyProvider.put(nonGreedyVariable, providers);
+		}
+		providers.add(o);
+	}
+
+	private void expandRequirements(Collection<IRequirement> reqs, IInstallableUnit iu, boolean isRootIu) throws ContradictionException {
+		if (reqs.isEmpty())
+			return;
+		for (IRequirement req : reqs) {
+			expandRequirement(req, iu, allOptionalAbstractRequirements, isRootIu);
+		}
+	}
+
+	public void processIU(IInstallableUnit iu, boolean isRootIU) throws ContradictionException {
+		iu = iu.unresolved();
+		Map<Version, IInstallableUnit> iuSlice = slice.get(iu.getId());
+		if (iuSlice == null) {
+			iuSlice = new HashMap<Version, IInstallableUnit>();
+			slice.put(iu.getId(), iuSlice);
+		}
+		iuSlice.put(iu.getVersion(), iu);
+		if (!isApplicable(iu)) {
+			createNegation(iu, null);
+			return;
+		}
+
+		IQueryResult<IInstallableUnit> applicablePatches = getApplicablePatches(iu);
+		expandLifeCycle(iu, isRootIU);
+		//No patches apply, normal code path
+		if (applicablePatches.isEmpty()) {
+			expandRequirements(getRequiredCapabilities(iu), iu, isRootIU);
+		} else {
+			//Patches are applicable to the IU
+			expandRequirementsWithPatches(iu, applicablePatches, allOptionalAbstractRequirements, isRootIU);
+		}
+	}
+
+	private Collection<IRequirement> getRequiredCapabilities(IInstallableUnit iu) {
+		boolean isFragment = iu instanceof IInstallableUnitFragment;
+		//Short-circuit for the case of an IInstallableUnit 
+		if ((!isFragment) && iu.getMetaRequirements().size() == 0)
+			return iu.getRequirements();
+
+		ArrayList<IRequirement> aggregatedRequirements = new ArrayList<IRequirement>(iu.getRequirements().size() + iu.getMetaRequirements().size() + (isFragment ? ((IInstallableUnitFragment) iu).getHost().size() : 0));
+		aggregatedRequirements.addAll(iu.getRequirements());
+
+		if (iu instanceof IInstallableUnitFragment) {
+			aggregatedRequirements.addAll(((IInstallableUnitFragment) iu).getHost());
+		}
+
+		if (considerMetaRequirements)
+			aggregatedRequirements.addAll(iu.getMetaRequirements());
+		return aggregatedRequirements;
+	}
+
+	static final class Pending {
+		List<? super IInstallableUnitPatch> matches;
+		Explanation explanation;
+		Object left;
+	}
+
+	private void expandRequirementsWithPatches(IInstallableUnit iu, IQueryResult<IInstallableUnit> applicablePatches, List<AbstractVariable> optionalAbstractRequirements, boolean isRootIu) throws ContradictionException {
+		//Unmodified dependencies
+		Collection<IRequirement> iuRequirements = getRequiredCapabilities(iu);
+		Map<IRequirement, List<IInstallableUnitPatch>> unchangedRequirements = new HashMap<IRequirement, List<IInstallableUnitPatch>>(iuRequirements.size());
+		Map<IRequirement, Pending> nonPatchedRequirements = new HashMap<IRequirement, Pending>(iuRequirements.size());
+		for (Iterator<IInstallableUnit> iterator = applicablePatches.iterator(); iterator.hasNext();) {
+			IInstallableUnitPatch patch = (IInstallableUnitPatch) iterator.next();
+			IRequirement[][] reqs = mergeRequirements(iu, patch);
+			if (reqs.length == 0)
+				return;
+
+			// Optional requirements are encoded via:
+			// ABS -> (match1(req) or match2(req) or ... or matchN(req))
+			// noop(IU)-> ~ABS
+			// IU -> (noop(IU) or ABS)
+			// Therefore we only need one optional requirement statement per IU
+			for (int i = 0; i < reqs.length; i++) {
+				//The requirement is unchanged
+				if (reqs[i][0] == reqs[i][1]) {
+					if (reqs[i][0].getMax() == 0) {
+						expandNegatedRequirement(reqs[i][0], iu, optionalAbstractRequirements, isRootIu);
+						return;
+					}
+					if (!isApplicable(reqs[i][0]))
+						continue;
+
+					List<IInstallableUnitPatch> patchesAppliedElseWhere = unchangedRequirements.get(reqs[i][0]);
+					if (patchesAppliedElseWhere == null) {
+						patchesAppliedElseWhere = new ArrayList<IInstallableUnitPatch>();
+						unchangedRequirements.put(reqs[i][0], patchesAppliedElseWhere);
+					}
+					patchesAppliedElseWhere.add(patch);
+					continue;
+				}
+
+				//Generate dependency when the patch is applied
+				//P1 -> (A -> D) equiv. (P1 & A) -> D
+				if (isApplicable(reqs[i][1])) {
+					IRequirement req = reqs[i][1];
+					List<IInstallableUnit> matches = getApplicableMatches(req);
+					determinePotentialHostsForFragment(iu);
+					if (req.getMin() > 0) {
+						if (matches.isEmpty()) {
+							missingRequirement(patch, req);
+						} else {
+							IInstallableUnit current;
+							if (req.isGreedy()) {
+								IInstallableUnit reqIu = matches.get(0);
+								Explanation explanation;
+								if (isRootIu) {
+									if (alreadyInstalledIUs.contains(reqIu)) {
+										explanation = new Explanation.IUInstalled(reqIu);
+									} else {
+										explanation = new Explanation.IUToInstall(reqIu);
+									}
+								} else {
+									explanation = new Explanation.PatchedHardRequirement(iu, req, patch);
+								}
+								createImplication(new Object[] {patch, iu}, matches, explanation);
+								for (Iterator<IInstallableUnit> it = matches.iterator(); it.hasNext();) {
+									current = it.next();
+									if (nonGreedyIUs.contains(current)) {
+										addNonGreedyProvider(getNonGreedyVariable(current), iu);
+									}
+								}
+							} else {
+								List<Object> newConstraint = new ArrayList<Object>();
+								for (Iterator<IInstallableUnit> it = matches.iterator(); it.hasNext();) {
+									current = it.next();
+									newConstraint.add(getNonGreedyVariable(current));
+								}
+								createImplication(new Object[] {iu}, newConstraint, new Explanation.HardRequirement(iu, req)); // FIXME
+							}
+						}
+					} else {
+						if (!matches.isEmpty()) {
+							IInstallableUnit current;
+							AbstractVariable abs;
+							if (req.isGreedy()) {
+								abs = getAbstractVariable(req);
+								createImplication(new Object[] {patch, abs, iu}, matches, Explanation.OPTIONAL_REQUIREMENT);
+								for (Iterator<IInstallableUnit> it = matches.iterator(); it.hasNext();) {
+									current = it.next();
+									if (nonGreedyIUs.contains(current)) {
+										addNonGreedyProvider(getNonGreedyVariable(current), abs);
+									}
+								}
+								optionalAbstractRequirements.add(abs);
+							} else {
+								abs = getAbstractVariable(req, false);
+								List<Object> newConstraint = new ArrayList<Object>(matches.size());
+								for (Iterator<IInstallableUnit> it = matches.iterator(); it.hasNext();) {
+									current = it.next();
+									newConstraint.add(getNonGreedyVariable(current));
+								}
+								createImplication(new Object[] {patch, abs, iu}, newConstraint, Explanation.OPTIONAL_REQUIREMENT);
+							}
+						}
+					}
+				}
+				//Generate dependency when the patch is not applied
+				//-P1 -> (A -> B) ( equiv. A -> (P1 or B) )
+				if (isApplicable(reqs[i][0])) {
+					IRequirement req = reqs[i][0];
+
+					// Fix: if multiple patches apply to the same IU-req, we need to make sure we list each
+					// patch as an optional match
+					Pending pending = nonPatchedRequirements.get(req);
+					if (pending != null) {
+						pending.matches.add(patch);
+						continue;
+					}
+					pending = new Pending();
+					pending.left = iu;
+					List<IInstallableUnit> matches = getApplicableMatches(req);
+					determinePotentialHostsForFragment(iu);
+					if (req.getMin() > 0) {
+						if (matches.isEmpty()) {
+							matches.add(patch);
+							pending.explanation = new Explanation.HardRequirement(iu, req);
+							pending.matches = matches;
+						} else {
+							// manage non greedy IUs
+							IInstallableUnit current;
+							List<Object> nonGreedys = new ArrayList<Object>();
+							for (Iterator<IInstallableUnit> it = matches.iterator(); it.hasNext();) {
+								current = it.next();
+								if (nonGreedyIUs.contains(current)) {
+									nonGreedys.add(getNonGreedyVariable(current));
+								}
+							}
+							matches.add(patch);
+							if (req.isGreedy()) {
+								IInstallableUnit reqIu = matches.get(0);///(IInstallableUnit) picker.query(new CapabilityQuery(req), new Collector(), null).iterator().next();
+								Explanation explanation;
+								if (isRootIu) {
+									if (alreadyInstalledIUs.contains(reqIu)) {
+										explanation = new Explanation.IUInstalled(reqIu);
+									} else {
+										explanation = new Explanation.IUToInstall(reqIu);
+									}
+								} else {
+									explanation = new Explanation.HardRequirement(iu, req);
+								}
+
+								// Fix: make sure we collect all patches that will impact this IU-req, not just one
+								pending.explanation = explanation;
+								pending.matches = matches;
+								for (Iterator<IInstallableUnit> it = matches.iterator(); it.hasNext();) {
+									current = it.next();
+									if (nonGreedyIUs.contains(current)) {
+										addNonGreedyProvider(getNonGreedyVariable(current), iu);
+									}
+								}
+							} else {
+								List<Object> newConstraint = new ArrayList<Object>(matches.size());
+								for (Iterator<IInstallableUnit> it = matches.iterator(); it.hasNext();) {
+									current = it.next();
+									newConstraint.add(getNonGreedyVariable(current));
+								}
+								pending.explanation = new Explanation.HardRequirement(iu, req);
+								pending.matches = newConstraint;
+							}
+							nonPatchedRequirements.put(req, pending);
+
+						}
+					} else {
+						if (!matches.isEmpty()) {
+							IInstallableUnit current;
+							AbstractVariable abs;
+							matches.add(patch);
+							pending = new Pending();
+							pending.explanation = Explanation.OPTIONAL_REQUIREMENT;
+
+							if (req.isGreedy()) {
+								abs = getAbstractVariable(req);
+								// Fix: make sure we collect all patches that will impact this IU-req, not just one
+								pending.left = new Object[] {abs, iu};
+								pending.matches = matches;
+								for (Iterator<IInstallableUnit> it = matches.iterator(); it.hasNext();) {
+									current = it.next();
+									if (nonGreedyIUs.contains(current)) {
+										addNonGreedyProvider(getNonGreedyVariable(current), abs);
+									}
+								}
+							} else {
+								abs = getAbstractVariable(req, false);
+								List<Object> newConstraint = new ArrayList<Object>(matches.size());
+								for (Iterator<IInstallableUnit> it = matches.iterator(); it.hasNext();) {
+									current = it.next();
+									newConstraint.add(getNonGreedyVariable(current));
+								}
+								newConstraint.add(patch);
+								pending.left = new Object[] {abs, iu};
+								pending.matches = newConstraint;
+							}
+							nonPatchedRequirements.put(req, pending);
+							optionalAbstractRequirements.add(abs);
+						}
+					}
+				}
+			}
+		}
+
+		// Fix: now create the pending non-patch requirements based on the full set of patches
+		for (Pending pending : nonPatchedRequirements.values()) {
+			createImplication(pending.left, pending.matches, pending.explanation);
+		}
+
+		for (Entry<IRequirement, List<IInstallableUnitPatch>> entry : unchangedRequirements.entrySet()) {
+			List<IInstallableUnitPatch> patchesApplied = entry.getValue();
+			Iterator<IInstallableUnit> allPatches = applicablePatches.iterator();
+			List<IInstallableUnitPatch> requiredPatches = new ArrayList<IInstallableUnitPatch>();
+			while (allPatches.hasNext()) {
+				IInstallableUnitPatch patch = (IInstallableUnitPatch) allPatches.next();
+				if (!patchesApplied.contains(patch))
+					requiredPatches.add(patch);
+			}
+			IRequirement req = entry.getKey();
+			List<IInstallableUnit> matches = getApplicableMatches(req);
+			determinePotentialHostsForFragment(iu);
+			if (req.getMin() > 0) {
+				if (matches.isEmpty()) {
+					if (requiredPatches.isEmpty()) {
+						missingRequirement(iu, req);
+					} else {
+						createImplication(iu, requiredPatches, new Explanation.HardRequirement(iu, req));
+					}
+				} else {
+					// manage non greedy IUs
+					IInstallableUnit current;
+					List<Object> nonGreedys = new ArrayList<Object>(matches.size());
+					for (Iterator<IInstallableUnit> it = matches.iterator(); it.hasNext();) {
+						current = it.next();
+						if (nonGreedyIUs.contains(current)) {
+							nonGreedys.add(getNonGreedyVariable(current));
+						}
+					}
+					if (!requiredPatches.isEmpty())
+						matches.addAll(requiredPatches);
+					if (req.isGreedy()) {
+						IInstallableUnit reqIu = matches.get(0);
+						Explanation explanation;
+						if (isRootIu) {
+							if (alreadyInstalledIUs.contains(reqIu)) {
+								explanation = new Explanation.IUInstalled(reqIu);
+							} else {
+								explanation = new Explanation.IUToInstall(reqIu);
+							}
+						} else {
+							explanation = new Explanation.HardRequirement(iu, req);
+						}
+						createImplication(iu, matches, explanation);
+						for (Iterator<IInstallableUnit> it = matches.iterator(); it.hasNext();) {
+							current = it.next();
+							if (nonGreedyIUs.contains(current)) {
+								addNonGreedyProvider(getNonGreedyVariable(current), iu);
+							}
+						}
+					} else {
+						List<Object> newConstraint = new ArrayList<Object>(matches.size());
+						for (Iterator<IInstallableUnit> it = matches.iterator(); it.hasNext();) {
+							current = it.next();
+							newConstraint.add(getNonGreedyVariable(current));
+						}
+						createImplication(new Object[] {iu}, newConstraint, new Explanation.HardRequirement(iu, req)); // FIXME
+					}
+				}
+			} else {
+				if (!matches.isEmpty()) {
+					IInstallableUnit current;
+					if (!requiredPatches.isEmpty())
+						matches.addAll(requiredPatches);
+					AbstractVariable abs;
+					if (req.isGreedy()) {
+						abs = getAbstractVariable(req);
+						createImplication(new Object[] {abs, iu}, matches, Explanation.OPTIONAL_REQUIREMENT);
+						for (Iterator<IInstallableUnit> it = matches.iterator(); it.hasNext();) {
+							current = it.next();
+							if (nonGreedyIUs.contains(current)) {
+								addNonGreedyProvider(getNonGreedyVariable(current), iu);
+							}
+						}
+					} else {
+						abs = getAbstractVariable(req, false);
+						List<Object> newConstraint = new ArrayList<Object>(matches.size());
+						for (Iterator<IInstallableUnit> it = matches.iterator(); it.hasNext();) {
+							current = it.next();
+							newConstraint.add(getNonGreedyVariable(current));
+						}
+						createImplication(new Object[] {abs, iu}, newConstraint, new Explanation.HardRequirement(iu, req)); // FIXME
+					}
+					optionalAbstractRequirements.add(abs);
+				}
+			}
+		}
+	}
+
+	private void expandLifeCycle(IInstallableUnit iu, boolean isRootIu) throws ContradictionException {
+		if (!(iu instanceof IInstallableUnitPatch))
+			return;
+		IInstallableUnitPatch patch = (IInstallableUnitPatch) iu;
+		IRequirement req = patch.getLifeCycle();
+		if (req == null)
+			return;
+		expandRequirement(req, iu, CollectionUtils.<AbstractVariable> emptyList(), isRootIu);
+	}
+
+	private void missingRequirement(IInstallableUnit iu, IRequirement req) throws ContradictionException {
+		result.add(new Status(IStatus.WARNING, DirectorActivator.PI_DIRECTOR, NLS.bind(Messages.Planner_Unsatisfied_dependency, iu, req)));
+		createNegation(iu, req);
+	}
+
+	/**
+	 * @param req
+	 * @return a list of mandatory requirements if any, an empty list if req.isOptional().
+	 */
+	private List<IInstallableUnit> getApplicableMatches(IRequirement req) {
+		List<IInstallableUnit> target = new ArrayList<IInstallableUnit>();
+		IQueryResult<IInstallableUnit> matches = picker.query(QueryUtil.createMatchQuery(req.getMatches()), null);
+		for (Iterator<IInstallableUnit> iterator = matches.iterator(); iterator.hasNext();) {
+			IInstallableUnit match = iterator.next();
+			if (isApplicable(match)) {
+				target.add(match);
+			}
+		}
+		emptyBecauseFiltered = !matches.isEmpty() && target.isEmpty();
+		return target;
+	}
+
+	//Return a new array of requirements representing the application of the patch
+	private IRequirement[][] mergeRequirements(IInstallableUnit iu, IInstallableUnitPatch patch) {
+		if (patch == null)
+			return null;
+		List<IRequirementChange> changes = patch.getRequirementsChange();
+		Collection<IRequirement> iuRequirements = iu.getRequirements();
+		IRequirement[] originalRequirements = iuRequirements.toArray(new IRequirement[iuRequirements.size()]);
+		List<IRequirement[]> rrr = new ArrayList<IRequirement[]>();
+		boolean found = false;
+		for (int i = 0; i < changes.size(); i++) {
+			IRequirementChange change = changes.get(i);
+			for (int j = 0; j < originalRequirements.length; j++) {
+				if (originalRequirements[j] != null && safeMatch(originalRequirements, change, j)) {
+					found = true;
+					if (change.newValue() != null)
+						rrr.add(new IRequirement[] {originalRequirements[j], change.newValue()});
+					else
+						// case where a requirement is removed
+						rrr.add(new IRequirement[] {originalRequirements[j], null});
+					originalRequirements[j] = null;
+				}
+				//				break;
+			}
+			if (!found && change.applyOn() == null && change.newValue() != null) //Case where a new requirement is added
+				rrr.add(new IRequirement[] {null, change.newValue()});
+		}
+		//Add all the unmodified requirements to the result
+		for (int i = 0; i < originalRequirements.length; i++) {
+			if (originalRequirements[i] != null)
+				rrr.add(new IRequirement[] {originalRequirements[i], originalRequirements[i]});
+		}
+		return rrr.toArray(new IRequirement[rrr.size()][]);
+	}
+
+	private boolean safeMatch(IRequirement[] originalRequirements, IRequirementChange change, int j) {
+		try {
+			return change.matches((IRequiredCapability) originalRequirements[j]);
+		} catch (ClassCastException e) {
+			return false;
+		}
+	}
+
+	//This will create as many implication as there is element in the right argument
+	private void createNegationImplication(Object left, List<?> right, Explanation name) throws ContradictionException {
+		if (DEBUG) {
+			Tracing.debug(name + ": " + left + "->" + right); //$NON-NLS-1$ //$NON-NLS-2$
+		}
+		for (Object r : right)
+			dependencyHelper.implication(new Object[] {left}).impliesNot(r).named(name);
+	}
+
+	private void createImplication(Object left, List<?> right, Explanation name) throws ContradictionException {
+		if (DEBUG) {
+			Tracing.debug(name + ": " + left + "->" + right); //$NON-NLS-1$ //$NON-NLS-2$
+		}
+		dependencyHelper.implication(new Object[] {left}).implies(right.toArray()).named(name);
+	}
+
+	private void createImplication(Object[] left, List<?> right, Explanation name) throws ContradictionException {
+		if (DEBUG) {
+			Tracing.debug(name + ": " + Arrays.asList(left) + "->" + right); //$NON-NLS-1$ //$NON-NLS-2$
+		}
+		dependencyHelper.implication(left).implies(right.toArray()).named(name);
+	}
+
+	//Return IUPatches that are applicable for the given iu
+	private IQueryResult<IInstallableUnit> getApplicablePatches(IInstallableUnit iu) {
+		if (patches == null)
+			patches = new QueryableArray(picker.query(QueryUtil.createIUPatchQuery(), null).toArray(IInstallableUnit.class));
+
+		return patches.query(new ApplicablePatchQuery(iu), null);
+	}
+
+	//Create constraints to deal with singleton
+	//When there is a mix of singleton and non singleton, several constraints are generated
+	private void createConstraintsForSingleton() throws ContradictionException {
+		Set<Entry<String, Map<Version, IInstallableUnit>>> s = slice.entrySet();
+		for (Entry<String, Map<Version, IInstallableUnit>> entry : s) {
+			Map<Version, IInstallableUnit> conflictingEntries = entry.getValue();
+			if (conflictingEntries.size() < 2)
+				continue;
+
+			Collection<IInstallableUnit> conflictingVersions = conflictingEntries.values();
+			List<IInstallableUnit> singletons = new ArrayList<IInstallableUnit>();
+			List<IInstallableUnit> nonSingletons = new ArrayList<IInstallableUnit>();
+			for (IInstallableUnit iu : conflictingVersions) {
+				if (iu.isSingleton()) {
+					singletons.add(iu);
+				} else {
+					nonSingletons.add(iu);
+				}
+			}
+			if (singletons.isEmpty())
+				continue;
+
+			IInstallableUnit[] singletonArray;
+			if (nonSingletons.isEmpty()) {
+				singletonArray = singletons.toArray(new IInstallableUnit[singletons.size()]);
+				createAtMostOne(singletonArray);
+			} else {
+				singletonArray = singletons.toArray(new IInstallableUnit[singletons.size() + 1]);
+				for (IInstallableUnit nonSingleton : nonSingletons) {
+					singletonArray[singletonArray.length - 1] = nonSingleton;
+					createAtMostOne(singletonArray);
+				}
+			}
+		}
+	}
+
+	private void createAtMostOne(IInstallableUnit[] ius) throws ContradictionException {
+		if (DEBUG) {
+			StringBuffer b = new StringBuffer();
+			for (int i = 0; i < ius.length; i++) {
+				b.append(ius[i].toString());
+			}
+			Tracing.debug("At most 1 of " + b); //$NON-NLS-1$
+		}
+		dependencyHelper.atMost(1, (Object[]) ius).named(new Explanation.Singleton(ius));
+	}
+
+	private AbstractVariable getAbstractVariable(IRequirement req) {
+		return getAbstractVariable(req, true);
+	}
+
+	private AbstractVariable getAbstractVariable(IRequirement req, boolean appearInOptFunction) {
+		AbstractVariable abstractVariable = DEBUG_ENCODING ? new AbstractVariable("Abs_" + req.toString()) : new AbstractVariable(); //$NON-NLS-1$
+		if (appearInOptFunction) {
+			abstractVariables.add(abstractVariable);
+		}
+		return abstractVariable;
+	}
+
+	private AbstractVariable getNonGreedyVariable(IInstallableUnit iu) {
+		AbstractVariable v = nonGreedyVariables.get(iu);
+		if (v == null) {
+			v = DEBUG_ENCODING ? new AbstractVariable("NG_" + iu.toString()) : new AbstractVariable(); //$NON-NLS-1$
+			nonGreedyVariables.put(iu, v);
+		}
+		return v;
+	}
+
+	public IStatus invokeSolver(IProgressMonitor monitor) {
+		if (result.getSeverity() == IStatus.ERROR)
+			return result;
+		// CNF filename is given on the command line
+		long start = System.currentTimeMillis();
+		if (DEBUG)
+			Tracing.debug("Invoking solver: " + start); //$NON-NLS-1$
+		try {
+			if (monitor.isCanceled())
+				return Status.CANCEL_STATUS;
+			if (dependencyHelper.hasASolution(assumptions)) {
+				if (DEBUG) {
+					Tracing.debug("Satisfiable !"); //$NON-NLS-1$
+				}
+				backToIU();
+				long stop = System.currentTimeMillis();
+				if (DEBUG)
+					Tracing.debug("Solver solution found in: " + (stop - start) + " ms."); //$NON-NLS-1$ //$NON-NLS-2$
+			} else {
+				long stop = System.currentTimeMillis();
+				if (DEBUG) {
+					Tracing.debug("Unsatisfiable !"); //$NON-NLS-1$
+					Tracing.debug("Solver solution NOT found: " + (stop - start)); //$NON-NLS-1$
+				}
+				result = new MultiStatus(DirectorActivator.PI_DIRECTOR, SimplePlanner.UNSATISFIABLE, result.getChildren(), Messages.Planner_Unsatisfiable_problem, null);
+				result.merge(new Status(IStatus.ERROR, DirectorActivator.PI_DIRECTOR, SimplePlanner.UNSATISFIABLE, Messages.Planner_Unsatisfiable_problem, null));
+			}
+		} catch (TimeoutException e) {
+			result.merge(new Status(IStatus.ERROR, DirectorActivator.PI_DIRECTOR, Messages.Planner_Timeout));
+		} catch (Exception e) {
+			result.merge(new Status(IStatus.ERROR, DirectorActivator.PI_DIRECTOR, Messages.Planner_Unexpected_problem, e));
+		}
+		if (DEBUG)
+			System.out.println();
+		return result;
+	}
+
+	private void backToIU() {
+		solution = new ArrayList<IInstallableUnit>();
+		IVec<Object> sat4jSolution = dependencyHelper.getSolution();
+		for (Iterator<Object> iter = sat4jSolution.iterator(); iter.hasNext();) {
+			Object var = iter.next();
+			if (var instanceof IInstallableUnit) {
+				IInstallableUnit iu = (IInstallableUnit) var;
+				if (iu == entryPoint)
+					continue;
+				solution.add(iu);
+			}
+		}
+	}
+
+	private void printSolution(Collection<IInstallableUnit> state) {
+		ArrayList<IInstallableUnit> l = new ArrayList<IInstallableUnit>(state);
+		Collections.sort(l);
+		Tracing.debug("Solution:"); //$NON-NLS-1$
+		Tracing.debug("Numbers of IUs selected: " + l.size()); //$NON-NLS-1$
+		for (IInstallableUnit s : l) {
+			Tracing.debug(s.toString());
+		}
+	}
+
+	public Collection<IInstallableUnit> extractSolution() {
+		if (DEBUG)
+			printSolution(solution);
+		return solution;
+	}
+
+	public Set<Explanation> getExplanation(IProgressMonitor monitor) {
+		ExplanationJob job = new ExplanationJob();
+		job.schedule();
+		monitor.setTaskName(Messages.Planner_NoSolution);
+		IProgressMonitor pm = new InfiniteProgress(monitor);
+		pm.beginTask(Messages.Planner_NoSolution, 1000);
+		try {
+			synchronized (job) {
+				while (job.getExplanationResult() == null && job.getState() != Job.NONE) {
+					if (monitor.isCanceled()) {
+						job.cancel();
+						throw new OperationCanceledException();
+					}
+					pm.worked(1);
+					try {
+						job.wait(100);
+					} catch (InterruptedException e) {
+						if (DEBUG)
+							Tracing.debug("Interrupted while computing explanations"); //$NON-NLS-1$
+					}
+				}
+			}
+		} finally {
+			monitor.done();
+		}
+		return job.getExplanationResult();
+	}
+
+	public Map<IInstallableUnitFragment, List<IInstallableUnit>> getFragmentAssociation() {
+		Map<IInstallableUnitFragment, List<IInstallableUnit>> resolvedFragments = new HashMap<IInstallableUnitFragment, List<IInstallableUnit>>(fragments.size());
+		for (Entry<IInstallableUnitFragment, Set<IInstallableUnit>> fragment : fragments.entrySet()) {
+			if (!dependencyHelper.getBooleanValueFor(fragment.getKey()))
+				continue;
+			Set<IInstallableUnit> potentialHosts = fragment.getValue();
+			List<IInstallableUnit> resolvedHost = new ArrayList<IInstallableUnit>(potentialHosts.size());
+			for (IInstallableUnit host : potentialHosts) {
+				if (dependencyHelper.getBooleanValueFor(host))
+					resolvedHost.add(host);
+			}
+			if (resolvedHost.size() != 0)
+				resolvedFragments.put(fragment.getKey(), resolvedHost);
+		}
+		return resolvedFragments;
+	}
+
+	private void rememberHostMatches(IInstallableUnitFragment fragment, List<IInstallableUnit> matches) {
+		Set<IInstallableUnit> existingMatches = fragments.get(fragment);
+		if (existingMatches == null) {
+			existingMatches = new HashSet<IInstallableUnit>();
+			fragments.put(fragment, existingMatches);
+			existingMatches.addAll(matches);
+		}
+		existingMatches.retainAll(matches);
+	}
+
+	public void setUserDefined(boolean containsKey) {
+		userDefinedFunction = containsKey;
+	}
+}

--- a/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/director/QueryableArray.java
+++ b/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/director/QueryableArray.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2008, 2010 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *     Cloudsmith Inc. - query indexes
+ *******************************************************************************/
+package org.eclipse.equinox.internal.p2.director;
+
+import java.util.Iterator;
+import java.util.List;
+import org.eclipse.equinox.internal.p2.core.helpers.CollectionUtils;
+import org.eclipse.equinox.internal.p2.metadata.InstallableUnit;
+import org.eclipse.equinox.internal.p2.metadata.TranslationSupport;
+import org.eclipse.equinox.internal.p2.metadata.index.*;
+import org.eclipse.equinox.p2.metadata.IInstallableUnit;
+import org.eclipse.equinox.p2.metadata.KeyWithLocale;
+import org.eclipse.equinox.p2.metadata.index.IIndex;
+
+public class QueryableArray extends IndexProvider<IInstallableUnit> {
+	private final List<IInstallableUnit> dataSet;
+	private IIndex<IInstallableUnit> capabilityIndex;
+	private IIndex<IInstallableUnit> idIndex;
+	private TranslationSupport translationSupport;
+
+	public QueryableArray(IInstallableUnit[] ius) {
+		dataSet = CollectionUtils.unmodifiableList(ius);
+	}
+
+	public Iterator<IInstallableUnit> everything() {
+		return dataSet.iterator();
+	}
+
+	public synchronized IIndex<IInstallableUnit> getIndex(String memberName) {
+		if (InstallableUnit.MEMBER_PROVIDED_CAPABILITIES.equals(memberName)) {
+			if (capabilityIndex == null)
+				capabilityIndex = new CapabilityIndex(dataSet.iterator());
+			return capabilityIndex;
+		}
+		if (InstallableUnit.MEMBER_ID.equals(memberName)) {
+			if (idIndex == null)
+				idIndex = new IdIndex(dataSet.iterator());
+			return idIndex;
+		}
+		return null;
+	}
+
+	public synchronized Object getManagedProperty(Object client, String memberName, Object key) {
+		if (!(client instanceof IInstallableUnit))
+			return null;
+		IInstallableUnit iu = (IInstallableUnit) client;
+		if (InstallableUnit.MEMBER_TRANSLATED_PROPERTIES.equals(memberName)) {
+			if (translationSupport == null)
+				translationSupport = new TranslationSupport(this);
+			return key instanceof KeyWithLocale ? translationSupport.getIUProperty(iu, (KeyWithLocale) key) : translationSupport.getIUProperty(iu, key.toString());
+		}
+		return null;
+	}
+}

--- a/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/director/SimpleDirector.java
+++ b/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/director/SimpleDirector.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2007, 2010 IBM Corporation and others. All rights reserved. This
+ * program and the accompanying materials are made available under the terms of
+ * the Eclipse Public License v1.0 which accompanies this distribution, and is
+ * available at http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors: 
+ *     IBM Corporation - initial API and implementation
+ *     Sonatype, Inc. - ongoing development
+ ******************************************************************************/
+package org.eclipse.equinox.internal.p2.director;
+
+import java.util.Collection;
+import org.eclipse.core.runtime.*;
+import org.eclipse.equinox.internal.provisional.p2.director.IDirector;
+import org.eclipse.equinox.internal.provisional.p2.director.PlanExecutionHelper;
+import org.eclipse.equinox.p2.engine.*;
+import org.eclipse.equinox.p2.metadata.IInstallableUnit;
+import org.eclipse.equinox.p2.planner.IPlanner;
+import org.eclipse.equinox.p2.planner.IProfileChangeRequest;
+import org.eclipse.osgi.util.NLS;
+
+public class SimpleDirector implements IDirector {
+	static final int PlanWork = 10;
+	static final int EngineWork = 100;
+	private IEngine engine;
+	private IPlanner planner;
+
+	public SimpleDirector(IEngine engine, IPlanner planner) {
+		if (engine == null)
+			throw new IllegalStateException("Provisioning engine is not registered"); //$NON-NLS-1$
+		this.engine = engine;
+		if (planner == null)
+			throw new IllegalStateException("Unable to find provisioning planner"); //$NON-NLS-1$
+		this.planner = planner;
+	}
+
+	public IStatus revert(IProfile currentProfile, IProfile revertProfile, ProvisioningContext context, IProgressMonitor monitor) {
+		SubMonitor sub = SubMonitor.convert(monitor, Messages.Director_Task_Updating, PlanWork + EngineWork);
+		try {
+			IProvisioningPlan plan = planner.getDiffPlan(currentProfile, revertProfile, sub.newChild(PlanWork));
+			return PlanExecutionHelper.executePlan(plan, engine, context, sub.newChild(EngineWork));
+		} finally {
+			sub.done();
+		}
+	}
+
+	public IStatus provision(IProfileChangeRequest request, ProvisioningContext context, IProgressMonitor monitor) {
+		String taskName = NLS.bind(Messages.Director_Task_Installing, ((ProfileChangeRequest) request).getProfile().getProperty(IProfile.PROP_INSTALL_FOLDER));
+		SubMonitor sub = SubMonitor.convert(monitor, taskName, PlanWork + EngineWork);
+		try {
+			Collection<IInstallableUnit> installRoots = request.getAdditions();
+			// mark the roots as such
+			for (IInstallableUnit root : installRoots) {
+				request.setInstallableUnitProfileProperty(root, IProfile.PROP_PROFILE_ROOT_IU, Boolean.toString(true));
+			}
+			IProvisioningPlan plan = planner.getProvisioningPlan(request, context, sub.newChild(PlanWork));
+			return PlanExecutionHelper.executePlan(plan, engine, context, sub.newChild(EngineWork));
+		} finally {
+			sub.done();
+		}
+	}
+}

--- a/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/director/SimplePlanner.java
+++ b/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/director/SimplePlanner.java
@@ -1,0 +1,855 @@
+/*******************************************************************************
+ * Copyright (c) 2007, 2013 IBM Corporation and others. All rights reserved. This
+ * program and the accompanying materials are made available under the terms of
+ * the Eclipse Public License v1.0 which accompanies this distribution, and is
+ * available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * 	IBM Corporation - initial API and implementation
+ * 	Genuitec - bug fixes
+ *  Sonatype, Inc. - ongoing development
+ *  Red Hat, Inc. - support for remediation page
+ ******************************************************************************/
+package org.eclipse.equinox.internal.p2.director;
+
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.util.*;
+
+import org.eclipse.core.runtime.*;
+import org.eclipse.equinox.internal.p2.core.helpers.LogHelper;
+import org.eclipse.equinox.internal.p2.core.helpers.Tracing;
+import org.eclipse.equinox.internal.p2.director.Explanation.MissingIU;
+import org.eclipse.equinox.internal.p2.metadata.IRequiredCapability;
+import org.eclipse.equinox.internal.p2.metadata.query.UpdateQuery;
+import org.eclipse.equinox.internal.p2.rollback.FormerState;
+import org.eclipse.equinox.internal.provisional.p2.director.PlannerStatus;
+import org.eclipse.equinox.internal.provisional.p2.director.RequestStatus;
+import org.eclipse.equinox.p2.core.IAgentLocation;
+import org.eclipse.equinox.p2.core.IProvisioningAgent;
+import org.eclipse.equinox.p2.engine.*;
+import org.eclipse.equinox.p2.engine.query.IUProfilePropertyQuery;
+import org.eclipse.equinox.p2.metadata.*;
+import org.eclipse.equinox.p2.metadata.MetadataFactory.InstallableUnitDescription;
+import org.eclipse.equinox.p2.planner.*;
+import org.eclipse.equinox.p2.query.*;
+import org.eclipse.osgi.util.NLS;
+
+public class SimplePlanner implements IPlanner {
+	private static boolean DEBUG = Tracing.DEBUG_PLANNER_OPERANDS;
+
+	private static final int ExpandWork = 12;
+	private static final String INCLUDE_PROFILE_IUS = "org.eclipse.equinox.p2.internal.profileius"; //$NON-NLS-1$
+	public static final String INCLUSION_RULES = "org.eclipse.equinox.p2.internal.inclusion.rules"; //$NON-NLS-1$
+	private static final String ID_IU_FOR_ACTIONS = "org.eclipse.equinox.p2.engine.actions.root"; //$NON-NLS-1$
+	private static final String EXPLANATION = "org.eclipse.equinox.p2.director.explain"; //$NON-NLS-1$
+	private static final String CONSIDER_METAREQUIREMENTS = "org.eclipse.equinox.p2.planner.resolveMetaRequirements"; //$NON-NLS-1$
+	
+	private static final String COM_APPCELERATOR_TITANIUM_FEATURE = "com.appcelerator.titanium"; //$NON-NLS-1$
+
+	static final int UNSATISFIABLE = 1; //status code indicating that the problem is not satisfiable
+
+	private final IProvisioningAgent agent;
+	private final IProfileRegistry profileRegistry;
+	private final IEngine engine;
+
+	private IProvisioningPlan generateProvisioningPlan(Collection<IInstallableUnit> fromState, Collection<IInstallableUnit> toState, ProfileChangeRequest changeRequest, IProvisioningPlan installerPlan, ProvisioningContext context) {
+		IProvisioningPlan plan = engine.createPlan(changeRequest.getProfile(), context);
+		plan.setFuturePlan(new CollectionResult<IInstallableUnit>(toState));
+		planIUOperations(plan, fromState, toState);
+		planPropertyOperations(plan, changeRequest, toState);
+
+		if (DEBUG) {
+			Object[] operands = new Object[0];
+			try {
+				Method getOperands = plan.getClass().getMethod("getOperands", new Class[0]); //$NON-NLS-1$
+				operands = (Object[]) getOperands.invoke(plan, new Object[0]);
+			} catch (Throwable e) {
+				// ignore
+			}
+			for (int i = 0; i < operands.length; i++) {
+				Tracing.debug(operands[i].toString());
+			}
+		}
+
+		Map<IInstallableUnit, RequestStatus>[] changes = computeActualChangeRequest(toState, changeRequest);
+		Map<IInstallableUnit, RequestStatus> requestChanges = (changes == null) ? null : changes[0];
+		Map<IInstallableUnit, RequestStatus> requestSideEffects = (changes == null) ? null : changes[1];
+		QueryableArray plannedState = new QueryableArray(toState.toArray(new IInstallableUnit[toState.size()]));
+		PlannerStatus plannerStatus = new PlannerStatus(Status.OK_STATUS, null, requestChanges, requestSideEffects, plannedState);
+		plan.setStatus(plannerStatus);
+		plan.setInstallerPlan(installerPlan);
+		return plan;
+	}
+
+	private Map<IInstallableUnit, RequestStatus>[] buildDetailedErrors(ProfileChangeRequest changeRequest) {
+		Collection<IInstallableUnit> requestedAdditions = changeRequest.getAdditions();
+		Collection<IInstallableUnit> requestedRemovals = changeRequest.getRemovals();
+		Map<IInstallableUnit, RequestStatus> requestStatus = new HashMap<IInstallableUnit, RequestStatus>(requestedAdditions.size() + requestedAdditions.size());
+		for (IInstallableUnit added : requestedAdditions) {
+			requestStatus.put(added, new RequestStatus(added, RequestStatus.ADDED, IStatus.ERROR, null));
+		}
+		for (IInstallableUnit removed : requestedRemovals) {
+			requestStatus.put(removed, new RequestStatus(removed, RequestStatus.REMOVED, IStatus.ERROR, null));
+		}
+		@SuppressWarnings("unchecked")
+		Map<IInstallableUnit, RequestStatus>[] maps = new Map[] {requestStatus, null};
+		return maps;
+	}
+
+	private Map<IInstallableUnit, RequestStatus>[] computeActualChangeRequest(Collection<IInstallableUnit> toState, ProfileChangeRequest changeRequest) {
+		Collection<IInstallableUnit> requestedAdditions = changeRequest.getAdditions();
+		Collection<IInstallableUnit> requestedRemovals = new ArrayList<IInstallableUnit>(changeRequest.getRemovals());
+		requestedRemovals.removeAll(requestedAdditions);
+
+		Map<IInstallableUnit, RequestStatus> requestStatus = new HashMap<IInstallableUnit, RequestStatus>(requestedAdditions.size() + requestedRemovals.size());
+		for (IInstallableUnit added : requestedAdditions) {
+			if (toState.contains(added))
+				requestStatus.put(added, new RequestStatus(added, RequestStatus.ADDED, IStatus.OK, null));
+			else
+				requestStatus.put(added, new RequestStatus(added, RequestStatus.ADDED, IStatus.ERROR, null));
+		}
+
+		for (IInstallableUnit removed : requestedRemovals) {
+			if (!toState.contains(removed))
+				requestStatus.put(removed, new RequestStatus(removed, RequestStatus.REMOVED, IStatus.OK, null));
+			else
+				requestStatus.put(removed, new RequestStatus(removed, RequestStatus.REMOVED, IStatus.ERROR, null));
+		}
+
+		//Compute the side effect changes (e.g. things installed optionally going away)
+		Iterator<IInstallableUnit> includedIUs = changeRequest.getProfile().query(new IUProfilePropertyQuery(INCLUSION_RULES, IUProfilePropertyQuery.ANY), null).iterator();
+		Map<IInstallableUnit, RequestStatus> sideEffectStatus = new HashMap<IInstallableUnit, RequestStatus>();
+		while (includedIUs.hasNext()) {
+			IInstallableUnit removal = includedIUs.next();
+			if (!toState.contains(removal) && !requestStatus.containsKey(removal)) {
+				sideEffectStatus.put(removal, new RequestStatus(removal, RequestStatus.REMOVED, IStatus.INFO, null));
+			}
+		}
+		@SuppressWarnings("unchecked")
+		Map<IInstallableUnit, RequestStatus>[] maps = new Map[] {requestStatus, sideEffectStatus};
+		return maps;
+	}
+
+	/**
+	 * Converts a set containing a list of resolver explanations into a human-readable status object.
+	 */
+	private IStatus convertExplanationToStatus(Set<Explanation> explanations) {
+		if (explanations == null)
+			return new Status(IStatus.ERROR, DirectorActivator.PI_DIRECTOR, Messages.Director_Unsatisfied_Dependencies);
+
+		// hack to create a useful message when a user installs something intended for a target platform into the IDE
+		ArrayList<IStatus> forTargets = new ArrayList<IStatus>(0);
+		for (Explanation next : explanations) {
+			if (next instanceof Explanation.MissingIU) {
+				Explanation.MissingIU missingIU = (MissingIU) next;
+				if (missingIU.req instanceof IRequiredCapability && missingIU.req.getMatches().getParameters().length == 3 && "A.PDE.Target.Platform".equals(((IRequiredCapability) missingIU.req).getNamespace())) //$NON-NLS-1$
+					forTargets.add(new Status(IStatus.ERROR, DirectorActivator.PI_DIRECTOR, missingIU.getUserReadableName(missingIU.iu)));
+			}
+		}
+		if (forTargets.size() > 0) {
+			// add a blurb about disabling 'include required software'.  The following line could be removed if bug 309863 is fixed
+			forTargets.add(new Status(IStatus.ERROR, DirectorActivator.PI_DIRECTOR, Messages.Director_For_Target_Unselect_Required));
+			// return a multi status with all the IUs that require A.PDE.Target.Platform
+			return new MultiStatus(DirectorActivator.PI_DIRECTOR, 1, forTargets.toArray(new IStatus[forTargets.size()]), Messages.Director_For_Target, null);
+		}
+		MultiStatus root = new MultiStatus(DirectorActivator.PI_DIRECTOR, 1, Messages.Director_Unsatisfied_Dependencies, null);
+		//try to find a more specific root message if possible
+		String specificMessage = null;
+		int errorCode = 0;
+		for (Explanation next : explanations) {
+			root.add(next.toStatus());
+			if (specificMessage == null && next instanceof Explanation.MissingIU) {
+				specificMessage = Messages.Explanation_rootMissing;
+				errorCode = 10053;
+			} else if (specificMessage == null && next instanceof Explanation.Singleton) {
+				specificMessage = Messages.Explanation_rootSingleton;
+				errorCode = 10054;
+			}
+		}
+		//use a more specific root message if available
+		if (specificMessage != null) {
+			MultiStatus newRoot = new MultiStatus(DirectorActivator.PI_DIRECTOR, errorCode, specificMessage, null);
+			newRoot.merge(root);
+			root = newRoot;
+		}
+		return root;
+	}
+
+	private void planPropertyOperations(IProvisioningPlan plan, ProfileChangeRequest profileChangeRequest, Collection<IInstallableUnit> toState) {
+
+		// First deal with profile properties to remove.
+		String[] toRemove = profileChangeRequest.getPropertiesToRemove();
+		for (int i = 0; i < toRemove.length; i++) {
+			plan.setProfileProperty(toRemove[i], null);
+		}
+		// Now deal with profile property changes/additions
+		Map<String, String> propertyChanges = profileChangeRequest.getPropertiesToAdd();
+		for (Map.Entry<String, String> entry : propertyChanges.entrySet()) {
+			plan.setProfileProperty(entry.getKey(), entry.getValue());
+		}
+
+		// Now deal with iu property changes/additions.
+		Map<IInstallableUnit, Map<String, String>> allIUPropertyChanges = profileChangeRequest.getInstallableUnitProfilePropertiesToAdd();
+		for (Map.Entry<IInstallableUnit, Map<String, String>> entry : allIUPropertyChanges.entrySet()) {
+			IInstallableUnit iu = entry.getKey();
+			if (!toState.contains(iu))
+				continue;
+			for (Map.Entry<String, String> entry2 : entry.getValue().entrySet()) {
+				plan.setInstallableUnitProfileProperty(iu, entry2.getKey(), entry2.getValue());
+			}
+		}
+		// Now deal with iu property removals.
+		Map<IInstallableUnit, List<String>> allIUPropertyDeletions = profileChangeRequest.getInstallableUnitProfilePropertiesToRemove();
+		for (Map.Entry<IInstallableUnit, List<String>> entry : allIUPropertyDeletions.entrySet()) {
+			IInstallableUnit iu = entry.getKey();
+			List<String> iuPropertyRemovals = entry.getValue();
+			for (String key : iuPropertyRemovals) {
+				plan.setInstallableUnitProfileProperty(iu, key, null);
+			}
+
+		}
+	}
+
+	private void planIUOperations(IProvisioningPlan plan, Collection<IInstallableUnit> fromState, Collection<IInstallableUnit> toState) {
+		new OperationGenerator(plan).generateOperation(fromState, toState);
+	}
+
+	public IProvisioningPlan getDiffPlan(IProfile currentProfile, IProfile targetProfile, IProgressMonitor monitor) {
+		SubMonitor sub = SubMonitor.convert(monitor, ExpandWork);
+		sub.setTaskName(Messages.Director_Task_Resolving_Dependencies);
+		try {
+			IProfileChangeRequest profileChangeRequest = FormerState.generateProfileDeltaChangeRequest(currentProfile, targetProfile);
+			ProvisioningContext context = new ProvisioningContext(agent);
+			if (context.getProperty(INCLUDE_PROFILE_IUS) == null)
+				context.setProperty(INCLUDE_PROFILE_IUS, Boolean.FALSE.toString());
+			context.setExtraInstallableUnits(Arrays.asList(targetProfile.available(QueryUtil.createIUAnyQuery(), null).toArray(IInstallableUnit.class)));
+			return getProvisioningPlan(profileChangeRequest, context, sub.newChild(ExpandWork / 2));
+		} finally {
+			sub.done();
+		}
+	}
+
+	public static Collection<IInstallableUnit> findPlannerMarkedIUs(final IProfile profile) {
+		IQuery<IInstallableUnit> markerQuery = new IUProfilePropertyQuery(INCLUSION_RULES, IUProfilePropertyQuery.ANY);
+		return profile.query(markerQuery, null).toUnmodifiableSet();
+	}
+
+	public static Map<String, String> createSelectionContext(Map<String, String> properties) {
+		HashMap<String, String> result = new HashMap<String, String>(properties);
+		String environments = properties.get(IProfile.PROP_ENVIRONMENTS);
+		if (environments == null)
+			return result;
+		for (StringTokenizer tokenizer = new StringTokenizer(environments, ","); tokenizer.hasMoreElements();) { //$NON-NLS-1$
+			String entry = tokenizer.nextToken();
+			int i = entry.indexOf('=');
+			String key = entry.substring(0, i).trim();
+			String value = entry.substring(i + 1).trim();
+			result.put(key, value);
+		}
+		return result;
+	}
+
+	private IInstallableUnit[] gatherAvailableInstallableUnits(IInstallableUnit[] additionalSource, ProvisioningContext context, IProgressMonitor monitor) {
+		Map<String, IInstallableUnit> resultsMap = new HashMap<String, IInstallableUnit>();
+		if (additionalSource != null) {
+			for (int i = 0; i < additionalSource.length; i++) {
+				String key = additionalSource[i].getId() + "_" + additionalSource[i].getVersion().toString(); //$NON-NLS-1$
+				resultsMap.put(key, additionalSource[i]);
+			}
+		}
+		if (context == null) {
+			context = new ProvisioningContext(agent);
+		} else {
+			for (IInstallableUnit iu : context.getExtraInstallableUnits()) {
+				String key = iu.getId() + '_' + iu.getVersion().toString();
+				resultsMap.put(key, iu);
+			}
+		}
+		SubMonitor sub = SubMonitor.convert(monitor, 1000);
+		IQueryable<IInstallableUnit> queryable = context.getMetadata(sub.newChild(500));
+		IQueryResult<IInstallableUnit> matches = queryable.query(QueryUtil.createIUQuery(null, VersionRange.emptyRange), sub.newChild(500));
+		for (Iterator<IInstallableUnit> it = matches.iterator(); it.hasNext();) {
+			IInstallableUnit iu = it.next();
+			String key = iu.getId() + "_" + iu.getVersion().toString(); //$NON-NLS-1$
+			IInstallableUnit currentIU = resultsMap.get(key);
+			if (currentIU == null || hasHigherFidelity(iu, currentIU))
+				resultsMap.put(key, iu);
+		}
+		sub.done();
+		Collection<IInstallableUnit> results = resultsMap.values();
+		return results.toArray(new IInstallableUnit[results.size()]);
+	}
+
+	private static boolean hasHigherFidelity(IInstallableUnit iu, IInstallableUnit currentIU) {
+		if (Boolean.valueOf(currentIU.getProperty(IInstallableUnit.PROP_PARTIAL_IU)).booleanValue() && !Boolean.valueOf(iu.getProperty(IInstallableUnit.PROP_PARTIAL_IU)).booleanValue())
+			return true;
+		return false;
+	}
+
+	public SimplePlanner(IProvisioningAgent agent) {
+		Assert.isNotNull(agent);
+		this.agent = agent;
+		this.engine = (IEngine) agent.getService(IEngine.SERVICE_NAME);
+		this.profileRegistry = (IProfileRegistry) agent.getService(IProfileRegistry.SERVICE_NAME);
+		Assert.isNotNull(engine);
+		Assert.isNotNull(profileRegistry);
+	}
+
+	private boolean satisfyMetaRequirements(Map<String, String> props) {
+		if (props == null)
+			return true;
+		if (props.get(CONSIDER_METAREQUIREMENTS) == null || "true".equalsIgnoreCase(props.get(CONSIDER_METAREQUIREMENTS))) //$NON-NLS-1$
+			return true;
+		return false;
+	}
+
+	private boolean satisfyMetaRequirements(IProfile p) {
+		return satisfyMetaRequirements(p.getProperties());
+	}
+
+	// Return the set of IUs representing the complete future state of the profile to satisfy the request or return a 
+	// ProvisioningPlan when the request can not be satisfied
+	private Object getSolutionFor(ProfileChangeRequest profileChangeRequest, ProvisioningContext context, IProgressMonitor monitor) {
+		SubMonitor sub = SubMonitor.convert(monitor, ExpandWork);
+		sub.setTaskName(Messages.Director_Task_Resolving_Dependencies);
+		try {
+			IProfile profile = profileChangeRequest.getProfile();
+
+			Object[] updatedPlan = updatePlannerInfo(profileChangeRequest, context);
+
+			Map<String, String> newSelectionContext = createSelectionContext(profileChangeRequest.getProfileProperties());
+
+			List<IInstallableUnit> extraIUs = new ArrayList<IInstallableUnit>(profileChangeRequest.getAdditions());
+			extraIUs.addAll(profileChangeRequest.getRemovals());
+			if (context == null || context.getProperty(INCLUDE_PROFILE_IUS) == null || context.getProperty(INCLUDE_PROFILE_IUS).equalsIgnoreCase(Boolean.TRUE.toString())) {
+				Iterator<IInstallableUnit> itor = profile.available(QueryUtil.createIUAnyQuery(), null).iterator();
+				while (itor.hasNext())
+					extraIUs.add(itor.next());
+			}
+
+			IInstallableUnit[] availableIUs = gatherAvailableInstallableUnits(extraIUs.toArray(new IInstallableUnit[extraIUs.size()]), context, sub.newChild(ExpandWork / 4));
+
+			Slicer slicer = new Slicer(new QueryableArray(availableIUs), newSelectionContext, satisfyMetaRequirements(profileChangeRequest.getProfileProperties()));
+			IQueryable<IInstallableUnit> slice = slicer.slice(new IInstallableUnit[] {(IInstallableUnit) updatedPlan[0]}, sub.newChild(ExpandWork / 4));
+			if (slice == null) {
+				IProvisioningPlan plan = engine.createPlan(profile, context);
+				plan.setStatus(slicer.getStatus());
+				return plan;
+			}
+			@SuppressWarnings("unchecked")
+			final IQueryable<IInstallableUnit>[] queryables = new IQueryable[] {slice, new QueryableArray(profileChangeRequest.getAdditions().toArray(new IInstallableUnit[profileChangeRequest.getAdditions().size()]))};
+			slice = new CompoundQueryable<IInstallableUnit>(queryables);
+			Projector projector = new Projector(slice, newSelectionContext, slicer.getNonGreedyIUs(), satisfyMetaRequirements(profileChangeRequest.getProfileProperties()));
+			projector.setUserDefined(profileChangeRequest.getPropertiesToAdd().containsKey("_internal_user_defined_"));
+			projector.encode((IInstallableUnit) updatedPlan[0], (IInstallableUnit[]) updatedPlan[1], profile, profileChangeRequest.getAdditions(), sub.newChild(ExpandWork / 4));
+			IStatus s = projector.invokeSolver(sub.newChild(ExpandWork / 4));
+			if (s.getSeverity() == IStatus.CANCEL) {
+				IProvisioningPlan plan = engine.createPlan(profile, context);
+				plan.setStatus(s);
+				return plan;
+			}
+			if (s.getSeverity() == IStatus.ERROR) {
+				sub.setTaskName(Messages.Planner_NoSolution);
+				if (s.getCode() != UNSATISFIABLE || (context != null && !(context.getProperty(EXPLANATION) == null || Boolean.TRUE.toString().equalsIgnoreCase(context.getProperty(EXPLANATION))))) {
+					IProvisioningPlan plan = engine.createPlan(profile, context);
+					plan.setStatus(s);
+					return plan;
+				}
+
+				//Extract the explanation
+				Set<Explanation> explanation = projector.getExplanation(sub.newChild(ExpandWork / 4));
+				IStatus explanationStatus = convertExplanationToStatus(explanation);
+
+				Map<IInstallableUnit, RequestStatus>[] changes = buildDetailedErrors(profileChangeRequest);
+				Map<IInstallableUnit, RequestStatus> requestChanges = (changes == null) ? null : changes[0];
+				Map<IInstallableUnit, RequestStatus> requestSideEffects = (changes == null) ? null : changes[1];
+				PlannerStatus plannerStatus = new PlannerStatus(explanationStatus, new RequestStatus(null, RequestStatus.REMOVED, IStatus.ERROR, explanation), requestChanges, requestSideEffects, null);
+
+				IProvisioningPlan plan = engine.createPlan(profile, context);
+				plan.setStatus(plannerStatus);
+				return plan;
+			}
+			//The resolution succeeded. We can forget about the warnings since there is a solution.
+			if (Tracing.DEBUG && s.getSeverity() != IStatus.OK)
+				LogHelper.log(s);
+			s = Status.OK_STATUS;
+
+			return projector;
+		} finally {
+			sub.done();
+		}
+	}
+
+	public IProvisioningPlan getProvisioningPlan(IProfileChangeRequest request, ProvisioningContext context, IProgressMonitor monitor) {
+		ProfileChangeRequest pcr = (ProfileChangeRequest) request;
+		SubMonitor sub = SubMonitor.convert(monitor, ExpandWork);
+		sub.setTaskName(Messages.Director_Task_Resolving_Dependencies);
+		try {
+			//Get the solution for the initial request
+			Object resolutionResult = getSolutionFor(pcr, context, sub.newChild(ExpandWork / 2));
+			// a return value of a plan indicates failure when resolving so return.
+			if (resolutionResult instanceof IProvisioningPlan)
+				return (IProvisioningPlan) resolutionResult;
+
+			Collection<IInstallableUnit> newState = ((Projector) resolutionResult).extractSolution();
+			Collection<IInstallableUnit> fullState = new ArrayList<IInstallableUnit>();
+			fullState.addAll(newState);
+			newState = AttachmentHelper.attachFragments(newState.iterator(), ((Projector) resolutionResult).getFragmentAssociation());
+
+			IProvisioningPlan temporaryPlan = generatePlan((Projector) resolutionResult, newState, pcr, context);
+
+			//Create a plan for installing necessary pieces to complete the installation (e.g touchpoint actions)
+			return createInstallerPlan(pcr.getProfile(), pcr, fullState, newState, temporaryPlan, context, sub.newChild(ExpandWork / 2));
+		} catch (OperationCanceledException e) {
+			IProvisioningPlan plan = engine.createPlan(pcr.getProfile(), context);
+			plan.setStatus(Status.CANCEL_STATUS);
+			return plan;
+		} finally {
+			sub.done();
+		}
+	}
+
+	//	private IProvisioningPlan generateAbsoluteProvisioningPlan(ProfileChangeRequest profileChangeRequest, ProvisioningContext context, IProgressMonitor monitor) {
+	//		Set<IInstallableUnit> toState = profileChangeRequest.getProfile().query(QueryUtil.createIUAnyQuery(), null).toSet();
+	//		HashSet<IInstallableUnit> fromState = new HashSet<IInstallableUnit>(toState);
+	//		toState.removeAll(profileChangeRequest.getRemovals());
+	//		toState.addAll(profileChangeRequest.getAdditions());
+	//
+	//		IProvisioningPlan plan = engine.createPlan(profileChangeRequest.getProfile(), context);
+	//		planIUOperations(plan, fromState, toState);
+	//		planPropertyOperations(plan, profileChangeRequest);
+	//
+	//		if (DEBUG) {
+	//			Object[] operands = new Object[0];
+	//			try {
+	//				Method getOperands = plan.getClass().getMethod("getOperands", new Class[0]); //$NON-NLS-1$
+	//				operands = (Object[]) getOperands.invoke(plan, new Object[0]);
+	//			} catch (Throwable e) {
+	//				// ignore
+	//			}
+	//			for (int i = 0; i < operands.length; i++) {
+	//				Tracing.debug(operands[i].toString());
+	//			}
+	//		}
+	//		Map<IInstallableUnit, RequestStatus>[] changes = computeActualChangeRequest(toState, profileChangeRequest);
+	//		Map<IInstallableUnit, RequestStatus> requestChanges = (changes == null) ? null : changes[0];
+	//		Map<IInstallableUnit, RequestStatus> requestSideEffects = (changes == null) ? null : changes[1];
+	//		QueryableArray plannedState = new QueryableArray(toState.toArray(new IInstallableUnit[toState.size()]));
+	//		PlannerStatus plannerStatus = new PlannerStatus(Status.OK_STATUS, null, requestChanges, requestSideEffects, plannedState);
+	//		plan.setStatus(plannerStatus);
+	//		return plan;
+	//	}
+
+	//Verify that all the meta requirements necessary to perform the uninstallation (if necessary) and all t
+	private Collection<IRequirement> areMetaRequirementsSatisfied(IProfile oldProfile, Collection<IInstallableUnit> newProfile, IProvisioningPlan initialPlan) {
+		Collection<IRequirement> allMetaRequirements = extractMetaRequirements(newProfile, initialPlan);
+		for (IRequirement requirement : allMetaRequirements) {
+			if (oldProfile.query(QueryUtil.createLimitQuery(QueryUtil.createMatchQuery(requirement.getMatches()), 1), null).isEmpty())
+				return allMetaRequirements;
+		}
+		return null;
+	}
+
+	//Return all the meta requirements for the list of IU specified and all the meta requirements listed necessary to satisfy the uninstallation 
+	private Collection<IRequirement> extractMetaRequirements(Collection<IInstallableUnit> ius, IProvisioningPlan plan) {
+		Set<IRequirement> allMetaRequirements = new HashSet<IRequirement>();
+		for (IInstallableUnit iu : ius) {
+			allMetaRequirements.addAll(iu.getMetaRequirements());
+		}
+		IQueryResult<IInstallableUnit> queryResult = plan.getRemovals().query(QueryUtil.createIUAnyQuery(), null);
+		for (Iterator<IInstallableUnit> iterator = queryResult.iterator(); iterator.hasNext();) {
+			IInstallableUnit iu = iterator.next();
+			allMetaRequirements.addAll(iu.getMetaRequirements());
+		}
+		return allMetaRequirements;
+	}
+
+	private IProvisioningPlan createInstallerPlan(IProfile profile, ProfileChangeRequest initialRequest, Collection<IInstallableUnit> unattachedState, Collection<IInstallableUnit> expectedState, IProvisioningPlan initialPlan, ProvisioningContext initialContext, IProgressMonitor monitor) {
+		SubMonitor sub = SubMonitor.convert(monitor, ExpandWork);
+
+		try {
+			sub.setTaskName(Messages.Director_Task_installer_plan);
+			if (profileRegistry == null) {
+				IProvisioningPlan plan = engine.createPlan(initialRequest.getProfile(), initialContext);
+				plan.setStatus(new Status(IStatus.ERROR, DirectorActivator.PI_DIRECTOR, Messages.Planner_no_profile_registry));
+				return plan;
+			}
+
+			//No installer agent set
+			if (agent.getService(IProvisioningAgent.INSTALLER_AGENT) == null) {
+				return initialPlan;
+			}
+
+			IProfile installerProfile = ((IProfileRegistry) ((IProvisioningAgent) agent.getService(IProvisioningAgent.INSTALLER_AGENT)).getService(IProfileRegistry.SERVICE_NAME)).getProfile((String) agent.getService(IProvisioningAgent.INSTALLER_PROFILEID));
+			if (installerProfile == null)
+				return initialPlan;
+
+			//The target and the installer are in the same agent / profile registry
+			if (haveSameLocation(agent, (IProvisioningAgent) agent.getService(IProvisioningAgent.INSTALLER_AGENT))) {
+				//The target and the installer are the same profile (e.g. the eclipse SDK)
+				if (profile.getProfileId().equals(installerProfile.getProfileId())) {
+					if (profile.getTimestamp() != installerProfile.getTimestamp()) {
+						IProvisioningPlan plan = engine.createPlan(initialRequest.getProfile(), initialContext);
+						plan.setStatus(new Status(IStatus.ERROR, DirectorActivator.PI_DIRECTOR, NLS.bind(Messages.Planner_profile_out_of_sync, profile.getProfileId())));
+						return plan;
+					}
+					return createInstallerPlanForCohostedCase(profile, initialRequest, initialPlan, unattachedState, expectedState, initialContext, sub);
+				}
+
+			}
+
+			if (satisfyMetaRequirements(profile) && !profile.getProfileId().equals(installerProfile.getProfileId())) {
+				return createInstallerPlanForCohostedCaseFromExternalInstaller(profile, initialRequest, initialPlan, expectedState, initialContext, installerProfile, sub);
+			}
+
+			return createInstallerPlanForExternalInstaller(profile, initialRequest, initialPlan, expectedState, initialContext, installerProfile, sub);
+
+		} finally {
+			sub.done();
+		}
+	}
+
+	private boolean haveSameLocation(IProvisioningAgent agent1, IProvisioningAgent agent2) {
+		if (agent1 == null || agent2 == null)
+			return false;
+		if (agent1 == agent2)
+			return true;
+		IAgentLocation thisLocation = (IAgentLocation) agent1.getService(IAgentLocation.SERVICE_NAME);
+		IAgentLocation otherLocation = (IAgentLocation) agent2.getService(IAgentLocation.SERVICE_NAME);
+		if (thisLocation == null || otherLocation == null || (thisLocation == null && otherLocation == null))
+			return false;
+		return thisLocation.getRootLocation().equals(otherLocation.getRootLocation());
+	}
+
+	private IProvisioningPlan createInstallerPlanForCohostedCaseFromExternalInstaller(IProfile profile, ProfileChangeRequest initialRequest, IProvisioningPlan initialPlan, Collection<IInstallableUnit> newState, ProvisioningContext initialContext, IProfile agentProfile, SubMonitor sub) {
+		IProvisioningPlan planForProfile = generatePlan(null, newState, initialRequest, initialContext);
+		return createInstallerPlanForExternalInstaller(profile, initialRequest, planForProfile, newState, initialContext, agentProfile, sub);
+	}
+
+	//Deal with the case where the agent profile is different than the one being provisioned
+	private IProvisioningPlan createInstallerPlanForExternalInstaller(IProfile targetedProfile, ProfileChangeRequest initialRequest, IProvisioningPlan initialPlan, Collection<IInstallableUnit> expectedState, ProvisioningContext initialContext, IProfile agentProfile, SubMonitor sub) {
+		IProfileRegistry installerRegistry = (IProfileRegistry) ((IProvisioningAgent) agent.getService(IProvisioningAgent.INSTALLER_AGENT)).getService(IProfileRegistry.SERVICE_NAME);
+		IProfile installerProfile = installerRegistry.getProfile((String) agent.getService(IProvisioningAgent.INSTALLER_PROFILEID));
+
+		Collection<IRequirement> metaRequirements = areMetaRequirementsSatisfied(installerProfile, expectedState, initialPlan);
+		if (metaRequirements == null)
+			return initialPlan;
+
+		IInstallableUnit actionsIU = createIUForMetaRequirements(targetedProfile, metaRequirements);
+		IInstallableUnit previousActionsIU = getPreviousIUForMetaRequirements(installerProfile, getActionGatheringIUId(targetedProfile), sub);
+
+		ProfileChangeRequest agentRequest = new ProfileChangeRequest(installerProfile);
+		agentRequest.add(actionsIU);
+		if (previousActionsIU != null)
+			agentRequest.remove(previousActionsIU);
+		Object externalInstallerPlan = getSolutionFor(agentRequest, initialContext, sub.newChild(10));
+		if (externalInstallerPlan instanceof IProvisioningPlan && ((IProvisioningPlan) externalInstallerPlan).getStatus().getSeverity() == IStatus.ERROR) {
+			MultiStatus externalInstallerStatus = new MultiStatus(DirectorActivator.PI_DIRECTOR, 0, Messages.Planner_can_not_install_preq, null);
+			externalInstallerStatus.add(((IProvisioningPlan) externalInstallerPlan).getStatus());
+			IProvisioningPlan plan = engine.createPlan(initialRequest.getProfile(), initialContext);
+			plan.setStatus(externalInstallerStatus);
+			IProvisioningPlan installerPlan = engine.createPlan(agentProfile, initialContext);
+			installerPlan.setStatus(externalInstallerStatus);
+			plan.setInstallerPlan(installerPlan);
+			return plan;
+		}
+
+		initialPlan.setInstallerPlan(generatePlan((Projector) externalInstallerPlan, null, agentRequest, initialContext));
+		return initialPlan;
+	}
+
+	//Deal with the case where the actions needs to be installed in the same profile than the one we are performing the initial request
+	//The expectedState represents the result of the initialRequest where the metaRequirements have been satisfied.
+	private IProvisioningPlan createInstallerPlanForCohostedCase(IProfile profile, ProfileChangeRequest initialRequest, IProvisioningPlan initialPlan, Collection<IInstallableUnit> unattachedState, Collection<IInstallableUnit> expectedState, ProvisioningContext initialContext, SubMonitor monitor) {
+		Collection<IRequirement> metaRequirements = initialRequest.getRemovals().size() == 0 ? areMetaRequirementsSatisfied(profile, expectedState, initialPlan) : extractMetaRequirements(expectedState, initialPlan);
+		if (metaRequirements == null || metaRequirements.isEmpty())
+			return initialPlan;
+
+		//Let's compute a plan that satisfy all the metaRequirements. We limit ourselves to only the IUs that were part of the previous solution.
+		IInstallableUnit metaRequirementIU = createIUForMetaRequirements(profile, metaRequirements);
+		IInstallableUnit previousMetaRequirementIU = getPreviousIUForMetaRequirements(profile, getActionGatheringIUId(profile), monitor);
+
+		//Create an agent request from the initial request
+		ProfileChangeRequest agentRequest = new ProfileChangeRequest(profile);
+		for (Map.Entry<String, String> entry : initialRequest.getPropertiesToAdd().entrySet()) {
+			agentRequest.setProfileProperty(entry.getKey(), entry.getValue());
+		}
+		String[] removedProperties = initialRequest.getPropertiesToRemove();
+		for (int i = 0; i < removedProperties.length; i++) {
+			agentRequest.removeProfileProperty(removedProperties[i]);
+		}
+		Map<IInstallableUnit, List<String>> removedIUProperties = initialRequest.getInstallableUnitProfilePropertiesToRemove();
+		for (Map.Entry<IInstallableUnit, List<String>> entry : removedIUProperties.entrySet()) {
+			for (String propKey : entry.getValue()) {
+				agentRequest.removeInstallableUnitProfileProperty(entry.getKey(), propKey);
+			}
+		}
+
+		if (previousMetaRequirementIU != null)
+			agentRequest.remove(previousMetaRequirementIU);
+		agentRequest.add(metaRequirementIU);
+
+		ProvisioningContext agentCtx = new ProvisioningContext(agent);
+		agentCtx.setMetadataRepositories(new URI[0]);
+		ArrayList<IInstallableUnit> extraIUs = new ArrayList<IInstallableUnit>(unattachedState);
+		agentCtx.setExtraInstallableUnits(extraIUs);
+		Object agentSolution = getSolutionFor(agentRequest, agentCtx, monitor.newChild(3));
+		if (agentSolution instanceof IProvisioningPlan && ((IProvisioningPlan) agentSolution).getStatus().getSeverity() == IStatus.ERROR) {
+			MultiStatus agentStatus = new MultiStatus(DirectorActivator.PI_DIRECTOR, 0, Messages.Planner_actions_and_software_incompatible, null);
+			agentStatus.add(((IProvisioningPlan) agentSolution).getStatus());
+			IProvisioningPlan plan = engine.createPlan(initialRequest.getProfile(), initialContext);
+			plan.setStatus(agentStatus);
+			IProvisioningPlan installerPlan = engine.createPlan(initialRequest.getProfile(), initialContext);
+			installerPlan.setStatus(agentStatus);
+			plan.setInstallerPlan(installerPlan);
+			return plan;
+		}
+
+		//Compute the installer plan. It is the difference between what is currently in the profile and the solution we just computed
+		Collection<IInstallableUnit> agentState = ((Projector) agentSolution).extractSolution();
+		agentState.remove(metaRequirementIU); //Remove the fake IU
+		agentState = AttachmentHelper.attachFragments(agentState.iterator(), ((Projector) agentSolution).getFragmentAssociation());
+
+		ProvisioningContext noRepoContext = createNoRepoContext(initialRequest);
+		//...This computes the attachment of what is currently in the profile 
+		Object initialSolution = getSolutionFor(new ProfileChangeRequest(new EverythingOptionalProfile(initialRequest.getProfile())), noRepoContext, new NullProgressMonitor());
+		if (initialSolution instanceof IProvisioningPlan) {
+			LogHelper.log(new Status(IStatus.ERROR, DirectorActivator.PI_DIRECTOR, "The resolution of the previous state contained in profile " + initialRequest.getProfile().getProfileId() + " version " + initialRequest.getProfile().getTimestamp() + " failed.")); //$NON-NLS-1$//$NON-NLS-2$//$NON-NLS-3$
+			return (IProvisioningPlan) initialSolution;
+		}
+		Iterator<IInstallableUnit> profileState = initialRequest.getProfile().query(QueryUtil.createIUAnyQuery(), null).iterator();
+		Collection<IInstallableUnit> initialState = AttachmentHelper.attachFragments(profileState, ((Projector) initialSolution).getFragmentAssociation());
+
+		IProvisioningPlan agentPlan = generateProvisioningPlan(initialState, agentState, initialRequest, null, initialContext);
+
+		//Compute the installation plan. It is the difference between the state after the installer plan has run and the expectedState.
+		return generateProvisioningPlan(agentState, expectedState, initialRequest, agentPlan, initialContext);
+	}
+
+	//Compute the set of operands based on the solution obtained previously
+	private IProvisioningPlan generatePlan(Projector newSolution, Collection<IInstallableUnit> newState, ProfileChangeRequest request, ProvisioningContext context) {
+		//Compute the attachment of the new state if not provided
+		if (newState == null) {
+			newState = newSolution.extractSolution();
+			newState = AttachmentHelper.attachFragments(newState.iterator(), newSolution.getFragmentAssociation());
+		}
+		ProvisioningContext noRepoContext = createNoRepoContext(request);
+
+		//Compute the attachment of the previous state
+		Object initialSolution = getSolutionFor(new ProfileChangeRequest(new EverythingOptionalProfile(request.getProfile())), noRepoContext, new NullProgressMonitor());
+		if (initialSolution instanceof IProvisioningPlan) {
+			LogHelper.log(new Status(IStatus.ERROR, DirectorActivator.PI_DIRECTOR, "The resolution of the previous state contained in profile " + request.getProfile().getProfileId() + " version " + request.getProfile().getTimestamp() + " failed.")); //$NON-NLS-1$//$NON-NLS-2$//$NON-NLS-3$
+			return (IProvisioningPlan) initialSolution;
+		}
+		Iterator<IInstallableUnit> profileState = request.getProfile().query(QueryUtil.createIUAnyQuery(), null).iterator();
+		Collection<IInstallableUnit> initialState = AttachmentHelper.attachFragments(profileState, ((Projector) initialSolution).getFragmentAssociation());
+
+		//Generate the plan
+		return generateProvisioningPlan(initialState, newState, request, null, context);
+	}
+
+	private ProvisioningContext createNoRepoContext(ProfileChangeRequest request) {
+		ProvisioningContext noRepoContext = new ProvisioningContext(agent);
+		noRepoContext.setMetadataRepositories(new URI[0]);
+		noRepoContext.setArtifactRepositories(new URI[0]);
+		noRepoContext.setProperty(INCLUDE_PROFILE_IUS, Boolean.FALSE.toString());
+		noRepoContext.setExtraInstallableUnits(new ArrayList<IInstallableUnit>(request.getProfile().query(QueryUtil.createIUAnyQuery(), new NullProgressMonitor()).toUnmodifiableSet()));
+		return noRepoContext;
+	}
+
+	private IInstallableUnit getPreviousIUForMetaRequirements(IProfile profile, String iuId, IProgressMonitor monitor) {
+		IQueryResult<IInstallableUnit> c = profile.query(QueryUtil.createIUQuery(iuId), monitor);
+		if (c.isEmpty())
+			return null;
+		return c.iterator().next();
+	}
+
+	private String getActionGatheringIUId(IProfile profile) {
+		return ID_IU_FOR_ACTIONS + '.' + profile.getProfileId();
+	}
+
+	private IInstallableUnit createIUForMetaRequirements(IProfile profile, Collection<IRequirement> metaRequirements) {
+		InstallableUnitDescription description = new InstallableUnitDescription();
+		String id = getActionGatheringIUId(profile);
+		description.setId(id);
+		Version version = Version.createOSGi(1, 0, 0, Long.toString(profile.getTimestamp()));
+		description.setVersion(version);
+		description.addRequirements(metaRequirements);
+
+		ArrayList<IProvidedCapability> providedCapabilities = new ArrayList<IProvidedCapability>();
+		IProvidedCapability providedCapability = MetadataFactory.createProvidedCapability(IInstallableUnit.NAMESPACE_IU_ID, id, version);
+		providedCapabilities.add(providedCapability);
+		description.addProvidedCapabilities(providedCapabilities);
+
+		IInstallableUnit actionsIU = MetadataFactory.createInstallableUnit(description);
+		return actionsIU;
+	}
+
+	private IInstallableUnit createIURepresentingTheProfile(Set<IRequirement> allRequirements) {
+		InstallableUnitDescription iud = new MetadataFactory.InstallableUnitDescription();
+		String time = Long.toString(System.currentTimeMillis());
+		iud.setId(time);
+		iud.setVersion(Version.createOSGi(0, 0, 0, time));
+		iud.setRequirements(allRequirements.toArray(new IRequirement[allRequirements.size()]));
+		return MetadataFactory.createInstallableUnit(iud);
+	}
+
+	//The planner uses installable unit properties to keep track of what it has been asked to install. This updates this information
+	//It returns at index 0 a meta IU representing everything that needs to be installed
+	//It returns at index 1 all the IUs that are in the profile after the removal have been done, but before the addition have been done 
+	private Object[] updatePlannerInfo(ProfileChangeRequest profileChangeRequest, ProvisioningContext context) {
+		IQueryResult<IInstallableUnit> alreadyInstalled = profileChangeRequest.getProfile().query(new IUProfilePropertyQuery(INCLUSION_RULES, IUProfilePropertyQuery.ANY), null);
+
+		Collection<IInstallableUnit> additionRequested = profileChangeRequest.getAdditions();
+		Collection<IInstallableUnit> removalRequested = profileChangeRequest.getRemovals();
+
+		for (Map.Entry<IInstallableUnit, List<String>> object : profileChangeRequest.getInstallableUnitProfilePropertiesToRemove().entrySet()) {
+			if (object.getValue().contains(INCLUSION_RULES))
+				profileChangeRequest.setInstallableUnitProfileProperty(object.getKey(), INCLUSION_RULES, ProfileInclusionRules.createStrictInclusionRule(object.getKey()));
+		}
+		//Remove the iu properties associated to the ius removed and the iu properties being removed as well
+		if (removalRequested.size() != 0) {
+			for (Iterator<IInstallableUnit> iterator = alreadyInstalled.iterator(); iterator.hasNext();) {
+				IInstallableUnit iu = iterator.next();
+				for (IInstallableUnit removed : removalRequested) {
+					if (iu.equals(removed)) {
+						profileChangeRequest.removeInstallableUnitProfileProperty(removed, INCLUSION_RULES);
+						iterator.remove();
+						break;
+					}
+				}
+			}
+		}
+		Set<IRequirement> gatheredRequirements = new HashSet<IRequirement>();
+
+		//Process all the IUs being added
+		Map<IInstallableUnit, Map<String, String>> iuPropertiesToAdd = profileChangeRequest.getInstallableUnitProfilePropertiesToAdd();
+		for (IInstallableUnit added : additionRequested) {
+			Map<String, String> propertiesForIU = iuPropertiesToAdd.get(added);
+			IRequirement profileRequirement = null;
+			if (propertiesForIU != null) {
+				profileRequirement = createRequirement(added, propertiesForIU.get(INCLUSION_RULES));
+			}
+			if (profileRequirement == null) {
+				profileChangeRequest.setInstallableUnitProfileProperty(added, INCLUSION_RULES, ProfileInclusionRules.createStrictInclusionRule(added));
+				profileRequirement = createStrictRequirement(added);
+			}
+			gatheredRequirements.add(profileRequirement);
+		}
+
+		//Process the IUs that were already there
+		for (Iterator<IInstallableUnit> iterator = alreadyInstalled.iterator(); iterator.hasNext();) {
+			IInstallableUnit iu = iterator.next();
+			Map<String, String> propertiesForIU = iuPropertiesToAdd.get(iu);
+			IRequirement profileRequirement = null;
+			//Test if the value has changed
+			if (propertiesForIU != null) {
+				profileRequirement = createRequirement(iu, propertiesForIU.get(INCLUSION_RULES));
+			}
+			if (profileRequirement == null) {
+				profileRequirement = createRequirement(iu, profileChangeRequest.getProfile().getInstallableUnitProperty(iu, INCLUSION_RULES));
+			}
+			gatheredRequirements.add(profileRequirement);
+		}
+
+		//Now add any other requirement that we need to see satisfied
+		if (profileChangeRequest.getExtraRequirements() != null)
+			gatheredRequirements.addAll(profileChangeRequest.getExtraRequirements());
+		IInstallableUnit[] existingRoots = profileChangeRequest.getProfile().query(new IUProfilePropertyQuery(INCLUSION_RULES, IUProfilePropertyQuery.ANY), null).toArray(IInstallableUnit.class);
+		return new Object[] {createIURepresentingTheProfile(gatheredRequirements), existingRoots};
+	}
+
+	private IRequirement createRequirement(IInstallableUnit iu, String rule) {
+		if (rule == null)
+			return null;
+		if (rule.equals(ProfileInclusionRules.createStrictInclusionRule(iu))) {
+			return createStrictRequirement(iu);
+		}
+		if (rule.equals(ProfileInclusionRules.createOptionalInclusionRule(iu))) {
+			return createOptionalRequirement(iu);
+		}
+		return null;
+	}
+
+	private IRequirement createOptionalRequirement(IInstallableUnit iu) {
+		return MetadataFactory.createRequirement(IInstallableUnit.NAMESPACE_IU_ID, iu.getId(), new VersionRange(iu.getVersion(), true, iu.getVersion(), true), null, true, false, true);
+	}
+
+	private IRequirement createStrictRequirement(IInstallableUnit iu) {
+		return MetadataFactory.createRequirement(IInstallableUnit.NAMESPACE_IU_ID, iu.getId(), new VersionRange(iu.getVersion(), true, iu.getVersion(), true), null, false, false, true);
+	}
+
+	public IQueryResult<IInstallableUnit> updatesFor(IInstallableUnit toUpdate, ProvisioningContext context, IProgressMonitor monitor) {
+		Map<String, IInstallableUnit> resultsMap = new HashMap<String, IInstallableUnit>();
+
+		SubMonitor sub = SubMonitor.convert(monitor, 1000);
+		IQueryable<IInstallableUnit> queryable = context.getMetadata(sub.newChild(500));
+		IQueryResult<IInstallableUnit> matches = queryable.query(new UpdateQuery(toUpdate), sub.newChild(500));
+		for (Iterator<IInstallableUnit> it = matches.iterator(); it.hasNext();) {
+			IInstallableUnit iu = it.next();
+			if (iu.getId().startsWith(COM_APPCELERATOR_TITANIUM_FEATURE))
+			{
+				//Skip all IUs related to Appcelerator. They will be taken care by Appcelerator specific updates.
+				continue;
+			}
+			String key = iu.getId() + "_" + iu.getVersion().toString(); //$NON-NLS-1$
+			IInstallableUnit currentIU = resultsMap.get(key);
+			if (currentIU == null || hasHigherFidelity(iu, currentIU))
+				resultsMap.put(key, iu);
+		}
+		sub.done();
+		return new CollectionResult<IInstallableUnit>(resultsMap.values());
+	}
+
+	//helper class to trick the resolver to believe that everything is optional
+	private static class EverythingOptionalProfile implements IProfile {
+		private IProfile profile;
+
+		public EverythingOptionalProfile(IProfile p) {
+			profile = p;
+		}
+
+		public IQueryResult<IInstallableUnit> available(IQuery<IInstallableUnit> query, IProgressMonitor monitor) {
+			return profile.available(query, monitor);
+		}
+
+		public Map<String, String> getInstallableUnitProperties(IInstallableUnit iu) {
+			return profile.getInstallableUnitProperties(iu);
+		}
+
+		public String getInstallableUnitProperty(IInstallableUnit iu, String key) {
+			if (INCLUSION_RULES.equals(key))
+				return ProfileInclusionRules.createOptionalInclusionRule(iu);
+			return profile.getInstallableUnitProperty(iu, key);
+		}
+
+		public String getProfileId() {
+			return profile.getProfileId();
+		}
+
+		public Map<String, String> getProperties() {
+			return profile.getProperties();
+		}
+
+		public String getProperty(String key) {
+			return profile.getProperty(key);
+		}
+
+		public IProvisioningAgent getProvisioningAgent() {
+			return profile.getProvisioningAgent();
+		}
+
+		public long getTimestamp() {
+			return profile.getTimestamp();
+		}
+
+		public IQueryResult<IInstallableUnit> query(IQuery<IInstallableUnit> query, IProgressMonitor monitor) {
+			return profile.query(query, monitor);
+		}
+	}
+
+	public IProfileChangeRequest createChangeRequest(IProfile profileToChange) {
+		return new ProfileChangeRequest(profileToChange);
+	}
+}

--- a/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/director/Slicer.java
+++ b/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/director/Slicer.java
@@ -1,0 +1,213 @@
+/*******************************************************************************
+ *  Copyright (c) 2007, 2010 IBM Corporation and others.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ * 
+ *  Contributors:
+ *      IBM Corporation - initial API and implementation
+ *      Sonatype, Inc. - ongoing development
+ *******************************************************************************/
+package org.eclipse.equinox.internal.p2.director;
+
+import java.util.*;
+import org.eclipse.core.runtime.*;
+import org.eclipse.equinox.internal.p2.core.helpers.LogHelper;
+import org.eclipse.equinox.internal.p2.core.helpers.Tracing;
+import org.eclipse.equinox.internal.p2.metadata.InstallableUnit;
+import org.eclipse.equinox.internal.p2.metadata.InstallableUnitPatch;
+import org.eclipse.equinox.p2.metadata.*;
+import org.eclipse.equinox.p2.metadata.expression.IMatchExpression;
+import org.eclipse.equinox.p2.query.*;
+import org.eclipse.osgi.util.NLS;
+
+public class Slicer {
+	private static boolean DEBUG = false;
+	private final IQueryable<IInstallableUnit> possibilites;
+	private final boolean considerMetaRequirements;
+	protected final IInstallableUnit selectionContext;
+	private final Map<String, Map<Version, IInstallableUnit>> slice; //The IUs that have been considered to be part of the problem
+	private final MultiStatus result;
+
+	private LinkedList<IInstallableUnit> toProcess;
+	private Set<IInstallableUnit> considered; //IUs to add to the slice
+	private Set<IInstallableUnit> nonGreedyIUs = new HashSet<IInstallableUnit>(); //IUs that are brought in by non greedy dependencies
+
+	public Slicer(IQueryable<IInstallableUnit> input, Map<String, String> context, boolean considerMetaRequirements) {
+		this(input, InstallableUnit.contextIU(context), considerMetaRequirements);
+	}
+
+	public Slicer(IQueryable<IInstallableUnit> possibilites, IInstallableUnit selectionContext, boolean considerMetaRequirements) {
+		this.possibilites = possibilites;
+		this.selectionContext = selectionContext;
+		this.considerMetaRequirements = considerMetaRequirements;
+		slice = new HashMap<String, Map<Version, IInstallableUnit>>();
+		result = new MultiStatus(DirectorActivator.PI_DIRECTOR, IStatus.OK, Messages.Planner_Problems_resolving_plan, null);
+	}
+
+	public IQueryable<IInstallableUnit> slice(IInstallableUnit[] ius, IProgressMonitor monitor) {
+		try {
+			long start = 0;
+			if (DEBUG) {
+				start = System.currentTimeMillis();
+				System.out.println("Start slicing: " + start); //$NON-NLS-1$
+			}
+
+			validateInput(ius);
+			considered = new HashSet<IInstallableUnit>(Arrays.asList(ius));
+			toProcess = new LinkedList<IInstallableUnit>(considered);
+			while (!toProcess.isEmpty()) {
+				if (monitor.isCanceled()) {
+					result.merge(Status.CANCEL_STATUS);
+					throw new OperationCanceledException();
+				}
+				processIU(toProcess.removeFirst());
+			}
+			computeNonGreedyIUs();
+			if (DEBUG) {
+				long stop = System.currentTimeMillis();
+				System.out.println("Slicing complete: " + (stop - start)); //$NON-NLS-1$
+			}
+		} catch (IllegalStateException e) {
+			result.add(new Status(IStatus.ERROR, DirectorActivator.PI_DIRECTOR, e.getMessage(), e));
+		}
+		if (Tracing.DEBUG && result.getSeverity() != IStatus.OK)
+			LogHelper.log(result);
+		if (result.getSeverity() == IStatus.ERROR)
+			return null;
+		return new QueryableArray(considered.toArray(new IInstallableUnit[considered.size()]));
+	}
+
+	private void computeNonGreedyIUs() {
+		IQueryable<IInstallableUnit> queryable = new QueryableArray(considered.toArray(new IInstallableUnit[considered.size()]));
+		Iterator<IInstallableUnit> it = queryable.query(QueryUtil.ALL_UNITS, new NullProgressMonitor()).iterator();
+		while (it.hasNext()) {
+			Collection<IRequirement> reqs = getRequirements(it.next().unresolved());
+			for (IRequirement req : reqs) {
+				if (!isApplicable(req))
+					continue;
+
+				if (!isGreedy(req)) {
+					nonGreedyIUs.addAll(queryable.query(QueryUtil.createMatchQuery(req.getMatches()), null).toUnmodifiableSet());
+				}
+			}
+		}
+	}
+
+	public MultiStatus getStatus() {
+		return result;
+	}
+
+	//This is a shortcut to simplify the error reporting when the filter of the ius we are being asked to install does not pass
+	private void validateInput(IInstallableUnit[] ius) {
+		for (int i = 0; i < ius.length; i++) {
+			if (!isApplicable(ius[i]))
+				throw new IllegalStateException(NLS.bind(Messages.Explanation_missingRootFilter, ius[i]));
+		}
+	}
+
+	// Check whether the requirement is applicable
+	protected boolean isApplicable(IRequirement req) {
+		IMatchExpression<IInstallableUnit> filter = req.getFilter();
+		return filter == null || filter.isMatch(selectionContext);
+	}
+
+	protected boolean isApplicable(IInstallableUnit iu) {
+		IMatchExpression<IInstallableUnit> filter = iu.getFilter();
+		return filter == null || filter.isMatch(selectionContext);
+	}
+
+	protected void processIU(IInstallableUnit iu) {
+		iu = iu.unresolved();
+
+		Map<Version, IInstallableUnit> iuSlice = slice.get(iu.getId());
+		if (iuSlice == null) {
+
+			iuSlice = new HashMap<Version, IInstallableUnit>();
+			slice.put(iu.getId(), iuSlice);
+		}
+		iuSlice.put(iu.getVersion(), iu);
+		if (!isApplicable(iu)) {
+			return;
+		}
+
+		Collection<IRequirement> reqs = getRequirements(iu);
+		if (reqs.isEmpty())
+			return;
+		for (IRequirement req : reqs) {
+			if (!isApplicable(req))
+				continue;
+
+			if (!isGreedy(req)) {
+				continue;
+			}
+
+			expandRequirement(iu, req);
+		}
+	}
+
+	protected boolean isGreedy(IRequirement req) {
+		return req.isGreedy();
+	}
+
+	private Collection<IRequirement> getRequirements(IInstallableUnit iu) {
+		boolean isPatch = iu instanceof IInstallableUnitPatch;
+		boolean isFragment = iu instanceof IInstallableUnitFragment;
+		//Short-circuit for the case of an IInstallableUnit 
+		if ((!isFragment) && (!isPatch) && iu.getMetaRequirements().size() == 0)
+			return iu.getRequirements();
+
+		ArrayList<IRequirement> aggregatedRequirements = new ArrayList<IRequirement>(iu.getRequirements().size() + iu.getMetaRequirements().size() + (isFragment ? ((IInstallableUnitFragment) iu).getHost().size() : 0) + (isPatch ? ((IInstallableUnitPatch) iu).getRequirementsChange().size() : 0));
+		aggregatedRequirements.addAll(iu.getRequirements());
+
+		if (iu instanceof IInstallableUnitFragment) {
+			aggregatedRequirements.addAll(((IInstallableUnitFragment) iu).getHost());
+		}
+
+		if (iu instanceof InstallableUnitPatch) {
+			IInstallableUnitPatch patchIU = (IInstallableUnitPatch) iu;
+			List<IRequirementChange> changes = patchIU.getRequirementsChange();
+			for (int i = 0; i < changes.size(); i++)
+				aggregatedRequirements.add(changes.get(i).newValue());
+		}
+
+		if (considerMetaRequirements)
+			aggregatedRequirements.addAll(iu.getMetaRequirements());
+		return aggregatedRequirements;
+	}
+
+	private void expandRequirement(IInstallableUnit iu, IRequirement req) {
+		if (req.getMax() == 0)
+			return;
+		IQueryResult<IInstallableUnit> matches = possibilites.query(QueryUtil.createMatchQuery(req.getMatches()), null);
+		int validMatches = 0;
+		for (Iterator<IInstallableUnit> iterator = matches.iterator(); iterator.hasNext();) {
+			IInstallableUnit match = iterator.next();
+			if (!isApplicable(match))
+				continue;
+			validMatches++;
+			Map<Version, IInstallableUnit> iuSlice = slice.get(match.getId());
+			if (iuSlice == null || !iuSlice.containsKey(match.getVersion()))
+				consider(match);
+		}
+
+		if (validMatches == 0) {
+			if (req.getMin() == 0) {
+				if (DEBUG)
+					System.out.println("No IU found to satisfy optional dependency of " + iu + " on req " + req); //$NON-NLS-1$//$NON-NLS-2$
+			} else {
+				result.add(new Status(IStatus.WARNING, DirectorActivator.PI_DIRECTOR, NLS.bind(Messages.Planner_Unsatisfied_dependency, iu, req)));
+			}
+		}
+	}
+
+	private void consider(IInstallableUnit match) {
+		if (considered.add(match))
+			toProcess.addLast(match);
+	}
+
+	Set<IInstallableUnit> getNonGreedyIUs() {
+		return nonGreedyIUs;
+	}
+}

--- a/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/director/UserDefinedOptimizationFunction.java
+++ b/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/director/UserDefinedOptimizationFunction.java
@@ -1,0 +1,200 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2013 Daniel Le Berre and others. All rights reserved. This
+ * program and the accompanying materials are made available under the terms of
+ * the Eclipse Public License v1.0 which accompanies this distribution, and is
+ * available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors: 
+ *     Daniel Le Berre - initial API and implementation
+ *     Red Hat, Inc. - support for remediation page
+ ******************************************************************************/
+package org.eclipse.equinox.internal.p2.director;
+
+import java.math.BigInteger;
+import java.util.*;
+import org.eclipse.equinox.internal.p2.director.Projector.AbstractVariable;
+import org.eclipse.equinox.p2.metadata.*;
+import org.eclipse.equinox.p2.query.*;
+import org.sat4j.pb.tools.*;
+import org.sat4j.specs.ContradictionException;
+
+public class UserDefinedOptimizationFunction extends OptimizationFunction {
+	private Collection<IInstallableUnit> alreadyExistingRoots;
+	private SteppedTimeoutLexicoHelper<Object, Explanation> dependencyHelper;
+	private IQueryable<IInstallableUnit> picker;
+
+	public UserDefinedOptimizationFunction(IQueryable<IInstallableUnit> lastState, List<AbstractVariable> abstractVariables, List<AbstractVariable> optionalVariables, IQueryable<IInstallableUnit> picker, IInstallableUnit selectionContext, Map<String, Map<Version, IInstallableUnit>> slice, DependencyHelper<Object, Explanation> dependencyHelper, Collection<IInstallableUnit> alreadyInstalledIUs) {
+		super(lastState, abstractVariables, optionalVariables, picker, selectionContext, slice);
+		this.picker = picker;
+		this.slice = slice;
+		this.dependencyHelper = (SteppedTimeoutLexicoHelper<Object, Explanation>) dependencyHelper;
+		this.alreadyExistingRoots = alreadyInstalledIUs;
+	}
+
+	public List<WeightedObject<? extends Object>> createOptimizationFunction(IInstallableUnit metaIu, Collection<IInstallableUnit> newRoots) {
+		List<WeightedObject<?>> weightedObjects = new ArrayList<WeightedObject<?>>();
+		List<Object> objects = new ArrayList<Object>();
+		BigInteger weight = BigInteger.valueOf(slice.size() + 1);
+		String[] criteria = new String[] {"+new", "-notuptodate", "-changed", "-removed"}; //$NON-NLS-1$//$NON-NLS-2$//$NON-NLS-3$//$NON-NLS-4$
+		BigInteger currentWeight = weight.pow(criteria.length - 1);
+		boolean maximizes;
+		Object thing;
+		for (int i = 0; i < criteria.length; i++) {
+			if (criteria[i].endsWith("new")) { //$NON-NLS-1$
+				weightedObjects.clear();
+				newRoots(weightedObjects, criteria[i].startsWith("+") ? currentWeight.negate() : currentWeight, metaIu); //$NON-NLS-1$
+				currentWeight = currentWeight.divide(weight);
+			} else if (criteria[i].endsWith("removed")) { //$NON-NLS-1$
+				weightedObjects.clear();
+				removedRoots(weightedObjects, criteria[i].startsWith("+") ? currentWeight.negate() : currentWeight, metaIu); //$NON-NLS-1$
+				currentWeight = currentWeight.divide(weight);
+			} else if (criteria[i].endsWith("notuptodate")) { //$NON-NLS-1$
+				weightedObjects.clear();
+				notuptodate(weightedObjects, criteria[i].startsWith("+") ? currentWeight.negate() : currentWeight, metaIu); //$NON-NLS-1$
+				currentWeight = currentWeight.divide(weight);
+			} else if (criteria[i].endsWith("changed")) { //$NON-NLS-1$
+				weightedObjects.clear();
+				changedRoots(weightedObjects, criteria[i].startsWith("+") ? currentWeight.negate() : currentWeight, metaIu); //$NON-NLS-1$
+				currentWeight = currentWeight.divide(weight);
+			}
+			objects.clear();
+			maximizes = criteria[i].startsWith("+"); //$NON-NLS-1$
+			for (Iterator<WeightedObject<?>> it = weightedObjects.iterator(); it.hasNext();) {
+				thing = it.next().thing;
+				if (maximizes) {
+					thing = dependencyHelper.not(thing);
+				}
+				objects.add(thing);
+			}
+			dependencyHelper.addCriterion(objects);
+		}
+		weightedObjects.clear();
+		return null;
+	}
+
+	protected void changedRoots(List<WeightedObject<?>> weightedObjects, BigInteger weight, IInstallableUnit entryPointIU) {
+		Collection<IRequirement> requirements = entryPointIU.getRequirements();
+		for (IRequirement req : requirements) {
+			IQuery<IInstallableUnit> query = QueryUtil.createMatchQuery(req.getMatches());
+			IQueryResult<IInstallableUnit> matches = picker.query(query, null);
+			Object[] changed = new Object[matches.toUnmodifiableSet().size()];
+			int i = 0;
+			for (IInstallableUnit match : matches) {
+				changed[i++] = isInstalledAsRoot(match) ? dependencyHelper.not(match) : match;
+			}
+			try {
+				Projector.AbstractVariable abs = new Projector.AbstractVariable("CHANGED"); //$NON-NLS-1$
+				dependencyHelper.or(FakeExplanation.getInstance(), abs, changed);
+				weightedObjects.add(WeightedObject.newWO(abs, weight));
+			} catch (ContradictionException e) {
+				// TODO Auto-generated catch block TODO
+				e.printStackTrace();
+			}
+		}
+	}
+
+	protected void newRoots(List<WeightedObject<?>> weightedObjects, BigInteger weight, IInstallableUnit entryPointIU) {
+		Collection<IRequirement> requirements = entryPointIU.getRequirements();
+		for (IRequirement req : requirements) {
+			IQuery<IInstallableUnit> query = QueryUtil.createMatchQuery(req.getMatches());
+			IQueryResult<IInstallableUnit> matches = picker.query(query, null);
+			boolean oneInstalled = false;
+			for (IInstallableUnit match : matches) {
+				oneInstalled = oneInstalled || isInstalledAsRoot(match);
+			}
+			if (!oneInstalled) {
+				try {
+					Projector.AbstractVariable abs = new Projector.AbstractVariable("NEW"); //$NON-NLS-1$
+					dependencyHelper.or(FakeExplanation.getInstance(), abs, matches.toArray(IInstallableUnit.class));
+					weightedObjects.add(WeightedObject.newWO(abs, weight));
+				} catch (ContradictionException e) {
+					// should not happen
+					e.printStackTrace();
+				}
+			}
+		}
+	}
+
+	protected void removedRoots(List<WeightedObject<?>> weightedObjects, BigInteger weight, IInstallableUnit entryPointIU) {
+		Collection<IRequirement> requirements = entryPointIU.getRequirements();
+		for (IRequirement req : requirements) {
+			IQuery<IInstallableUnit> query = QueryUtil.createMatchQuery(req.getMatches());
+			IQueryResult<IInstallableUnit> matches = picker.query(query, null);
+			boolean installed = false;
+			Object[] literals = new Object[matches.toUnmodifiableSet().size()];
+			int i = 0;
+			for (IInstallableUnit match : matches) {
+				installed = installed || isInstalledAsRoot(match);
+				literals[i++] = dependencyHelper.not(match);
+			}
+			if (installed) {
+				try {
+					Projector.AbstractVariable abs = new Projector.AbstractVariable("REMOVED"); //$NON-NLS-1$
+					dependencyHelper.and(FakeExplanation.getInstance(), abs, literals);
+					weightedObjects.add(WeightedObject.newWO(abs, weight));
+				} catch (ContradictionException e) {
+					// should not happen TODO
+					e.printStackTrace();
+				}
+			}
+		}
+	}
+
+	protected void notuptodate(List<WeightedObject<?>> weightedObjects, BigInteger weight, IInstallableUnit entryPointIU) {
+		Collection<IRequirement> requirements = entryPointIU.getRequirements();
+		for (IRequirement req : requirements) {
+			IQuery<IInstallableUnit> query = QueryUtil.createMatchQuery(req.getMatches());
+			IQueryResult<IInstallableUnit> matches = picker.query(query, null);
+			List<IInstallableUnit> toSort = new ArrayList<IInstallableUnit>(matches.toUnmodifiableSet());
+			Collections.sort(toSort, Collections.reverseOrder());
+			if (toSort.size() == 0)
+				continue;
+
+			Projector.AbstractVariable abs = new Projector.AbstractVariable();
+			Object notlatest = dependencyHelper.not(toSort.get(0));
+			try {
+				// notuptodate <=> not iuvn and (iuv1 or iuv2 or ... iuvn-1) 
+				dependencyHelper.implication(new Object[] {abs}).implies(notlatest).named(FakeExplanation.getInstance());
+				Object[] clause = new Object[toSort.size()];
+				toSort.toArray(clause);
+				clause[0] = dependencyHelper.not(abs);
+				dependencyHelper.clause(FakeExplanation.getInstance(), clause);
+				for (int i = 1; i < toSort.size(); i++) {
+					dependencyHelper.implication(new Object[] {notlatest, toSort.get(i)}).implies(abs).named(FakeExplanation.getInstance());
+				}
+			} catch (ContradictionException e) {
+				// should never happen
+				e.printStackTrace();
+			}
+
+			weightedObjects.add(WeightedObject.newWO(abs, weight));
+		}
+	}
+
+	private static class FakeExplanation extends Explanation {
+		private static Explanation singleton = new FakeExplanation();
+
+		public static Explanation getInstance() {
+			return singleton;
+		}
+
+		protected int orderValue() {
+			return Explanation.OTHER_REASON;
+		}
+
+		@Override
+		public int shortAnswer() {
+			return 0;
+		}
+
+	}
+
+	private boolean isInstalledAsRoot(IInstallableUnit isInstalled) {
+		for (IInstallableUnit installed : alreadyExistingRoots) {
+			if (isInstalled.equals(installed))
+				return true;
+		}
+		return false;
+	}
+
+}

--- a/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/director/messages.properties
+++ b/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/director/messages.properties
@@ -1,0 +1,51 @@
+###############################################################################
+# Copyright (c) 2007, 2010 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+
+Director_Task_installer_plan=Computing prerequisite plan
+Director_Task_Installing=Installing into {0}
+Director_Task_Updating=Updating
+Director_Task_Resolving_Dependencies=Calculating requirements and dependencies.
+Director_Unsatisfied_Dependencies=\
+Cannot complete the install because some dependencies are not satisfiable
+Director_error_applying_configuration=Unexpected failure applying configuration after for the installer plan execution.
+Director_For_Target = The following software cannot be installed because it is intended for use only in Plug-in Development Environment (PDE) target platforms. Please deselect these items and retry the operation.
+Director_For_Target_Unselect_Required = If provisioning a target platform then try disabling the option 'Include required software'
+
+Explanation_alreadyInstalled=Software currently installed: {0}
+Explanation_from=From: {0}
+Explanation_fromPatch=From Patch: {0}
+Explanation_hardDependency=Cannot satisfy dependency: {0} depends on: {1}
+Explanation_patchedHardDependency=Cannot satisfy patched ({0}) dependency: {1} depends on: {2}
+Explanation_missingRequired=Missing requirement: {0} requires ''{1}'' but it could not be found
+Explanation_missingRootRequired=You requested to install ''{0}'' but it could not be found
+Explanation_missingNonGreedyRequired=Missing non greedy requirement: ''{0}'' is required non greedily but it could not be found
+Explanation_missingRequiredFilter=Missing requirement for filter {0}: {1} requires ''{2}'' but it could not be found
+Explanation_missingRootFilter={0} cannot be installed in this environment because its filter is not applicable.
+Explanation_optionalDependency=Optional dependency
+Explanation_rootMissing=Cannot complete the install because one or more required items could not be found.
+Explanation_rootSingleton=Cannot complete the install because of a conflicting dependency.
+Explanation_singleton=Only one of the following can be installed at once: {0}
+Explanation_to=To: {0}
+Explanation_toInstall=Software being installed: {0}
+Explanation_unsatisfied=Cannot satisfy dependency:
+
+Planner_Timeout=The solver timed out on problem {0}.
+Planner_Problems_resolving_plan=Problems resolving provisioning plan.
+Planner_Unsatisfiable_problem=No solution found because the problem is unsatisfiable.
+Planner_Unsatisfied_dependency=Unable to satisfy dependency from {0} to {1}.
+Planner_NoSolution=Cannot complete the request.  Generating details.
+Planner_Unexpected_problem=An unexpected error occurred while resolving.
+Planner_actions_and_software_incompatible=The actions required to successfully install the requested software are incompatible with the software to install. 
+Planner_can_not_install_preq=The actions required to successfully install the requested software can not be installed. 
+Planner_no_profile_registry=Profile Registry is not registered.
+Planner_profile_out_of_sync=The copies of profile {0} are not in sync.
+Planner_no_installer_agent=Problems resolving meta requirements while installing in profile {0}. 
+RequestStatus_message=Plan status for {0}

--- a/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/rollback/FormerState.java
+++ b/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/rollback/FormerState.java
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ *  Copyright (c) 2007, 2010 IBM Corporation and others.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ * 
+ *  Contributors:
+ *      IBM Corporation - initial API and implementation
+ *     Sonatype, Inc. - ongoing development
+ *******************************************************************************/
+package org.eclipse.equinox.internal.p2.rollback;
+
+import java.util.*;
+import java.util.Map.Entry;
+import org.eclipse.equinox.internal.p2.director.ProfileChangeRequest;
+import org.eclipse.equinox.internal.p2.director.SimplePlanner;
+import org.eclipse.equinox.p2.engine.IProfile;
+import org.eclipse.equinox.p2.metadata.IInstallableUnit;
+import org.eclipse.equinox.p2.planner.IProfileChangeRequest;
+import org.eclipse.equinox.p2.query.QueryUtil;
+
+public class FormerState {
+
+	public static IProfileChangeRequest generateProfileDeltaChangeRequest(IProfile current, IProfile target) {
+		ProfileChangeRequest request = new ProfileChangeRequest(current);
+
+		synchronizeProfileProperties(request, current, target);
+		synchronizeMarkedIUs(request, current, target);
+		synchronizeAllIUProperties(request, current, target);
+
+		return request;
+	}
+
+	private static void synchronizeAllIUProperties(IProfileChangeRequest request, IProfile current, IProfile target) {
+		Set<IInstallableUnit> currentIUset = current.query(QueryUtil.createIUAnyQuery(), null).toUnmodifiableSet();
+		Iterator<IInstallableUnit> targetIUs = target.query(QueryUtil.createIUAnyQuery(), null).iterator();
+		List<IInstallableUnit> iusToAdd = new ArrayList<IInstallableUnit>();
+		List<IInstallableUnit> iusToUpdate = new ArrayList<IInstallableUnit>();
+		while (targetIUs.hasNext()) {
+			IInstallableUnit nxt = targetIUs.next();
+			if (currentIUset.contains(nxt))
+				iusToUpdate.add(nxt);
+			else
+				iusToAdd.add(nxt);
+		}
+
+		//additions
+		for (IInstallableUnit iu : iusToAdd) {
+			for (Entry<String, String> entry : target.getInstallableUnitProperties(iu).entrySet()) {
+				request.setInstallableUnitProfileProperty(iu, entry.getKey(), entry.getValue());
+			}
+		}
+
+		// updates
+		for (IInstallableUnit iu : iusToUpdate) {
+			Map<String, String> propertiesToSet = new HashMap<String, String>(target.getInstallableUnitProperties(iu));
+			for (Entry<String, String> entry : current.getInstallableUnitProperties(iu).entrySet()) {
+				String key = entry.getKey();
+				String newValue = propertiesToSet.get(key);
+				if (newValue == null) {
+					request.removeInstallableUnitProfileProperty(iu, key);
+				} else if (newValue.equals(entry.getValue()))
+					propertiesToSet.remove(key);
+			}
+
+			for (Entry<String, String> entry : propertiesToSet.entrySet()) {
+				request.setInstallableUnitProfileProperty(iu, entry.getKey(), entry.getValue());
+			}
+		}
+	}
+
+	private static void synchronizeMarkedIUs(IProfileChangeRequest request, IProfile current, IProfile target) {
+		Collection<IInstallableUnit> currentPlannerMarkedIUs = SimplePlanner.findPlannerMarkedIUs(current);
+		Collection<IInstallableUnit> targetPlannerMarkedIUs = SimplePlanner.findPlannerMarkedIUs(target);
+
+		//additions
+		Collection<IInstallableUnit> markedIUsToAdd = new HashSet<IInstallableUnit>(targetPlannerMarkedIUs);
+		markedIUsToAdd.removeAll(currentPlannerMarkedIUs);
+		request.addAll(markedIUsToAdd);
+
+		// removes
+		Collection<IInstallableUnit> markedIUsToRemove = new HashSet<IInstallableUnit>(currentPlannerMarkedIUs);
+		markedIUsToRemove.removeAll(targetPlannerMarkedIUs);
+		request.removeAll(markedIUsToRemove);
+	}
+
+	private static void synchronizeProfileProperties(IProfileChangeRequest request, IProfile current, IProfile target) {
+		Map<String, String> profilePropertiesToSet = new HashMap<String, String>(target.getProperties());
+		for (Entry<String, String> entry : current.getProperties().entrySet()) {
+			String key = entry.getKey();
+
+			String newValue = profilePropertiesToSet.get(key);
+			if (newValue == null) {
+				request.removeProfileProperty(key);
+			} else if (newValue.equals(entry.getValue()))
+				profilePropertiesToSet.remove(key);
+		}
+
+		for (Entry<String, String> entry : profilePropertiesToSet.entrySet()) {
+			request.setProfileProperty(entry.getKey(), entry.getValue());
+		}
+	}
+}

--- a/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/provisional/p2/director/IDirector.java
+++ b/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/provisional/p2/director/IDirector.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ *  Copyright (c) 2007, 2010 IBM Corporation and others.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ * 
+ *  Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.equinox.internal.provisional.p2.director;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.equinox.p2.engine.IProfile;
+import org.eclipse.equinox.p2.engine.ProvisioningContext;
+import org.eclipse.equinox.p2.planner.IProfileChangeRequest;
+
+/**
+ * Directors are responsible for determining what should be done to a given 
+ * profile to reshape it as requested. That is, given the current state of a 
+ * profile, a description of the desired end state of that profile and metadata 
+ * describing the available IUs, a director produces a list of provisioning 
+ * operations (e.g., install, update or uninstall) to perform on the related IUs. 
+ * Directors are also able to validate profiles and assist in the diagnosis of 
+ * configuration errors. Note that directors may range in complexity from 
+ * very simple (e.g., reading a list of bundles from a static file) to very complex. 
+ */
+public interface IDirector {
+
+	/**
+	 * Service name constant for the director service.
+	 */
+	public static final String SERVICE_NAME = IDirector.class.getName();
+
+	/**
+	 * performs the change request with the given context.
+	 * 
+	 * @param profileChangeRequest The change request
+	 * @param context The provisioning context used for finding resources
+	 * @param monitor a progress monitor, or <code>null</code> if progress
+	 *    reporting is not desired
+	 */
+	public IStatus provision(IProfileChangeRequest profileChangeRequest, ProvisioningContext context, IProgressMonitor monitor);
+
+	/**
+	 * Reverts the profile to a previous state described in the target revertProfile.
+	 * 
+	 * @param profile The profile to revert
+	 * @param revertProfile The profile snapshot state to revert to
+	 * @param context The provisioning context used for finding resources
+	 * @param monitor a progress monitor, or <code>null</code> if progress
+	 *    reporting is not desired
+	 */
+	public IStatus revert(IProfile profile, IProfile revertProfile, ProvisioningContext context, IProgressMonitor monitor);
+}

--- a/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/provisional/p2/director/PlanExecutionHelper.java
+++ b/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/provisional/p2/director/PlanExecutionHelper.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2010 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.equinox.internal.provisional.p2.director;
+
+import java.io.IOException;
+import org.eclipse.core.runtime.*;
+import org.eclipse.equinox.internal.p2.core.helpers.ServiceHelper;
+import org.eclipse.equinox.internal.p2.director.DirectorActivator;
+import org.eclipse.equinox.internal.p2.director.Messages;
+import org.eclipse.equinox.internal.provisional.configurator.Configurator;
+import org.eclipse.equinox.p2.engine.*;
+
+public class PlanExecutionHelper {
+	public static IStatus executePlan(IProvisioningPlan result, IEngine engine, ProvisioningContext context, IProgressMonitor progress) {
+		return executePlan(result, engine, PhaseSetFactory.createDefaultPhaseSet(), context, progress);
+	}
+
+	public static IStatus executePlan(IProvisioningPlan result, IEngine engine, IPhaseSet phaseSet, ProvisioningContext context, IProgressMonitor progress) {
+		if (!result.getStatus().isOK())
+			return result.getStatus();
+
+		if (result.getInstallerPlan() != null) {
+			IStatus installerPlanStatus = ((IEngine) result.getInstallerPlan().getProfile().getProvisioningAgent().getService(IEngine.SERVICE_NAME)).perform(result.getInstallerPlan(), phaseSet, progress);
+			if (!installerPlanStatus.isOK())
+				return installerPlanStatus;
+			Configurator configChanger = (Configurator) ServiceHelper.getService(DirectorActivator.context, Configurator.class.getName());
+			try {
+				configChanger.applyConfiguration();
+			} catch (IOException e) {
+				return new Status(IStatus.ERROR, DirectorActivator.PI_DIRECTOR, Messages.Director_error_applying_configuration, e);
+			}
+		}
+		return engine.perform(result, phaseSet, progress);
+	}
+}

--- a/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/provisional/p2/director/PlannerStatus.java
+++ b/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/provisional/p2/director/PlannerStatus.java
@@ -1,0 +1,127 @@
+/*******************************************************************************
+ * Copyright (c) 2011 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.equinox.internal.provisional.p2.director;
+
+import java.util.Map;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.equinox.p2.metadata.IInstallableUnit;
+import org.eclipse.equinox.p2.query.*;
+
+public class PlannerStatus implements IStatus {
+
+	private final IStatus status;
+	private final RequestStatus globalRequestStatus;
+	private final Map<IInstallableUnit, RequestStatus> requestChanges;
+	private final Map<IInstallableUnit, RequestStatus> requestSideEffects;
+	private final IQueryable<IInstallableUnit> plannedState;
+
+	private static final IQueryable<IInstallableUnit> EMPTY_IU_QUERYABLE = new IQueryable<IInstallableUnit>() {
+		public IQueryResult<IInstallableUnit> query(IQuery<IInstallableUnit> query, IProgressMonitor monitor) {
+			return Collector.emptyCollector();
+		}
+	};
+
+	public PlannerStatus(IStatus status, RequestStatus globalRequestStatus, Map<IInstallableUnit, RequestStatus> requestChanges, Map<IInstallableUnit, RequestStatus> requestSideEffects, IQueryable<IInstallableUnit> plannedState) {
+		this.status = status;
+		this.globalRequestStatus = globalRequestStatus;
+		this.requestChanges = requestChanges;
+		this.requestSideEffects = requestSideEffects;
+		this.plannedState = (plannedState == null) ? EMPTY_IU_QUERYABLE : plannedState;
+	}
+
+	/**
+	 * Returns a request status object containing additional global details on the planning of the request
+	 * 
+	 * @return An IStatus object with global details on the planning process
+	 */
+	public RequestStatus getRequestStatus() {
+		return globalRequestStatus;
+	}
+
+	/**
+	 * Returns a map of the problems associated with changes to the given installable unit
+	 * in this plan. A status with severity {@link IStatus#OK} is returned if the unit
+	 * can be provisioned successfully
+	 * 
+	 * @return A map of {@link IInstallableUnit} to {@link IStatus} of the requested 
+	 * changes and their corresponding explanation.
+	 */
+	public Map<IInstallableUnit, RequestStatus> getRequestChanges() {
+		return requestChanges;
+	}
+
+	/**
+	 * Returns a map of side-effects that will occur as a result of the plan being executed.
+	 * Side-effects of an install may include:
+	 * <ul>
+	 * <li>Optional software being installed that will become satisfied once the plan
+	 * is executed.</li>
+	 * <li>Optional software currently in the profile that will be uninstalled as a result
+	 * of the plan being executed. This occurs when the optional software has dependencies
+	 * that are incompatible with the software being installed.
+	 * This includes additional software that will be installed as a result of the change,
+	 * or optional changes and their corresponding explanation.
+	 * @return A map of {@link IInstallableUnit} to {@link IStatus} of the additional side effect
+	 * status, or <code>null</code> if there are no side effects.
+	 */
+	public Map<IInstallableUnit, RequestStatus> getRequestSideEffects() {
+		return requestSideEffects;
+	}
+
+	/**
+	 * Returns the set of InstallableUnits that make up the expected planned state in terms 
+	 * of additions and removals to the profile based on the planning process. 
+	 * 
+	 * @return An IQueryable of the InstallableUnits in the planned state. 
+	 */
+	public IQueryable<IInstallableUnit> getPlannedState() {
+		return plannedState;
+	}
+
+	// Remaining Methods Delegate to wrapped Status 
+	public IStatus[] getChildren() {
+		return status.getChildren();
+	}
+
+	public int getCode() {
+		return status.getCode();
+	}
+
+	public Throwable getException() {
+		return status.getException();
+	}
+
+	public String getMessage() {
+		return status.getMessage();
+	}
+
+	public String getPlugin() {
+		return status.getPlugin();
+	}
+
+	public int getSeverity() {
+		return status.getSeverity();
+	}
+
+	public boolean isMultiStatus() {
+		return status.isMultiStatus();
+	}
+
+	public boolean isOK() {
+		return status.isOK();
+	}
+
+	public boolean matches(int severityMask) {
+		return status.matches(severityMask);
+	}
+
+}

--- a/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/provisional/p2/director/RequestStatus.java
+++ b/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/provisional/p2/director/RequestStatus.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2008, 2010 IBM Corporation and others. All rights reserved. This
+ * program and the accompanying materials are made available under the terms of
+ * the Eclipse Public License v1.0 which accompanies this distribution, and is
+ * available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * 	IBM Corporation - initial API and implementation
+ ******************************************************************************/
+package org.eclipse.equinox.internal.provisional.p2.director;
+
+import java.util.*;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.equinox.internal.p2.director.*;
+import org.eclipse.equinox.internal.p2.director.Explanation.IUInstalled;
+import org.eclipse.equinox.internal.p2.director.Explanation.IUToInstall;
+import org.eclipse.equinox.p2.metadata.IInstallableUnit;
+import org.eclipse.osgi.util.NLS;
+
+public class RequestStatus extends Status {
+	public static final byte ADDED = 0;
+	public static final byte REMOVED = 1;
+
+	private byte initialRequestType;
+	private IInstallableUnit iu;
+	private Set<Explanation> explanation;
+	private Explanation detailedExplanation;
+	private Set<IInstallableUnit> conflictingRootIUs;
+	private Set<IInstallableUnit> conflictingInstalledIUs;
+
+	public RequestStatus(IInstallableUnit iu, byte initialRequesType, int severity, Set<Explanation> explanation) {
+		super(severity, DirectorActivator.PI_DIRECTOR, NLS.bind(Messages.RequestStatus_message, iu));
+		this.iu = iu;
+		this.initialRequestType = initialRequesType;
+		this.explanation = explanation;
+		conflictingRootIUs = new HashSet<IInstallableUnit>();
+		conflictingInstalledIUs = new HashSet<IInstallableUnit>();
+		if (explanation != null) {
+			Iterator<Explanation> iterator = explanation.iterator();
+			Explanation o = null;
+			while (iterator.hasNext() && ((o = iterator.next()) instanceof Explanation.IUToInstall)) {
+				conflictingRootIUs.add(((IUToInstall) o).iu);
+			}
+			if (o instanceof Explanation.IUInstalled) {
+				conflictingInstalledIUs.add(((IUInstalled) o).iu);
+				while (iterator.hasNext() && ((o = iterator.next()) instanceof Explanation.IUInstalled)) {
+					conflictingInstalledIUs.add(((IUInstalled) o).iu);
+				}
+			}
+			detailedExplanation = o;
+		}
+	}
+
+	public byte getInitialRequestType() {
+		return initialRequestType;
+	}
+
+	public IInstallableUnit getIu() {
+		return iu;
+	}
+
+	//Return the already installed roots with which this IU is in conflict
+	//Return an empty set if there is no conflict
+	public Set<IInstallableUnit> getConflictsWithInstalledRoots() {
+		return conflictingRootIUs;
+	}
+
+	//Return the already installed roots with which this IU is in conflict
+	//Return an empty set if there is no conflict
+	public Set<IInstallableUnit> getConflictsWithAnyRoots() {
+		return conflictingInstalledIUs;
+	}
+
+	//Return an explanation as to why this IU can not be resolved.
+	public Set<Explanation> getExplanations() {
+		//To start with, this does not have to return the most specific explanation. If it simply returns an global explanation it is good enough.
+		return explanation;
+	}
+
+	public int getShortExplanation() {
+		return detailedExplanation.shortAnswer();
+	}
+
+	public Explanation getExplanationDetails() {
+		return detailedExplanation;
+	}
+}

--- a/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/p2/planner/IPlanner.java
+++ b/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/p2/planner/IPlanner.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ *  Copyright (c) 2007, 2010 IBM Corporation and others.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ * 
+ *  Contributors:
+ *     IBM Corporation - initial API and implementation
+ *     Sonatype, Inc. - ongoing development
+ *******************************************************************************/
+package org.eclipse.equinox.p2.planner;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.equinox.p2.engine.*;
+import org.eclipse.equinox.p2.metadata.IInstallableUnit;
+import org.eclipse.equinox.p2.query.IQueryResult;
+
+/**
+ * Planners are responsible for determining what should be done to a given 
+ * profile to reshape it as requested. That is, given the current state of a 
+ * profile, a description of the desired changes to that profile and metadata 
+ * describing the available installable units, a planner produces a concrete plan that lists the
+ * exact steps that the engine should perform.
+ * 
+ * @noimplement This interface is not intended to be implemented by clients.
+ * @noextend This interface is not intended to be extended by clients.
+ * @since 2.0
+ */
+public interface IPlanner {
+	/**
+	 * Service name constant for the planner service.
+	 */
+	public static final String SERVICE_NAME = IPlanner.class.getName();
+
+	/**
+	 * Returns a plan describing the set of changes that must be performed to
+	 * satisfy the given profile change request.
+	 * 
+	 * @param profileChangeRequest the request to be evaluated
+	 * @param context the context in which the request is processed
+	 * @param monitor a monitor on which planning
+	 * @return the plan representing the system that needs to be
+	 */
+	public IProvisioningPlan getProvisioningPlan(IProfileChangeRequest profileChangeRequest, ProvisioningContext context, IProgressMonitor monitor);
+
+	public IProvisioningPlan getDiffPlan(IProfile currentProfile, IProfile targetProfile, IProgressMonitor monitor);
+
+	public IProfileChangeRequest createChangeRequest(IProfile profileToChange);
+
+	/**
+	 * @noreference This method is not intended to be referenced by clients. 
+	 * You may want to consider using the org.eclipse.equinox.p2.operations.UpdateOperation class instead. 
+	 */
+	public IQueryResult<IInstallableUnit> updatesFor(IInstallableUnit iu, ProvisioningContext context, IProgressMonitor monitor);
+}

--- a/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/p2/planner/IProfileChangeRequest.java
+++ b/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/p2/planner/IProfileChangeRequest.java
@@ -1,0 +1,134 @@
+/*******************************************************************************
+ *  Copyright (c) 2010, 2013 Sonatype, Inc and others.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ * 
+ *  Contributors:
+ *     Sonatype, Inc. - initial API and implementation
+ *     IBM Corporation - ongoing development
+ *     Rapicorp, Inc. - ongoing development
+ *******************************************************************************/
+package org.eclipse.equinox.p2.planner;
+
+import java.util.Collection;
+import org.eclipse.equinox.p2.engine.IProfile;
+import org.eclipse.equinox.p2.metadata.IInstallableUnit;
+import org.eclipse.equinox.p2.metadata.IRequirement;
+
+/**
+ *  A profile change request is a description of a set of changes that a client
+ *  would like to perform on a profile. The request is provided as input to an
+ *  {@link IPlanner}, which validates which of the requested changes can be
+ *  performed, and what other changes are required in order to make the profile
+ *  state consistent.
+ *
+ *  It is important to note that a change request can only be submitted once to the planner.
+ *  
+ *  Clients should create and manipulate profile change requests via the API {@link IPlanner#createChangeRequest(IProfile)}.
+ *  
+ * @noimplement This interface is not intended to be implemented by clients.
+ * @noextend This interface is not intended to be extended by clients.
+ * @since 2.0
+ */
+public interface IProfileChangeRequest {
+
+	/**
+	 * Causes the installation of the mentioned IU.
+	 * @param toInstall the entity to add to the profile
+	 */
+	public abstract void add(IInstallableUnit toInstall);
+
+	/**
+	 * Causes the installation of all the IUs mentioned
+	 * @param toInstall the installable units to be added to the profile
+	 */
+	public abstract void addAll(Collection<IInstallableUnit> toInstall);
+
+	/**
+	 * Requests the removal of the specified installable unit
+	 * 
+	 * @param toUninstall the installable units to be remove from the profile
+	 */
+	public abstract void remove(IInstallableUnit toUninstall);
+
+	/**
+	 * Requests the removal of all installable units in the provided collection
+	 * @param toUninstall the installable units to be remove from the profile
+	 */
+	public abstract void removeAll(Collection<IInstallableUnit> toUninstall);
+
+	/**
+	 * Add extra requirements that must be satisfied by the planner.
+	 * 
+	 * @param requirements the additional requirements
+	 */
+	public void addExtraRequirements(Collection<IRequirement> requirements);
+
+	/**
+	 * Associate an inclusion rule with the installable unit. An inclusion rule will dictate how
+	 * the installable unit is treated when its dependencies are not satisfied.
+	 * <p>
+	 * The provided inclusion rule must be one of the values specified in {@link ProfileInclusionRules}.
+	 * </p>
+	 * @param iu the installable unit to set an inclusion rule for
+	 * @param inclusionRule The inclusion rule.
+	 */
+	public abstract void setInstallableUnitInclusionRules(IInstallableUnit iu, String inclusionRule);
+
+	/**
+	 * Removes all inclusion rules associated with the given installable unit
+	 * 
+	 * @param iu the installable unit to remove inclusion rules for
+	 */
+	public abstract void removeInstallableUnitInclusionRules(IInstallableUnit iu);
+
+	/** 
+	 * Set a global property on the profile
+	 * 
+	 * @param key key of the property
+	 * @param value value of the property
+	 */
+	public abstract void setProfileProperty(String key, String value);
+
+	/** 
+	 * Remove a global property on the profile
+	 * 
+	 * @param key key of the property
+	 */
+	public abstract void removeProfileProperty(String key);
+
+	/** 
+	 * Associate a property with a given installable unit.
+	 * 
+	 * @param key key of the property
+	 * @param value value of the property
+	 */
+	public abstract void setInstallableUnitProfileProperty(IInstallableUnit iu, String key, String value);
+
+	/** 
+	 * Remove a property with a given installable unit.
+	 * @param iu The installable until to remove a property for
+	 * @param key key of the property
+	 */
+	public abstract void removeInstallableUnitProfileProperty(IInstallableUnit iu, String key);
+
+	/**
+	 *  Provide the set of installable units that have been requested for addition
+	 * @return a collection of the installable units to add
+	 */
+	public abstract Collection<IInstallableUnit> getAdditions();
+
+	/**
+	 *  Provide the set of installable units that have been requested for removal
+	 * @return a collection of the installable units to remove
+	 */
+	public abstract Collection<IInstallableUnit> getRemovals();
+
+	/**
+	 * Get the extra requirements that have been specified through method {@link #addExtraRequirements(Collection)}
+	 * @since 2.2
+	 */
+	public abstract Collection<IRequirement> getExtraRequirements();
+}

--- a/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/p2/planner/ProfileInclusionRules.java
+++ b/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/p2/planner/ProfileInclusionRules.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ *  Copyright (c) 2008, 2010 IBM Corporation and others.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ * 
+ *  Contributors:
+ *      IBM Corporation - initial API and implementation
+ *      Sonatype Inc - Refactoring
+ *******************************************************************************/
+package org.eclipse.equinox.p2.planner;
+
+import org.eclipse.equinox.p2.metadata.IInstallableUnit;
+
+/**
+ * Helper method to decide on the way the installable units are being included.
+ * @noinstantiate This class is not intended to be instantiated by clients.
+ * @noextend This class is not intended to be subclassed by clients.
+ * @since 2.0
+ */
+public class ProfileInclusionRules {
+	private ProfileInclusionRules() {
+		//Can't instantiate profile inclusion rules
+	}
+
+	/**
+	 * Returns an inclusion rule to strictly install the given installable unit. Strictly
+	 * installed installable units will never be uninstalled in order to satisfy a
+	 * later profile change request. That is, when there is a dependency conflict
+	 * between a strictly installed unit and a non-strict unit, the strictly installed
+	 * installable unit will take precedence.
+	 * 
+	 * @param iu the installable unit to be installed.
+	 * @return an opaque token to be passed to the {@link IProfileChangeRequest#setInstallableUnitInclusionRules(IInstallableUnit, String)}
+	 */
+	public static String createStrictInclusionRule(IInstallableUnit iu) {
+		return "STRICT"; //$NON-NLS-1$
+	}
+
+	/**
+	 * Returns an inclusion rule to optionally install the given installable unit. An optionally
+	 * installed installable unit will automatically be removed from the profile if any of
+	 * its dependencies become unsatisfied.
+	 * 
+	 * @param iu the installable unit to be installed.
+	 * @return an opaque token to be passed to the {@link IProfileChangeRequest#setInstallableUnitInclusionRules(IInstallableUnit, String)}
+	 */
+	public static String createOptionalInclusionRule(IInstallableUnit iu) {
+		return "OPTIONAL"; //$NON-NLS-1$
+	}
+}

--- a/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/p2/planner/package.html
+++ b/plugins/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/p2/planner/package.html
@@ -1,0 +1,18 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html>
+<head>
+   <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+   <title>Package-level Javadoc</title>
+</head>
+<body>
+Provides core support for interacting with a dependency resolution mechanism.
+<h2>
+Package Specification</h2>
+<p>
+This package specifies an API for performing dependency resolution of the p2 metadata. 
+</p>
+<p>
+@since 2.0
+<p>
+</body>
+</html>


### PR DESCRIPTION
Added a new plugin equinox.p2.director to disable the appcelerator specific updates in the update toast during startup.

The specific minor changes are in SimplerPlanner.updatesFor() method to avoid considering appcelerator updates. Those updates will always be considered in our startup or Check for Appcelerator updates action.
