### PR TITLE
Supporting changes for TISTUD-3814 Alloy: add hover info for element names in Alloy .xml file

### DIFF
--- a/plugins/com.aptana.buildpath.core/src/com/aptana/buildpath/core/BuildPathManager.java
+++ b/plugins/com.aptana.buildpath.core/src/com/aptana/buildpath/core/BuildPathManager.java
@@ -13,6 +13,7 @@ import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -29,8 +30,8 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.QualifiedName;
 import org.osgi.framework.Bundle;
 
+import com.aptana.core.IMap;
 import com.aptana.core.logging.IdeLog;
-import com.aptana.core.util.BuildUtil;
 import com.aptana.core.util.CollectionsUtil;
 import com.aptana.core.util.ConfigurationElementDispatcher;
 import com.aptana.core.util.EclipseUtil;
@@ -39,14 +40,15 @@ import com.aptana.core.util.ResourceUtil;
 import com.aptana.core.util.StringUtil;
 import com.aptana.index.core.IndexContainerJob;
 import com.aptana.index.core.IndexFileJob;
-import com.aptana.projects.primary.natures.IPrimaryNatureContributor;
-import com.aptana.projects.primary.natures.PrimaryNaturesManager;
 
 /**
  * BuildPathManager
  */
 public class BuildPathManager
 {
+	private static final String BUILD_PATH_ENTRY_DELIMITER = "\0"; //$NON-NLS-1$
+	private static final String NAME_AND_PATH_DELIMITER = "\t"; //$NON-NLS-1$
+
 	private static final String PROJECT_BUILD_PATH_PROPERTY_NAME = "projectBuildPath"; //$NON-NLS-1$
 
 	private static final String BUILD_PATHS_ID = "buildPaths"; //$NON-NLS-1$
@@ -75,7 +77,7 @@ public class BuildPathManager
 		return instance;
 	}
 
-	private Set<BuildPathEntry> buildPaths;
+	private Set<IBuildPathEntry> whitelistedBuildPaths;
 	private List<IBuildPathContributor> contributors;
 
 	/**
@@ -89,18 +91,22 @@ public class BuildPathManager
 	 * Add a new build path entry to this manager
 	 * 
 	 * @param entry
+	 * @return whether the entry was added or not.
 	 */
-	public void addBuildPath(BuildPathEntry entry)
+	public boolean addBuildPath(IBuildPathEntry entry)
 	{
-		if (entry != null)
+		if (entry == null)
 		{
-			if (buildPaths == null)
-			{
-				buildPaths = new LinkedHashSet<BuildPathEntry>();
-			}
-
-			buildPaths.add(entry);
+			return false;
 		}
+
+		if (whitelistedBuildPaths == null)
+		{
+			// FIXME We need to synchronize on modifications and lazy init of this field!
+			whitelistedBuildPaths = new LinkedHashSet<IBuildPathEntry>();
+		}
+
+		return whitelistedBuildPaths.add(entry);
 	}
 
 	/**
@@ -108,22 +114,25 @@ public class BuildPathManager
 	 * 
 	 * @param project
 	 * @param entry
+	 * @return whether the entry was added or not. An entry may not get added because it already exists
 	 */
-	public void addBuildPath(IProject project, IBuildPathEntry entry)
+	public boolean addBuildPath(IProject project, IBuildPathEntry entry)
 	{
-		if (project != null && entry != null)
+		if (project == null || entry == null)
 		{
-			Set<IBuildPathEntry> buildPaths = getBuildPaths(project);
-
-			if (!buildPaths.contains(entry))
-			{
-				buildPaths.add(entry);
-
-				setBuildPaths(project, buildPaths);
-
-				index(entry);
-			}
+			return false;
 		}
+
+		// Use a copy, because we're going to modify
+		Set<IBuildPathEntry> buildPaths = new HashSet<IBuildPathEntry>(getBuildPaths(project));
+		if (buildPaths.add(entry))
+		{
+			setBuildPaths(project, buildPaths);
+			index(entry);
+			return true;
+		}
+
+		return false;
 	}
 
 	/**
@@ -161,12 +170,13 @@ public class BuildPathManager
 	 * @param displayName
 	 * @param path
 	 */
-	public void addBuildPath(String displayName, URI path)
+	private boolean addBuildPath(String displayName, URI path)
 	{
 		if (!StringUtil.isEmpty(displayName) && path != null)
 		{
-			addBuildPath(new BuildPathEntry(displayName, path));
+			return addBuildPath(new BuildPathEntry(displayName, path));
 		}
+		return false;
 	}
 
 	/**
@@ -174,31 +184,30 @@ public class BuildPathManager
 	 * 
 	 * @param contributor
 	 */
-	protected void addContributor(IBuildPathContributor contributor)
+	private boolean addContributor(IBuildPathContributor contributor)
 	{
-		if (contributor != null)
+		if (contributor == null)
 		{
-			if (contributors == null)
-			{
-				contributors = new ArrayList<IBuildPathContributor>();
-			}
-
-			contributors.add(contributor);
+			return false;
 		}
+
+		if (contributors == null)
+		{
+			// FIXME need to synchronize on lazy init of field!
+			contributors = new ArrayList<IBuildPathContributor>();
+		}
+
+		return contributors.add(contributor);
 	}
 
-	/**
-	 * getBuildPathPropertyName
-	 * 
-	 * @return
-	 */
-	protected QualifiedName getBuildPathPropertyName()
+	private QualifiedName getBuildPathPropertyName()
 	{
 		return new QualifiedName(BuildPathCorePlugin.PLUGIN_ID, PROJECT_BUILD_PATH_PROPERTY_NAME);
 	}
 
 	/**
-	 * getBuildPaths
+	 * Returns the list of all possible valid build paths globally. Used primarily to display the list in the build path
+	 * UI for users to add/remove manually for a given project.
 	 * 
 	 * @return
 	 */
@@ -207,9 +216,9 @@ public class BuildPathManager
 		Set<IBuildPathEntry> result = new LinkedHashSet<IBuildPathEntry>();
 
 		// Add static paths, if we have any
-		if (buildPaths != null)
+		if (whitelistedBuildPaths != null)
 		{
-			result.addAll(buildPaths);
+			result.addAll(whitelistedBuildPaths);
 		}
 
 		// Add dynamic paths
