### PR TITLE
TISTUD-5868 NavigationGroup element appears twice in code hints

### DIFF
--- a/plugins/com.aptana.editor.xml/src/com/aptana/editor/xml/contentassist/XMLContentAssistProcessor.java
+++ b/plugins/com.aptana.editor.xml/src/com/aptana/editor/xml/contentassist/XMLContentAssistProcessor.java
@@ -353,6 +353,8 @@ public class XMLContentAssistProcessor extends CommonContentAssistProcessor
 				}
 			}
 		}
+		// Track tag names to enforce unique proposals by tag name (no repeats)
+		Set<String> uniques = new HashSet<String>(elements.size());
 
 		// TODO If user doesn't want tags closed for them, then don't do it!
 		// boolean addCloseTag = XMLPlugin.getDefault().getPreferenceStore()
@@ -365,6 +367,13 @@ public class XMLContentAssistProcessor extends CommonContentAssistProcessor
 		List<ICompletionProposal> proposals = new ArrayList<ICompletionProposal>();
 		for (ElementElement element : elements)
 		{
+			// Enforce unique proposals for elements (avoid duplicates)
+			String tagName = element.getName();
+			if (uniques.contains(tagName))
+			{
+				continue;
+			}
+
 			StringBuilder replacement = new StringBuilder(element.getName());
 			List<Integer> positions = new ArrayList<Integer>();
 			int cursorPosition = replacement.length();
@@ -417,8 +426,10 @@ public class XMLContentAssistProcessor extends CommonContentAssistProcessor
 				}
 			}
 			positions.add(0, cursorPosition);
-			CommonCompletionProposal proposal = createElementProposal(replaceLength, replaceOffset, element, replacement, positions);
+			CommonCompletionProposal proposal = createElementProposal(replaceLength, replaceOffset, element,
+					replacement, positions);
 			proposals.add(proposal);
+			uniques.add(tagName);
 		}
 
 		return proposals;
@@ -427,8 +438,8 @@ public class XMLContentAssistProcessor extends CommonContentAssistProcessor
 	protected XMLTagProposal createElementProposal(int replaceLength, int replaceOffset, ElementElement element,
 			StringBuilder replacement, List<Integer> positions)
 	{
-		return new XMLTagProposal(replacement.toString(), replaceOffset,
-				replaceLength, element, positions.toArray(new Integer[positions.size()]));
+		return new XMLTagProposal(replacement.toString(), replaceOffset, replaceLength, element,
+				positions.toArray(new Integer[positions.size()]));
 	}
 
 	private boolean isEmptyTagType(ElementElement element)

--- a/tests/com.aptana.editor.xml.tests/src/com/aptana/editor/xml/contentassist/XMLContentAssistProcessorTest.java
+++ b/tests/com.aptana.editor.xml.tests/src/com/aptana/editor/xml/contentassist/XMLContentAssistProcessorTest.java
@@ -14,23 +14,29 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
-import org.eclipse.core.filesystem.IFileStore;
+import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.IDocumentPartitioner;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.Position;
-import org.eclipse.jface.text.TextViewer;
 import org.eclipse.jface.text.contentassist.ICompletionProposal;
 import org.eclipse.jface.text.link.LinkedModeModel;
-import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Point;
-import org.eclipse.swt.widgets.Shell;
+import org.junit.Before;
 import org.junit.Test;
 
 import com.aptana.core.util.CollectionsUtil;
 import com.aptana.core.util.StringUtil;
 import com.aptana.editor.common.AbstractThemeableEditor;
+import com.aptana.editor.common.CommonEditorPlugin;
+import com.aptana.editor.common.ExtendedFastPartitioner;
+import com.aptana.editor.common.IExtendedPartitioner;
+import com.aptana.editor.common.NullPartitionerSwitchStrategy;
 import com.aptana.editor.common.tests.BadDocument;
 import com.aptana.editor.common.tests.util.AssertUtil;
+import com.aptana.editor.common.text.rules.CompositePartitionScanner;
+import com.aptana.editor.common.text.rules.NullSubPartitionScanner;
+import com.aptana.editor.xml.XMLSourceConfiguration;
 import com.aptana.editor.xml.tests.XMLEditorBasedTests;
 import com.aptana.editor.xml.tests.XMLTestUtil;
 import com.aptana.xml.core.index.XMLIndexQueryHelper;
