### PR TITLE
TISTUD-6018 Object property content assist missing inside object declaration

### DIFF
--- a/plugins/com.aptana.js.core/src/com/aptana/js/core/model/ParameterElement.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/core/model/ParameterElement.java
@@ -11,12 +11,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import com.aptana.jetty.util.epl.ajax.JSON.Convertible;
-import com.aptana.jetty.util.epl.ajax.JSON.Output;
-
 import com.aptana.core.util.CollectionsUtil;
 import com.aptana.core.util.StringUtil;
 import com.aptana.index.core.IndexUtil;
+import com.aptana.jetty.util.epl.ajax.JSON.Convertible;
+import com.aptana.jetty.util.epl.ajax.JSON.Output;
 
 public class ParameterElement implements Convertible
 {
@@ -66,7 +65,16 @@ public class ParameterElement implements Convertible
 		this.setUsage(StringUtil.getStringValue(object.get(USAGE_PROPERTY)));
 		this.setDescription(StringUtil.getStringValue(object.get(DESCRIPTION_PROPERTY)));
 
-		this._types = IndexUtil.createList(object.get(TYPES_PROPERTY));
+		// JSCA contains a single "type" value
+		if (object.containsKey("type"))
+		{
+			this._types = CollectionsUtil.newList((String) object.get("type"));
+		}
+		else
+		{
+			// Our index contains multiple types as a list
+			this._types = IndexUtil.createList(object.get(TYPES_PROPERTY));
+		}
 	}
 
 	/**

--- a/tests/com.aptana.editor.js.tests/metadata/tistud-6018.jsca
+++ b/tests/com.aptana.editor.js.tests/metadata/tistud-6018.jsca
@@ -1,0 +1,81 @@
+{
+	"types": [
+		{
+			"name": "Titanium.UI",
+            "functions": [
+            {
+                    "name": "createView", 
+                    "isInternal": false, 
+                    "parameters": [
+                        {
+                            "name": "parameters", 
+                            "usage": "optional", 
+                            "type": "Titanium.UI.View", 
+                            "description": "<p>Properties to set on a new object, including any defined by Titanium.UI.View except those marked not-creation or read-only.</p>"
+                        }
+                    ], 
+                    "deprecated": false, 
+                    "since": [
+                        {
+                            "name": "Titanium Mobile SDK - Android", 
+                            "version": "0.9"
+                        }, 
+                        {
+                            "name": "Titanium Mobile SDK - BlackBerry", 
+                            "version": "3.1.2"
+                        }, 
+                        {
+                            "name": "Titanium Mobile SDK - iPhone", 
+                            "version": "0.9"
+                        }, 
+                        {
+                            "name": "Titanium Mobile SDK - iPad", 
+                            "version": "0.9"
+                        }, 
+                        {
+                            "name": "Titanium Mobile SDK - Mobile Web", 
+                            "version": "1.8"
+                        }, 
+                        {
+                            "name": "Titanium Mobile SDK - Tizen", 
+                            "version": "3.1"
+                        }
+                    ], 
+                    "returnTypes": [
+                        {
+                            "type": "Titanium.UI.View", 
+                            "description": ""
+                        }
+                    ], 
+                    "isConstructor": false, 
+                    "isClassProperty": false, 
+                    "examples": [], 
+                    "userAgents": [
+                        {
+                            "platform": "android"
+                        }, 
+                        {
+                            "platform": "blackberry"
+                        }, 
+                        {
+                            "platform": "iphone"
+                        }, 
+                        {
+                            "platform": "ipad"
+                        }, 
+                        {
+                            "platform": "mobileweb"
+                        }, 
+                        {
+                            "platform": "tizen"
+                        }
+                    ], 
+                    "exceptions": [], 
+                    "references": [], 
+                    "isMethod": true, 
+                    "isInstanceProperty": true, 
+                    "description": "<p>Creates and returns an instance of Titanium.UI.View.</p>"
+                }]
+		}
+	]
+}

--- a/tests/com.aptana.editor.js.tests/src/com/aptana/editor/js/index/JSCAIndexingTest.java
+++ b/tests/com.aptana.editor.js.tests/src/com/aptana/editor/js/index/JSCAIndexingTest.java
@@ -39,6 +39,8 @@ import com.aptana.index.core.IndexManager;
 import com.aptana.index.core.IndexPlugin;
 import com.aptana.js.core.index.JSCAFileIndexingParticipant;
 import com.aptana.js.core.index.JSIndexQueryHelper;
+import com.aptana.js.core.model.FunctionElement;
+import com.aptana.js.core.model.ParameterElement;
 import com.aptana.js.core.model.PropertyElement;
 import com.aptana.js.core.model.TypeElement;
 import com.aptana.js.internal.core.index.JSIndexReader;
@@ -287,6 +289,32 @@ public class JSCAIndexingTest extends JSEditorBasedTestCase
 		assertNotNull(
 				"Titanium.UI is missing the create2DMatrix function. Did a temporary type not get merged with real definition?",
 				p);
+	}
+
+	/**
+	 * Test for TISTUD-6018
+	 * 
+	 * @throws CoreException
+	 */
+	@Test
+	public void testSingleTypeForParameterIsHandledProperly() throws CoreException
+	{
+		Index index = indexResource("metadata/tistud-6018.jsca");
+
+		// make sure target type exists
+		TypeElement t = assertTypeInIndex(index, "Titanium.UI", true);
+
+		PropertyElement p = t.getProperty("createView");
+		assertNotNull(
+				"Titanium.UI is missing the createView function. Did a temporary type not get merged with real definition?",
+				p);
+
+		List<ParameterElement> params = ((FunctionElement) p).getParameters();
+		assertEquals(1, params.size());
+		ParameterElement param = params.get(0);
+		List<String> types = param.getTypes();
+		assertEquals(1, types.size());
+		assertEquals("Titanium.UI.View", types.get(0));
 	}
 
 	protected IndexManager getIndexManager()


### PR DESCRIPTION
Fix for when JSCA uses a single "type" property for parameters for functions (whereas our internal model uses a list of for a "types" property).

This is another bug stemming from a mismatch in how JSCA formats the model in JSON and how we format the same data in JSON in our indices.