@@ -219,7 +228,8 @@ public class BuildPathManager
 	}
 
 	/**
-	 * getBuildPaths
+	 * Returns the set of build paths for a project. This set cannot be relied upon for modifications (i.e. it is likely
+	 * to be unmodifiable). Make a copy if you plan to add/remove entries.
 	 * 
 	 * @param project
 	 * @return
@@ -235,34 +245,28 @@ public class BuildPathManager
 		Set<IBuildPathEntry> result = new LinkedHashSet<IBuildPathEntry>();
 		try
 		{
-			PrimaryNaturesManager manager = PrimaryNaturesManager.getManager();
-			String[] natureIds = project.getDescription().getNatureIds();
-			List<String> entries = new ArrayList<String>();
-			for (String natureId : natureIds)
-			{
-				IPrimaryNatureContributor contributor = manager.getPrimaryNatureContributor(natureId);
-				if (contributor != null)
-				{
-					entries.addAll(contributor.getBuildPathEntries(project, getBuildPathPropertyName()));
-				}
-			}
-			for (String entry : entries)
-			{
-				String[] nameAndPath = entry.split(BuildUtil.NAME_AND_PATH_DELIMITER);
+			String property = project.getPersistentProperty(getBuildPathPropertyName());
 
-				if (nameAndPath.length >= 2)
+			if (property != null)
+			{
+				String[] entries = property.split(BUILD_PATH_ENTRY_DELIMITER);
+				for (String entry : entries)
 				{
-					String name = nameAndPath[0];
-					String uri = nameAndPath[1];
+					String[] nameAndPath = entry.split(NAME_AND_PATH_DELIMITER);
 
-					try
+					if (nameAndPath.length >= 2)
 					{
-						URI path = Path.fromOSString(uri).toFile().toURI();
-						result.add(new BuildPathEntry(name, path));
-					}
-					catch (Exception e)
-					{
-						// @formatter:off
+						String name = nameAndPath[0];
+						String uri = nameAndPath[1];
+
+						try
+						{
+							URI path = new URI(uri);
+							result.add(new BuildPathEntry(name, path));
+						}
+						catch (Exception e)
+						{
+							// @formatter:off
 							String message = MessageFormat.format(
 								Messages.BuildPathManager_UnableToConvertURI,
 								uri,
@@ -271,7 +275,8 @@ public class BuildPathManager
 							);
 							// @formatter:on
 
-						IdeLog.logError(BuildPathCorePlugin.getDefault(), message, e);
+							IdeLog.logError(BuildPathCorePlugin.getDefault(), message, e);
+						}
 					}
 				}
 			}
@@ -289,41 +294,50 @@ public class BuildPathManager
 			IdeLog.logError(BuildPathCorePlugin.getDefault(), message, e);
 		}
 
+		// OK, now grab the build paths contributed dynamically by contributors for this project!
+		if (contributors != null)
+		{
+			for (IBuildPathContributor contributor : contributors)
+			{
+				List<IBuildPathEntry> entries = contributor.getBuildPathEntries(project);
+				if (!CollectionsUtil.isEmpty(entries))
+				{
+					result.addAll(entries);
+				}
+			}
+		}
+
 		if (!result.isEmpty())
 		{
 			// only include paths that are actually registered
 			result.retainAll(getBuildPaths());
 		}
 
-		return result;
+		// Don't allow modifications!
+		return Collections.unmodifiableSet(result);
 	}
 
 	/**
-	 * getDynamicBuildPaths
+	 * The set of globally available whitelisted build paths contributed by extensions.
 	 * 
 	 * @return
 	 */
 	private Set<IBuildPathEntry> getDynamicBuildPaths()
 	{
-		Set<IBuildPathEntry> result;
-
-		if (contributors != null)
+		if (CollectionsUtil.isEmpty(contributors))
 		{
-			result = new LinkedHashSet<IBuildPathEntry>();
-
-			for (IBuildPathContributor contributor : contributors)
-			{
-				List<IBuildPathEntry> files = contributor.getBuildPathEntries();
-
-				if (files != null)
-				{
-					result.addAll(files);
-				}
-			}
+			return Collections.emptySet();
 		}
-		else
+
+		Set<IBuildPathEntry> result = new LinkedHashSet<IBuildPathEntry>(contributors.size());
+		for (IBuildPathContributor contributor : contributors)
 		{
-			result = Collections.emptySet();
+			List<IBuildPathEntry> files = contributor.getBuildPathEntries();
+
+			if (files != null)
+			{
+				result.addAll(files);
+			}
 		}
 
 		return result;
@@ -335,13 +349,13 @@ public class BuildPathManager
 	 * @param entry
 	 * @return
 	 */
-	public boolean hasBuildPath(BuildPathEntry entry)
+	public boolean hasBuildPath(IBuildPathEntry entry)
 	{
 		return getBuildPaths().contains(entry);
 	}
 
 	/**
-	 * hasBuildPath
+	 * Does a given build path entry exist in the set attached to a project?
 	 * 
 	 * @param project
 	 * @param entry
@@ -349,16 +363,12 @@ public class BuildPathManager
 	 */
 	public boolean hasBuildPath(IProject project, IBuildPathEntry entry)
 	{
-		boolean result = false;
-
-		if (project != null && entry != null)
+		if (project == null || entry == null)
 		{
-			Set<IBuildPathEntry> buildPathSet = getBuildPaths(project);
-
-			result = buildPathSet.contains(entry);
+			return false;
 		}
 
-		return result;
+		return getBuildPaths(project).contains(entry);
 	}
 
 	private class BuildPathProcessor implements IConfigurationElementProcessor
@@ -506,12 +516,14 @@ public class BuildPathManager
 	 * 
 	 * @param entry
 	 */
-	public void removeBuildPath(BuildPathEntry entry)
+	public boolean removeBuildPath(IBuildPathEntry entry)
 	{
-		if (entry != null && buildPaths != null)
+		if (entry == null || whitelistedBuildPaths == null)
 		{
-			buildPaths.remove(entry);
+			return false;
 		}
+
+		return whitelistedBuildPaths.remove(entry);
 	}
 
 	/**
@@ -520,35 +532,22 @@ public class BuildPathManager
 	 * @param project
 	 * @param entry
 	 */
-	public void removeBuildPath(IProject project, IBuildPathEntry entry)
+	public boolean removeBuildPath(IProject project, IBuildPathEntry entry)
 	{
-		if (project != null && entry != null)
+		if (project == null || entry == null)
 		{
-			Set<IBuildPathEntry> entries = getBuildPaths(project);
-
-			if (entries.contains(entry))
-			{
-				entries.remove(entry);
-
-				setBuildPaths(project, entries);
-
-				// TODO Remove the index for it? Don't we need to see if no other references to it are out there?
-			}
+			return false;
 		}
-	}
 
-	/**
-	 * Remove an existing build path from this manager
-	 * 
-	 * @param displayName
-	 * @param path
-	 */
-	public void removeBuildPath(String displayName, URI path)
-	{
-		if (!StringUtil.isEmpty(displayName) && path != null)
+		// Use a copy!
+		Set<IBuildPathEntry> entries = new HashSet<IBuildPathEntry>(getBuildPaths(project));
+		if (entries.remove(entry))
 		{
-			removeBuildPath(new BuildPathEntry(displayName, path));
+			setBuildPaths(project, entries);
+			// TODO Remove the index for it? Don't we need to see if no other references to it are out there?
+			return true;
 		}
+		return false;
 	}
 
 	/**
@@ -557,30 +556,33 @@ public class BuildPathManager
 	 * @param project
 	 * @param entries
 	 */
-	public void setBuildPaths(IProject project, Collection<IBuildPathEntry> entries)
+	public boolean setBuildPaths(IProject project, Collection<IBuildPathEntry> entries)
 	{
-		if (project != null && entries != null)
+		if (project == null || entries == null)
 		{
-			List<String> nameAndPaths = new ArrayList<String>();
+			return false;
+		}
 
-			for (IBuildPathEntry entry : entries)
+		List<String> nameAndPaths = CollectionsUtil.map(entries, new IMap<IBuildPathEntry, String>()
+		{
+			public String map(IBuildPathEntry item)
 			{
-				String nameAndPath = entry.getDisplayName() + BuildUtil.NAME_AND_PATH_DELIMITER + entry.getPath();
-
-				nameAndPaths.add(nameAndPath);
+				return item.getDisplayName() + NAME_AND_PATH_DELIMITER + item.getPath();
 			}
+		});
 
-			String value = StringUtil.join(BuildUtil.BUILD_PATH_ENTRY_DELIMITER, nameAndPaths);
+		String value = StringUtil.join(BUILD_PATH_ENTRY_DELIMITER, nameAndPaths);
 
-			// FIXME This severely limits the value's size, which we could run into over time! It also does not make the
-			// value portable across users/workspaces
-			try
-			{
-				project.setPersistentProperty(getBuildPathPropertyName(), value);
-			}
-			catch (CoreException e)
-			{
-				// @formatter:off
+		// FIXME This severely limits the value's size, which we could run into over time! It also does not make the
+		// value portable across users/workspaces
+		try
+		{
+			project.setPersistentProperty(getBuildPathPropertyName(), value);
+			return true;
+		}
+		catch (CoreException e)
+		{
+			// @formatter:off
 				String message = MessageFormat.format(
 					Messages.BuildPathManager_UnableToSetPersistenceProperty,
 					PROJECT_BUILD_PATH_PROPERTY_NAME,
@@ -588,8 +590,8 @@ public class BuildPathManager
 				);
 				// @formatter:on
 
-				IdeLog.logError(BuildPathCorePlugin.getDefault(), message, e);
-			}
+			IdeLog.logError(BuildPathCorePlugin.getDefault(), message, e);
+			return false;
 		}
 	}
 }