@@ -41,6 +47,18 @@ public class XMLContentAssistProcessorTest extends XMLEditorBasedTests
 {
 
 	private IDocument fDocument;
+	private List<ElementElement> fElements;
+
+	@Before
+	public void setup()
+	{
+		ElementElement ee = new ElementElement();
+		ee.setName("element");
+		ee.addAttribute("id");
+		ee.addAttribute("class");
+		ee.addAttribute("attribute");
+		fElements = CollectionsUtil.newList(ee);
+	}
 
 	@Override
 	protected XMLContentAssistProcessor createContentAssistProcessor(AbstractThemeableEditor editor)
@@ -55,12 +73,7 @@ public class XMLContentAssistProcessorTest extends XMLEditorBasedTests
 					@Override
 					public List<ElementElement> getElements()
 					{
-						ElementElement ee = new ElementElement();
-						ee.setName("element");
-						ee.addAttribute("id");
-						ee.addAttribute("class");
-						ee.addAttribute("attribute");
-						return CollectionsUtil.newList(ee);
+						return fElements;
 					}
 
 					@Override
@@ -86,6 +99,7 @@ public class XMLContentAssistProcessorTest extends XMLEditorBasedTests
 	public void tearDown() throws Exception
 	{
 		fDocument = null;
+		fElements = null;
 
 		super.tearDown();
 	}
@@ -99,6 +113,21 @@ public class XMLContentAssistProcessorTest extends XMLEditorBasedTests
 	@Test
 	public void testElementProposalTagUnclosedNoPrefix()
 	{
+		assertCompletionCorrect("<|", '\t', 1, "element", "<element></element>", null); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+	}
+
+	@Test
+	public void testNoDuplicateElementsProposed()
+	{
+		// Add another element with same name
+		ElementElement ee = new ElementElement();
+		ee.setName("element");
+		ee.addAttribute("something");
+		ee.addAttribute("other");
+		ee.addAttribute("yeah");
+		fElements.add(ee);
+
+		// Verify only one proposal returned since we enforce uniques
 		assertCompletionCorrect("<|", '\t', 1, "element", "<element></element>", null); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 	}
 
@@ -307,36 +336,56 @@ public class XMLContentAssistProcessorTest extends XMLEditorBasedTests
 	public void testIsValidAutoActivationLocationText()
 	{
 		String source = "<element>|";
-		IFileStore fileStore = createFileStore("proposal_tests", "html", source);
-		this.setupTestContext(fileStore);
+
+		document = new Document(source);
+		handleCursorOffsets(document);
+
+		attachPartitioner(document);
+
 		int offset = this.cursorOffsets.get(0);
 
-		assertFalse("Don't auto-pop CA when typing text between tags",
-				processor.isValidAutoActivationLocation('t', 't', document, offset));
+		assertFalse("Don't auto-pop CA when typing text between tags", createContentAssistProcessor(null)
+				.isValidAutoActivationLocation('t', 't', document, offset));
 	}
 
 	protected ITextViewer createTextViewer(IDocument fDocument)
 	{
-		ITextViewer viewer = new TextViewer(new Shell(), SWT.NONE);
-		viewer.setDocument(fDocument);
-		return viewer;
+		return new com.aptana.editor.common.tests.TextViewer(fDocument);
 	}
 
 	protected void assertCompletionCorrect(String source, char trigger, int proposalCount, String proposalToChoose,
 			String postCompletion, Point point)
 	{
-		IFileStore fileStore = createFileStore("proposal_tests", "html", source);
-		this.setupTestContext(fileStore);
+		document = new Document(source);
+		handleCursorOffsets(document);
+
+		attachPartitioner(document);
 
 		int offset = this.cursorOffsets.get(0);
-		ITextViewer viewer = AssertUtil.createTextViewer(document);
-		ICompletionProposal[] proposals = processor.doComputeCompletionProposals(viewer, offset, trigger, false);
 
-		assertEquals(proposalCount, proposals.length);
+		ITextViewer viewer = createTextViewer(document);
+		ICompletionProposal[] proposals = createContentAssistProcessor(null).doComputeCompletionProposals(viewer,
+				offset, trigger, false);
+
+		assertEquals("Received proposal count we didn't expect: " + StringUtil.join(",", proposals), proposalCount,
+				proposals.length);
 		if (proposalToChoose != null)
 		{
 			AssertUtil.assertProposalFound(proposalToChoose, proposals);
 			AssertUtil.assertProposalApplies(postCompletion, document, proposalToChoose, proposals, offset, point);
 		}
+	}
+
+	protected void attachPartitioner(IDocument document)
+	{
+		CompositePartitionScanner partitionScanner = new CompositePartitionScanner(XMLSourceConfiguration.getDefault()
+				.createSubPartitionScanner(), new NullSubPartitionScanner(), new NullPartitionerSwitchStrategy());
+		IDocumentPartitioner partitioner = new ExtendedFastPartitioner(partitionScanner, XMLSourceConfiguration
+				.getDefault().getContentTypes());
+		partitionScanner.setPartitioner((IExtendedPartitioner) partitioner);
+		partitioner.connect(document);
+		document.setDocumentPartitioner(partitioner);
+		CommonEditorPlugin.getDefault().getDocumentScopeManager()
+				.registerConfiguration(document, XMLSourceConfiguration.getDefault());
 	}
 }


### PR DESCRIPTION
- Add unit test, enforce no duplicates in element/tag proposals (by tag name)
- Update unit tests to run in-memory, rather than generating temporary files/editors (speeds them up considerably).