--- a/plugins/com.aptana.buildpath.core/src/com/aptana/buildpath/core/IBuildPathContributor.java
+++ b/plugins/com.aptana.buildpath.core/src/com/aptana/buildpath/core/IBuildPathContributor.java
@@ -9,15 +9,27 @@ package com.aptana.buildpath.core;
 
 import java.util.List;
 
+import org.eclipse.core.resources.IProject;
+
 /**
  * BuildPathContributor
  */
 public interface IBuildPathContributor
 {
 	/**
-	 * Contribute a list of bundle path entries to the project build path master list
+	 * Contribute a list of bundle path entries to the project build path master list. This contributes to the list of
+	 * globally "accepted valid" paths that can be assigned.
 	 * 
 	 * @return
 	 */
 	List<IBuildPathEntry> getBuildPathEntries();
+
+	/**
+	 * This will return the list of build paths we dynamically add for a given project. Examples include the project's
+	 * Titanium Mobile SDK's JSCA (for the given version in the tiapp.xml), or Alloy JSCA.
+	 * 
+	 * @param project
+	 * @return
+	 */
+	List<IBuildPathEntry> getBuildPathEntries(IProject project);
 }

--- a/plugins/com.aptana.core.epl/src/com/aptana/projects/primary/natures/AbstractPrimaryNatureContributor.java
+++ b/plugins/com.aptana.core.epl/src/com/aptana/projects/primary/natures/AbstractPrimaryNatureContributor.java
@@ -7,17 +7,9 @@
  */
 package com.aptana.projects.primary.natures;
 
-import java.util.List;
-
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.QualifiedName;
-
-import com.aptana.core.epl.CoreEPLPlugin;
-import com.aptana.core.logging.IdeLog;
-import com.aptana.core.util.BuildUtil;
-import com.aptana.core.util.CollectionsUtil;
 
 /**
  * An abstract base implementation of an {@link IPrimaryNatureContributor}. This class provides an empty implementation
@@ -39,23 +31,5 @@ public abstract class AbstractPrimaryNatureContributor implements IPrimaryNature
 	public IPath getLibraryContainerPath(IPath projectPath)
 	{
 		return projectPath;
-	}
-
-	public List<String> getBuildPathEntries(IProject project, QualifiedName buildPropertyName)
-	{
-		try
-		{
-			String property = project.getPersistentProperty(buildPropertyName);
-			if (property != null)
-			{
-				String[] entries = property.split(BuildUtil.BUILD_PATH_ENTRY_DELIMITER);
-				return CollectionsUtil.newList(entries);
-			}
-		}
-		catch (CoreException e)
-		{
-			IdeLog.logError(CoreEPLPlugin.getDefault(), e);
-		}
-		return CollectionsUtil.newList();
 	}
 }

--- a/plugins/com.aptana.core.epl/src/com/aptana/projects/primary/natures/IPrimaryNatureContributor.java
+++ b/plugins/com.aptana.core.epl/src/com/aptana/projects/primary/natures/IPrimaryNatureContributor.java
@@ -7,12 +7,9 @@
  */
 package com.aptana.projects.primary.natures;
 
-import java.util.List;
-
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.QualifiedName;
 
 /**
  * @author pinnamuri
@@ -57,10 +54,4 @@ public interface IPrimaryNatureContributor
 	 * @return
 	 */
 	public IPath getLibraryContainerPath(IPath projectPath);
-
-	/**
-	 * @param project
-	 * @return
-	 */
-	public List<String> getBuildPathEntries(IProject project, QualifiedName buildPropertyName);
 }

--- a/plugins/com.aptana.core/src/com/aptana/core/util/BuildUtil.java
+++ b/plugins/com.aptana.core/src/com/aptana/core/util/BuildUtil.java
@@ -33,9 +33,6 @@ import com.aptana.core.CorePlugin;
 public class BuildUtil
 {
 
-	public static final String BUILD_PATH_ENTRY_DELIMITER = "\0"; //$NON-NLS-1$
-	public static final String NAME_AND_PATH_DELIMITER = "\t"; //$NON-NLS-1$
-
 	/**
 	 * Synchronous run of a builder with the given name on the given project.
 	 * 

--- a/plugins/com.aptana.editor.js/src/com/aptana/editor/js/contentassist/JSModelFormatter.java
+++ b/plugins/com.aptana.editor.js/src/com/aptana/editor/js/contentassist/JSModelFormatter.java
@@ -12,6 +12,7 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -33,10 +34,12 @@ import com.aptana.core.util.StringUtil;
 import com.aptana.editor.common.hover.TagStripperAndTypeBolder;
 import com.aptana.editor.js.JSPlugin;
 import com.aptana.js.core.JSTypeConstants;
+import com.aptana.js.core.model.BaseElement;
 import com.aptana.js.core.model.FunctionElement;
 import com.aptana.js.core.model.ParameterElement;
 import com.aptana.js.core.model.PropertyElement;
 import com.aptana.js.core.model.SinceElement;
+import com.aptana.js.core.model.TypeElement;
 import com.aptana.js.core.model.UserAgentElement;
 
 public class JSModelFormatter
@@ -107,13 +110,13 @@ public class JSModelFormatter
 		private static final String BULLET = "\u2022"; //$NON-NLS-1$
 		private TagStripperAndTypeBolder stripAndBold = new TagStripperAndTypeBolder();
 
-		public String getDocumentation(Collection<PropertyElement> properties)
+		public String getDocumentation(Collection<? extends BaseElement> properties)
 		{
 			if (CollectionsUtil.isEmpty(properties))
 			{
 				return null;
 			}
-			PropertyElement prop = properties.iterator().next();
+			BaseElement prop = properties.iterator().next();
 
 			if (prop instanceof FunctionElement)
 			{
@@ -202,7 +205,7 @@ public class JSModelFormatter
 	 * @param root
 	 * @return
 	 */
-	public String getHeader(PropertyElement property, URI root)
+	public String getHeader(BaseElement property, URI root)
 	{
 		return getHeader(CollectionsUtil.newList(property), root);
 	}
@@ -214,7 +217,7 @@ public class JSModelFormatter
 	 * @param root
 	 * @return
 	 */
-	public String getHeader(final Collection<PropertyElement> properties, URI root)
+	public String getHeader(final Collection<? extends BaseElement> properties, URI root)
 	{
 		if (CollectionsUtil.isEmpty(properties))
 		{
@@ -255,7 +258,7 @@ public class JSModelFormatter
 	 * @param property
 	 * @return
 	 */
-	public String getDocumentation(PropertyElement property)
+	public String getDocumentation(BaseElement property)
 	{
 		return getDocumentation(CollectionsUtil.newList(property));
 	}
@@ -266,7 +269,7 @@ public class JSModelFormatter
 	 * @param properties
 	 * @return
 	 */
-	public String getDocumentation(final Collection<PropertyElement> properties)
+	public String getDocumentation(final Collection<? extends BaseElement> properties)
 	{
 		List<Section> docSections = CollectionsUtil.filter(fSections, new IFilter<Section>()
 		{
@@ -443,7 +446,7 @@ public class JSModelFormatter
 			return builder.toString();
 		}
 
-		public abstract String generate(Collection<PropertyElement> properties, URI root);
+		public abstract String generate(Collection<? extends BaseElement> properties, URI root);
 
 		protected String formatTypes(List<String> typeNames)
 		{
@@ -473,22 +476,26 @@ public class JSModelFormatter
 				return true;
 			}
 
-			public String generate(Collection<PropertyElement> properties, URI root)
+			public String generate(Collection<? extends BaseElement> properties, URI root)
 			{
-				PropertyElement prop = properties.iterator().next();
+				BaseElement base = properties.iterator().next();
 				List<String> builder = new ArrayList<String>();
-				builder.add(prop.getName());
-				List<String> typeNames = prop.getTypeNames();
-				if (prop instanceof FunctionElement)
+				builder.add(base.getName());
+				if (base instanceof PropertyElement)
 				{
-					FunctionElement fe = (FunctionElement) prop;
-					builder.add("("); //$NON-NLS-1$
-					builder.add(formatParameters(fe.getParameters()));
-					builder.add(")"); //$NON-NLS-1$
-					typeNames = fe.getReturnTypeNames();
+					PropertyElement prop = (PropertyElement) base;
+					List<String> typeNames = prop.getTypeNames();
+					if (prop instanceof FunctionElement)
+					{
+						FunctionElement fe = (FunctionElement) prop;
+						builder.add("("); //$NON-NLS-1$
+						builder.add(formatParameters(fe.getParameters()));
+						builder.add(")"); //$NON-NLS-1$
+						typeNames = fe.getReturnTypeNames();
+					}
+					builder.add(COLON_SPACE);
+					builder.add(formatTypes(typeNames));
 				}
-				builder.add(COLON_SPACE);
-				builder.add(formatTypes(typeNames));
 				return StringUtil.concat(builder);
 			}
 
@@ -529,12 +536,12 @@ public class JSModelFormatter
 			}
 
 			@Override
-			public String generate(Collection<PropertyElement> properties, URI root)
+			public String generate(Collection<? extends BaseElement> properties, URI root)
 			{
 				Set<String> documents = new LinkedHashSet<String>(); // linked hash set to preserve add order
 
 				// collect all documents
-				for (PropertyElement pe : properties)
+				for (BaseElement pe : properties)
 				{
 					documents.addAll(pe.getDocuments());
 				}
@@ -578,17 +585,17 @@ public class JSModelFormatter
 		final static Section EXAMPLE = new Section()
 		{
 			@Override
-			public String generate(Collection<PropertyElement> properties, URI root)
+			public String generate(Collection<? extends BaseElement> properties, URI root)
 			{
 				String example = getFirstExample(properties);
 				return addSection(Messages.JSTextHover_Example, example);
 			}
 
-			private String getFirstExample(Collection<PropertyElement> properties)
+			private String getFirstExample(Collection<? extends BaseElement> properties)
 			{
-				for (PropertyElement prop : properties)
+				for (BaseElement prop : properties)
 				{
-					List<String> examples = prop.getExamples();
+					List<String> examples = getExamples(prop);
 					for (String example : examples)
 					{
 						if (!StringUtil.isEmpty(example))
@@ -607,12 +614,12 @@ public class JSModelFormatter
 		final static Section EXAMPLES = new Section()
 		{
 			@Override
-			public String generate(Collection<PropertyElement> properties, URI root)
+			public String generate(Collection<? extends BaseElement> properties, URI root)
 			{
 				List<String> examples = new ArrayList<String>();
-				for (PropertyElement prop : properties)
+				for (BaseElement prop : properties)
 				{
-					examples.addAll(prop.getExamples());
+					examples.addAll(getExamples(prop));
 				}
 				examples = CollectionsUtil.filter(examples, new IFilter<String>()
 				{
@@ -641,10 +648,10 @@ public class JSModelFormatter
 		final static Section SPECIFICATIONS = new Section()
 		{
 			@Override
-			public String generate(Collection<PropertyElement> properties, URI root)
+			public String generate(Collection<? extends BaseElement> properties, URI root)
 			{
 				Set<SinceElement> sinceElements = new HashSet<SinceElement>();
-				for (PropertyElement property : properties)
+				for (BaseElement property : properties)
 				{
 					sinceElements.addAll(property.getSinceList());
 				}
@@ -679,10 +686,10 @@ public class JSModelFormatter
 			private TagStripperAndTypeBolder stripAndBold = new TagStripperAndTypeBolder();
 
 			@Override
-			public String generate(Collection<PropertyElement> properties, URI root)
+			public String generate(Collection<? extends BaseElement> properties, URI root)
 			{
 				Set<String> descriptions = new HashSet<String>();
-				for (PropertyElement property : properties)
+				for (BaseElement property : properties)
 				{
 					// strip p elements and bold any items that look like open tags with dotted local names
 					stripAndBold.setUseHTML(useHTML);
@@ -713,10 +720,10 @@ public class JSModelFormatter
 		final static Section PLATFORMS = new Section()
 		{
 			@Override
-			public String generate(Collection<PropertyElement> properties, URI root)
+			public String generate(Collection<? extends BaseElement> properties, URI root)
 			{
 				Set<UserAgentElement> userAgents = new HashSet<UserAgentElement>();
-				for (PropertyElement property : properties)
+				for (BaseElement property : properties)
 				{
 					userAgents.addAll(property.getUserAgents());
 				}
@@ -749,10 +756,10 @@ public class JSModelFormatter
 		final static Section RETURNS = new Section()
 		{
 			@Override
-			public String generate(Collection<PropertyElement> properties, URI root)
+			public String generate(Collection<? extends BaseElement> properties, URI root)
 			{
 				List<String> returnTypeNames = new ArrayList<String>();
-				for (PropertyElement property : properties)
+				for (BaseElement property : properties)
 				{
 					if (property instanceof FunctionElement)
 					{
@@ -770,11 +777,11 @@ public class JSModelFormatter
 		final static Section PARAMETERS = new Section()
 		{
 			@Override
-			public String generate(Collection<PropertyElement> properties, URI root)
+			public String generate(Collection<? extends BaseElement> properties, URI root)
 			{
 				List<ParameterElement> parameters = new ArrayList<ParameterElement>();
 
-				for (PropertyElement property : properties)
+				for (BaseElement property : properties)
 				{
 					if (property instanceof FunctionElement)
 					{
@@ -812,5 +819,20 @@ public class JSModelFormatter
 				return StringUtil.join(COMMA_SPACE, strings);
 			}
 		};
+
+		protected static List<String> getExamples(BaseElement prop)
+		{
+			if (prop instanceof TypeElement)
+			{
+				TypeElement te = (TypeElement) prop;
+				return te.getExamples();
+			}
+			if (prop instanceof PropertyElement)
+			{
+				PropertyElement pe = (PropertyElement) prop;
+				return pe.getExamples();
+			}
+			return Collections.emptyList();
+		}
 	}
 }

--- a/plugins/com.aptana.js.core/src/com/aptana/js/core/model/BaseElement.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/core/model/BaseElement.java
@@ -33,6 +33,7 @@ public abstract class BaseElement implements Convertible, IndexDocument
 	private static final String SINCE_PROPERTY = "since"; //$NON-NLS-1$
 	private static final String DESCRIPTION_PROPERTY = "description"; //$NON-NLS-1$
 	private static final String NAME_PROPERTY = "name"; //$NON-NLS-1$
+	private static final String DEPRECATED_PROPERTY = "deprecated"; //$NON-NLS-1$
 
 	// A special instance used to indicate that this element should associate all user agents with it
 	private static final Set<UserAgentElement> ALL_USER_AGENTS = Collections.emptySet();
@@ -42,6 +43,7 @@ public abstract class BaseElement implements Convertible, IndexDocument
 	private Set<UserAgentElement> _userAgents;
 	private List<SinceElement> _sinceList;
 	private List<String> _documents;
+	private boolean _deprecated;
 
 	/**
 	 * addDocument
@@ -156,6 +158,7 @@ public abstract class BaseElement implements Convertible, IndexDocument
 		this.setName(StringUtil.getStringValue(object.get(NAME_PROPERTY)));
 		this.setDescription(StringUtil.getStringValue(object.get(DESCRIPTION_PROPERTY)));
 		this._sinceList = IndexUtil.createList(object.get(SINCE_PROPERTY), SinceElement.class);
+		this.setIsDeprecated(Boolean.TRUE == object.get(DEPRECATED_PROPERTY)); // $codepro.audit.disable useEquals
 
 		Object userAgentsProperty = object.get(USER_AGENTS_PROPERTY);
 
@@ -167,6 +170,26 @@ public abstract class BaseElement implements Convertible, IndexDocument
 		{
 			this._userAgents = createUserAgentSet(userAgentsProperty);
 		}
+	}
+	
+	/**
+	 * isDeprecated
+	 * 
+	 * @return
+	 */
+	public boolean isDeprecated()
+	{
+		return this._deprecated;
+	}
+
+	/**
+	 * setIsDeprecated
+	 * 
+	 * @param value
+	 */
+	public void setIsDeprecated(boolean value)
+	{
+		this._deprecated = value;
 	}
 
 	/**
@@ -338,6 +361,7 @@ public abstract class BaseElement implements Convertible, IndexDocument
 		// TODO To shrink string size, don't write out empty descriptions?
 		out.add(DESCRIPTION_PROPERTY, this.getDescription());
 		out.add(SINCE_PROPERTY, this.getSinceList());
+		out.add(DEPRECATED_PROPERTY, this.isDeprecated());
 
 		if (hasAllUserAgents())
 		{

--- a/plugins/com.aptana.js.core/src/com/aptana/js/core/model/EventElement.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/core/model/EventElement.java
@@ -24,11 +24,9 @@ public class EventElement extends BaseElement
 {
 	private static final String OWNING_TYPE_PROPERTY = "owningType"; //$NON-NLS-1$
 	private static final String PROPERTIES_PROPERTY = "properties"; //$NON-NLS-1$
-	private static final String DEPRECATED_PROPERTY = "deprecated"; //$NON-NLS-1$
 
 	private String _owningType;
 	private List<EventPropertyElement> _properties;
-	private boolean _deprecated;
 
 	/**
 	 * EventElement
@@ -77,7 +75,6 @@ public class EventElement extends BaseElement
 				this.addProperty(property);
 			}
 		}
-		this.setIsDeprecated(Boolean.TRUE == object.get(DEPRECATED_PROPERTY)); // $codepro.audit.disable useEquals
 	}
 
 	/**
@@ -109,26 +106,6 @@ public class EventElement extends BaseElement
 	{
 		this._owningType = type;
 	}
-	
-	/**
-	 * isDeprecated
-	 * 
-	 * @return
-	 */
-	public boolean isDeprecated()
-	{
-		return this._deprecated;
-	}
-
-	/**
-	 * setIsDeprecated
-	 * 
-	 * @param value
-	 */
-	public void setIsDeprecated(boolean value)
-	{
-		this._deprecated = value;
-	}
 
 	/*
 	 * (non-Javadoc)
@@ -140,7 +117,6 @@ public class EventElement extends BaseElement
 		super.toJSON(out);
 
 		out.add(OWNING_TYPE_PROPERTY, this.getOwningType());
-		out.add(DEPRECATED_PROPERTY, this.isDeprecated());
 		out.add(PROPERTIES_PROPERTY, this.getProperties());
 	}
 

--- a/plugins/com.aptana.js.core/src/com/aptana/js/core/model/EventPropertyElement.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/core/model/EventPropertyElement.java
@@ -20,11 +20,8 @@ public class EventPropertyElement extends BaseElement
 {
 
 	private static final String TYPE_PROPERTY = "type"; //$NON-NLS-1$
-	private static final String DEPRECATED_PROPERTY = "deprecated"; //$NON-NLS-1$
 
 	private String _type;
-
-	private boolean _deprecated;
 
 	/**
 	 * EventProperty
@@ -44,7 +41,6 @@ public class EventPropertyElement extends BaseElement
 		super.fromJSON(object);
 
 		this.setType(StringUtil.getStringValue(object.get(TYPE_PROPERTY)));
-		this.setIsDeprecated(Boolean.TRUE == object.get(DEPRECATED_PROPERTY)); // $codepro.audit.disable useEquals
 	}
 
 	/**
@@ -64,26 +60,6 @@ public class EventPropertyElement extends BaseElement
 		this._type = type;
 	}
 
-	/**
-	 * isDeprecated
-	 * 
-	 * @return
-	 */
-	public boolean isDeprecated()
-	{
-		return this._deprecated;
-	}
-
-	/**
-	 * setIsDeprecated
-	 * 
-	 * @param value
-	 */
-	public void setIsDeprecated(boolean value)
-	{
-		this._deprecated = value;
-	}
-
 	/*
 	 * (non-Javadoc)
 	 * @see com.aptana.editor.js.contentassist.model.BaseElement#toJSON(com.aptana.jetty.util.epl.ajax.JSON.Output)
@@ -94,7 +70,6 @@ public class EventPropertyElement extends BaseElement
 		super.toJSON(out);
 
 		out.add(TYPE_PROPERTY, this.getType());
-		out.add(DEPRECATED_PROPERTY, this.isDeprecated());
 	}
 
 	/**

--- a/plugins/com.aptana.js.core/src/com/aptana/js/core/model/PropertyElement.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/core/model/PropertyElement.java
@@ -29,7 +29,6 @@ public class PropertyElement extends BaseElement
 	private static final String IS_INSTANCE_PROPERTY = "isInstanceProperty"; //$NON-NLS-1$
 	private static final String IS_CLASS_PROPERTY = "isClassProperty"; //$NON-NLS-1$
 	private static final String OWNING_TYPE_PROPERTY = "owningType"; //$NON-NLS-1$
-	private static final String DEPRECATED_PROPERTY = "deprecated"; //$NON-NLS-1$
 
 	private String _owningType;
 	private boolean _isInstanceProperty;
@@ -37,7 +36,6 @@ public class PropertyElement extends BaseElement
 	private boolean _isInternal;
 	private List<ReturnTypeElement> _types;
 	private List<String> _examples;
-	private boolean _deprecated;
 
 	/**
 	 * PropertyElement
@@ -165,7 +163,6 @@ public class PropertyElement extends BaseElement
 		this.setIsClassProperty(Boolean.TRUE == object.get(IS_CLASS_PROPERTY)); // $codepro.audit.disable useEquals
 		this.setIsInstanceProperty(Boolean.TRUE == object.get(IS_INSTANCE_PROPERTY)); // $codepro.audit.disable
 																						// useEquals
-		this.setIsDeprecated(Boolean.TRUE == object.get(DEPRECATED_PROPERTY)); // $codepro.audit.disable useEquals
 		this.setIsInternal(Boolean.TRUE == object.get(IS_INTERNAL_PROPERTY)); // $codepro.audit.disable useEquals
 
 		this._types = IndexUtil.createList(object.get(TYPES_PROPERTY), ReturnTypeElement.class);
@@ -288,26 +285,6 @@ public class PropertyElement extends BaseElement
 		this._owningType = type;
 	}
 
-	/**
-	 * isDeprecated
-	 * 
-	 * @return
-	 */
-	public boolean isDeprecated()
-	{
-		return this._deprecated;
-	}
-
-	/**
-	 * setIsDeprecated
-	 * 
-	 * @param value
-	 */
-	public void setIsDeprecated(boolean value)
-	{
-		this._deprecated = value;
-	}
-
 	/*
 	 * (non-Javadoc)
 	 * @see com.aptana.editor.js.contentassist.model.BaseElement#toJSON(com.aptana.jetty.util.epl.ajax.JSON.Output)
@@ -321,7 +298,6 @@ public class PropertyElement extends BaseElement
 		out.add(IS_CLASS_PROPERTY, this.isClassProperty());
 		out.add(IS_INSTANCE_PROPERTY, this.isInstanceProperty());
 		out.add(IS_INTERNAL_PROPERTY, this.isInternal());
-		out.add(DEPRECATED_PROPERTY, this.isDeprecated());
 		out.add(TYPES_PROPERTY, this.getTypes());
 		out.add(EXAMPLES_PROPERTY, this.getExamples());
 	}

--- a/plugins/com.aptana.js.core/src/com/aptana/js/core/model/TypeElement.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/core/model/TypeElement.java
@@ -26,7 +26,6 @@ public class TypeElement extends BaseElement
 	private static final String EVENTS_PROPERTY = "events"; //$NON-NLS-1$
 	private static final String EXAMPLES_PROPERTY = "examples"; //$NON-NLS-1$
 	private static final String REMARKS_PROPERTY = "remarks"; //$NON-NLS-1$
-	private static final String DEPRECATED_PROPERTY = "deprecated"; //$NON-NLS-1$
 	private static final String IS_INTERNAL_PROPERTY = "internal"; //$NON-NLS-1$
 
 	private List<String> _parentTypes;
@@ -34,7 +33,6 @@ public class TypeElement extends BaseElement
 	private List<EventElement> _events;
 	private List<String> _examples;
 	private List<String> _remarks;
-	private boolean _deprecated;
 	private boolean _serializeProperties;
 	private boolean _isInternal;
 
@@ -214,8 +212,6 @@ public class TypeElement extends BaseElement
 				}
 			}
 		}
-
-		this.setIsDeprecated(Boolean.TRUE == object.get(DEPRECATED_PROPERTY)); // $codepro.audit.disable useEquals
 
 		// JSCA holds "isInternal", but we serialize as "internal"
 		if (object.containsKey("isInternal")) //$NON-NLS-1$
@@ -401,16 +397,6 @@ public class TypeElement extends BaseElement
 	}
 
 	/**
-	 * isDeprecated
-	 * 
-	 * @return
-	 */
-	public boolean isDeprecated()
-	{
-		return this._deprecated;
-	}
-
-	/**
 	 * removeProperty
 	 * 
 	 * @param property
@@ -425,16 +411,6 @@ public class TypeElement extends BaseElement
 		}
 
 		return result;
-	}
-
-	/**
-	 * setIsDeprecated
-	 * 
-	 * @param value
-	 */
-	public void setIsDeprecated(boolean value)
-	{
-		this._deprecated = value;
 	}
 
 	/**
@@ -487,7 +463,6 @@ public class TypeElement extends BaseElement
 			out.add(EVENTS_PROPERTY, this.getEvents());
 			out.add(EXAMPLES_PROPERTY, this.getExamples());
 			out.add(REMARKS_PROPERTY, this.getRemarks());
-			out.add(DEPRECATED_PROPERTY, this.isDeprecated());
 			out.add(IS_INTERNAL_PROPERTY, this.isInternal());
 		}
 	}

--- a/plugins/com.aptana.js.core/src/com/aptana/js/internal/core/build/NodeJSSourceContributor.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/internal/core/build/NodeJSSourceContributor.java
@@ -9,8 +9,10 @@ package com.aptana.js.internal.core.build;
 
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
+import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
@@ -61,6 +63,11 @@ public class NodeJSSourceContributor implements IBuildPathContributor
 	protected INodePackageManager getNodePackageManager()
 	{
 		return JSCorePlugin.getDefault().getNodePackageManager();
+	}
+
+	public List<IBuildPathEntry> getBuildPathEntries(IProject project)
+	{
+		return Collections.emptyList();
 	}
 
 }

--- a/plugins/com.aptana.scripting/src/com/aptana/scripting/ScriptingBuildPathContributor.java
+++ b/plugins/com.aptana.scripting/src/com/aptana/scripting/ScriptingBuildPathContributor.java
@@ -9,9 +9,12 @@ package com.aptana.scripting;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
+import org.eclipse.core.resources.IProject;
 
 import com.aptana.buildpath.core.BuildPathEntry;
 import com.aptana.buildpath.core.IBuildPathContributor;
@@ -48,5 +51,10 @@ public class ScriptingBuildPathContributor implements IBuildPathContributor
 		}
 
 		return new ArrayList<IBuildPathEntry>(result);
+	}
+
+	public List<IBuildPathEntry> getBuildPathEntries(IProject project)
+	{
+		return Collections.emptyList();
 	}
 }

--- a/tests/com.aptana.buildpath.core.tests/src/com/aptana/buildpath/core/BuildPathManagerTest.java
+++ b/tests/com.aptana.buildpath.core.tests/src/com/aptana/buildpath/core/BuildPathManagerTest.java
@@ -1,0 +1,215 @@
+package com.aptana.buildpath.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.core.resources.IProject;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.aptana.core.tests.TestProject;
+import com.aptana.core.util.CollectionsUtil;
+import com.aptana.core.util.FileUtil;
+
+public class BuildPathManagerTest
+{
+
+	private static IProject project;
+	private static TestProject tp;
+
+	@BeforeClass
+	public static void setupProject() throws Exception
+	{
+		tp = new TestProject("bpm", new String[0]);
+		project = tp.getInnerProject();
+	}
+
+	@AfterClass
+	public static void tearDownProject() throws Exception
+	{
+		tp.delete();
+	}
+
+	@After
+	public void tearDownBuildPaths() throws Exception
+	{
+		// Essentially we wipe the build paths for the project each time
+		BuildPathManager.getInstance().setBuildPaths(project, new HashSet<IBuildPathEntry>());
+	}
+
+	@Test
+	public void testManagingGlobalBuildPaths() throws IOException
+	{
+		BuildPathManager bpm = BuildPathManager.getInstance();
+
+		File file = FileUtil.createTempFile("bpe", ".entry");
+		IBuildPathEntry entry = new BuildPathEntry("build path entry", file.toURI());
+
+		Set<IBuildPathEntry> entries = bpm.getBuildPaths();
+		int initialSize = entries.size();
+
+		assertFalse(bpm.hasBuildPath(entry));
+
+		// Add it
+		assertTrue(bpm.addBuildPath(entry));
+
+		entries = bpm.getBuildPaths();
+		assertEquals("Expected build path set to increase size by one, because of one we registered globally",
+				initialSize + 1, entries.size());
+		assertTrue("Expected build paths to include one we just added!", bpm.hasBuildPath(entry));
+
+		// Now remove it
+		assertTrue(bpm.removeBuildPath(entry));
+
+		// check that it got removed
+		entries = bpm.getBuildPaths();
+		assertEquals(initialSize, entries.size());
+		assertFalse("Expected build paths to no longer include one we just removed!", bpm.hasBuildPath(entry));
+	}
+
+	@Test
+	public void testAddingNullEntryReturnsFalse() throws IOException
+	{
+		BuildPathManager bpm = BuildPathManager.getInstance();
+		assertFalse(bpm.addBuildPath(null));
+	}
+
+	@Test
+	public void testRemovingNullEntryReturnsFalse() throws IOException
+	{
+		BuildPathManager bpm = BuildPathManager.getInstance();
+		assertFalse(bpm.removeBuildPath(null));
+	}
+
+	@Test
+	public void testRemovingEntryThatDidntExistReturnsFalse() throws IOException
+	{
+		BuildPathManager bpm = BuildPathManager.getInstance();
+
+		File file = FileUtil.createTempFile("bpe", ".entry");
+		IBuildPathEntry entry = new BuildPathEntry("build path entry", file.toURI());
+		assertFalse(bpm.hasBuildPath(entry));
+		assertFalse(bpm.removeBuildPath(entry));
+	}
+
+	@Test
+	public void testGetBuildPathsOfNullProject()
+	{
+		BuildPathManager bpm = BuildPathManager.getInstance();
+		Set<IBuildPathEntry> entries = bpm.getBuildPaths(null);
+		assertTrue("Expected empty build path set on null project", CollectionsUtil.isEmpty(entries));
+	}
+
+	@Test
+	public void testOnlyRegisteredBuildPathsAreReturnedFromProjectBuildPathSet() throws Exception
+	{
+		BuildPathManager bpm = BuildPathManager.getInstance();
+
+		File file = FileUtil.createTempFile("bpe", ".entry");
+		IBuildPathEntry entry = new BuildPathEntry("build path entry", file.toURI());
+
+		Set<IBuildPathEntry> entries = bpm.getBuildPaths(project);
+		assertTrue("Expected empty build path set on project with none added", CollectionsUtil.isEmpty(entries));
+
+		// Add an unregistered build path to the project
+		assertTrue(bpm.addBuildPath(project, entry));
+
+		entries = bpm.getBuildPaths(project);
+		assertTrue("Expected empty build path set for project since single build path set was not globally registered",
+				CollectionsUtil.isEmpty(entries));
+	}
+
+	@Test
+	public void testSetAndGetBuildPathsOnProject() throws Exception
+	{
+		BuildPathManager bpm = BuildPathManager.getInstance();
+
+		// Register the build path entry "globally" as a valid one.
+		File file = FileUtil.createTempFile("bpe", ".entry");
+		IBuildPathEntry entry = new BuildPathEntry("build path entry", file.toURI());
+		bpm.addBuildPath(entry);
+
+		// verify the build path is not attached to the project
+		assertFalse(bpm.hasBuildPath(project, entry));
+		assertTrue("Expected empty build path set on project with none added",
+				CollectionsUtil.isEmpty(bpm.getBuildPaths(project)));
+
+		// Now add the build path to the project
+		assertTrue(bpm.addBuildPath(project, entry));
+
+		// Verify it got added
+		assertEquals(1, bpm.getBuildPaths(project).size());
+		assertTrue(bpm.hasBuildPath(project, entry));
+
+		// Remove it
+		assertTrue(bpm.removeBuildPath(project, entry));
+
+		// verify it got removed
+		assertFalse(bpm.hasBuildPath(project, entry));
+		assertTrue("Expected empty build path set on project with none added",
+				CollectionsUtil.isEmpty(bpm.getBuildPaths(project)));
+
+		// Now use setEntries to add
+		Set<IBuildPathEntry> newEntries = CollectionsUtil.newSet(entry);
+		assertTrue(bpm.setBuildPaths(project, newEntries));
+		assertEquals(1, bpm.getBuildPaths(project).size());
+		assertTrue(bpm.hasBuildPath(project, entry));
+	}
+
+	@Test
+	public void testAddingNullEntryToProjectReturnsFalse() throws Exception
+	{
+		BuildPathManager bpm = BuildPathManager.getInstance();
+		assertFalse(bpm.addBuildPath(project, null));
+	}
+
+	@Test
+	public void testAddingEntryToNullProjectReturnsFalse() throws Exception
+	{
+		BuildPathManager bpm = BuildPathManager.getInstance();
+		File file = FileUtil.createTempFile("bpe", ".entry");
+		IBuildPathEntry entry = new BuildPathEntry("build path entry", file.toURI());
+		assertFalse(bpm.addBuildPath(null, entry));
+	}
+
+	@Test
+	public void testRemovingNullEntryFromProjectReturnsFalse() throws Exception
+	{
+		BuildPathManager bpm = BuildPathManager.getInstance();
+		assertFalse(bpm.removeBuildPath(project, null));
+	}
+
+	@Test
+	public void testRemovingEntryFromNullProjectReturnsFalse() throws Exception
+	{
+		BuildPathManager bpm = BuildPathManager.getInstance();
+		File file = FileUtil.createTempFile("bpe", ".entry");
+		IBuildPathEntry entry = new BuildPathEntry("build path entry", file.toURI());
+		assertFalse(bpm.removeBuildPath(null, entry));
+	}
+
+	@Test
+	public void testSetBuildPathsOnNullProjectReturnsFalse() throws Exception
+	{
+		BuildPathManager bpm = BuildPathManager.getInstance();
+		File file = FileUtil.createTempFile("bpe", ".entry");
+		IBuildPathEntry entry = new BuildPathEntry("build path entry", file.toURI());
+		Set<IBuildPathEntry> newEntries = CollectionsUtil.newSet(entry);
+		assertFalse(bpm.setBuildPaths(null, newEntries));
+	}
+
+	@Test
+	public void testSetNullBuildPathsOnProjectReturnsFalse() throws Exception
+	{
+		BuildPathManager bpm = BuildPathManager.getInstance();
+		assertFalse(bpm.setBuildPaths(project, null));
+	}
+}

--- a/tests/com.aptana.buildpath.core.tests/src/com/aptana/buildpath/core/tests/BuildPathCoreTests.java
+++ b/tests/com.aptana.buildpath.core.tests/src/com/aptana/buildpath/core/tests/BuildPathCoreTests.java
@@ -4,11 +4,13 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
 import com.aptana.buildpath.core.BuildPathEntryTest;
+import com.aptana.buildpath.core.BuildPathManagerTest;
 import com.aptana.core.build.CoreBuildTests;
 import com.aptana.core.internal.build.InternalBuildTests;
 
 @RunWith(Suite.class)
-@Suite.SuiteClasses({ CoreBuildTests.class, InternalBuildTests.class, BuildPathEntryTest.class })
+@Suite.SuiteClasses({ CoreBuildTests.class, InternalBuildTests.class, BuildPathEntryTest.class,
+		BuildPathManagerTest.class })
 public class BuildPathCoreTests
 {
 


### PR DESCRIPTION
- Move deprecated property up model type hierarchy to BaseElement
- Allow JSModelFormatter to take in BaseElements so we can pass in a TypeElement and get a somewhat decent hover.
- fix broken behavior due to changes for TISTUD-5648
- Add unit tests around BuildPathManager
- Make the BuildPathManager methods take in IBuildPathEntry, not impl
- Make the BuildPathManager methods return booleans rather than nothing
