### PR TITLE
TISTUD-4645 Proxy: Install Titanium SDK from local URL: Platform proxy API not available


### DIFF
--- a/plugins/com.aptana.core.io/src/com/aptana/ide/core/io/downloader/ContentDownloadRequest.java
+++ b/plugins/com.aptana.core.io/src/com/aptana/ide/core/io/downloader/ContentDownloadRequest.java
@@ -10,8 +10,7 @@ package com.aptana.ide.core.io.downloader;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.net.URISyntaxException;
-import java.net.URL;
+import java.net.URI;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
@@ -20,11 +19,9 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Status;
-import org.eclipse.ecf.filetransfer.UserCancelledException;
 import org.eclipse.osgi.util.NLS;
 
 import com.aptana.core.epl.downloader.FileReader;
-import com.aptana.core.logging.IdeLog;
 import com.aptana.core.util.FileUtil;
 import com.aptana.ide.core.io.CoreIOPlugin;
 
@@ -35,18 +32,18 @@ import com.aptana.ide.core.io.CoreIOPlugin;
  */
 public class ContentDownloadRequest
 {
-	private URL url;
+	protected final URI uri;
 	private File saveTo;
 	private IStatus result;
 
-	public ContentDownloadRequest(URL url) throws CoreException
+	public ContentDownloadRequest(URI uri) throws CoreException
 	{
-		this(url, getTempFile(url));
+		this(uri, getTempFile(uri));
 	}
 
-	public ContentDownloadRequest(URL url, File saveTo)
+	public ContentDownloadRequest(URI uri, File saveTo)
 	{
-		this.url = url;
+		this.uri = uri;
 		this.saveTo = saveTo;
 	}
 
@@ -76,7 +73,7 @@ public class ContentDownloadRequest
 
 	public void execute(IProgressMonitor monitor)
 	{
-		monitor.subTask(NLS.bind(Messages.ContentDownloadRequest_downloading, url.toString()));
+		monitor.subTask(NLS.bind(Messages.ContentDownloadRequest_downloading, uri.toString()));
 		IStatus status = download(monitor);
 		setResult(status);
 	}
@@ -96,7 +93,7 @@ public class ContentDownloadRequest
 			// Use ECF FileTransferJob implementation to get the remote file.
 			FileReader reader = new FileReader(null);
 			FileOutputStream anOutputStream = new FileOutputStream(this.saveTo);
-			reader.readInto(this.url.toURI(), anOutputStream, 0, monitor);
+			reader.readInto(this.uri, anOutputStream, 0, monitor);
 			// check that job ended ok - throw exceptions otherwise
 			IStatus result = reader.getResult();
 			if (result != null)
@@ -130,23 +127,16 @@ public class ContentDownloadRequest
 	 * @return
 	 * @throws CoreException
 	 */
-	protected static File getTempFile(URL url) throws CoreException
+	protected static File getTempFile(URI uri) throws CoreException
 	{
-		String tempPath = FileUtil.getTempDirectory().toOSString();
-		try
+		IPath path = Path.fromOSString(uri.getPath());
+		String name = path.lastSegment();
+		if (name != null && name.length() > 0)
 		{
-			IPath path = Path.fromOSString(url.toURI().getPath());
-			String name = path.lastSegment();
-			if (name != null && name.length() > 0)
-			{
-				File f = new File(tempPath, name);
-				f.deleteOnExit();
-				return f;
-			}
-		}
-		catch (URISyntaxException e)
-		{
-			IdeLog.logError(CoreIOPlugin.getDefault(), e);
+			String tempPath = FileUtil.getTempDirectory().toOSString();
+			File f = new File(tempPath, name);
+			f.deleteOnExit();
+			return f;
 		}
 
 		try

--- a/plugins/com.aptana.core.io/src/com/aptana/ide/core/io/downloader/DownloadManager.java
+++ b/plugins/com.aptana.core.io/src/com/aptana/ide/core/io/downloader/DownloadManager.java
@@ -1,6 +1,6 @@
 /**
  * Aptana Studio
- * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2014 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the GNU Public License (GPL) v3 (with exceptions).
  * Please see the license.html included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.
@@ -8,12 +8,15 @@
 package com.aptana.ide.core.io.downloader;
 
 import java.io.File;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
+import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -52,36 +55,75 @@ public class DownloadManager
 	 *            A URL with a file-name to be downloaded.
 	 * @throws CoreException
 	 *             In case the URL file name cannot be extracted from the URL.
+	 * @deprecated Use {@link #addURI(URI)}
 	 */
 	public void addURL(URL url) throws CoreException
 	{
 		if (url != null)
 		{
-			addDownload(new ContentDownloadRequest(url));
+			try
+			{
+				addURI(url.toURI());
+			}
+			catch (URISyntaxException e)
+			{
+				throw new CoreException(new Status(IStatus.ERROR, CoreIOPlugin.PLUGIN_ID, e.getMessage(), e));
+			}
 		}
 	}
 
 	/**
-	 * Adds a URL for the pending downloads list.<br>
-	 * This method also accepts a {@link File} that the download process will write to.<br>
+	 * Adds a URI for the pending downloads list.<br>
 	 * Note that this method should be called <b>before</b> the {@link #start(IProgressMonitor)} is called.
 	 * 
-	 * @param url
-	 *            A URL with a file-name to be downloaded.
-	 * @param saveTo
-	 *            The file to write to.
+	 * @param uri
+	 *            A URI with a file-name to be downloaded.
 	 * @throws CoreException
-	 *             In case the URL file name cannot be extracted from the URL.
+	 *             In case the URI file name cannot be extracted from the URI.
 	 */
-	public void addURL(URL url, File saveTo) throws CoreException
+	public void addURI(URI uri) throws CoreException
 	{
-		if (url != null)
+		if (uri != null)
 		{
-			addDownload(new ContentDownloadRequest(url, saveTo));
+			if (EFS.SCHEME_FILE.equals(uri.getScheme()))
+			{
+				addDownload(new FileDownloadRequest(uri));
+			}
+			else
+			{
+				addDownload(new ContentDownloadRequest(uri));
+			}
 		}
 	}
 
-	private synchronized void addDownload(ContentDownloadRequest request)
+	/**
+	 * Adds a URI for the pending downloads list.<br>
+	 * This method also accepts a {@link File} that the download process will write to.<br>
+	 * Note that this method should be called <b>before</b> the {@link #start(IProgressMonitor)} is called.
+	 * 
+	 * @param uri
+	 *            A URI with a file-name to be downloaded.
+	 * @param saveTo
+	 *            The file to write to.
+	 * @throws CoreException
+	 *             In case the URI file name cannot be extracted from the URI.
+	 */
+	public void addURI(URI uri, File saveTo) throws CoreException
+	{
+		if (uri != null)
+		{
+			if (EFS.SCHEME_FILE.equals(uri.getScheme()))
+			{
+				addDownload(new FileDownloadRequest(uri, saveTo));
+			}
+			else
+			{
+				addDownload(new ContentDownloadRequest(uri, saveTo));
+			}
+		}
+	}
+
+	protected synchronized void addDownload(ContentDownloadRequest request)
 	{
 		if (downloads == null)
 		{
@@ -99,13 +141,13 @@ public class DownloadManager
 	 * @throws CoreException
 	 *             In case one or more of the given URLs do not contain a file name.
 	 */
-	public void addURLs(List<URL> urls) throws CoreException
+	public void addURIs(List<URI> uris) throws CoreException
 	{
-		if (!CollectionsUtil.isEmpty(urls))
+		if (!CollectionsUtil.isEmpty(uris))
 		{
-			for (URL url : urls)
+			for (URI uri : uris)
 			{
-				addURL(url);
+				addURI(uri);
 			}
 		}
 	}
@@ -151,6 +193,9 @@ public class DownloadManager
 				// TODO Append to multi status and return that?
 				return Status.CANCEL_STATUS;
 			}
+
+			// FIXME If the request if for a file URI, we should cheat and not "download" anything. We should just
+			// basically do a no-op and return the original path (or copy to intended saveLocation)
 
 			ContentDownloadRequest request = iterator.next();
 			request.execute(subMonitor.newChild(1));

--- a/plugins/com.aptana.core.io/src/com/aptana/ide/core/io/downloader/FileDownloadRequest.java
+++ b/plugins/com.aptana.core.io/src/com/aptana/ide/core/io/downloader/FileDownloadRequest.java
@@ -1,0 +1,60 @@
+/**
+ * Aptana Studio
+ * Copyright (c) 2014 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the GNU Public License (GPL) v3 (with exceptions).
+ * Please see the license.html included with this distribution for details.
+ * Any modifications to this file must keep this entire header intact.
+ */
+package com.aptana.ide.core.io.downloader;
+
+import java.io.File;
+import java.net.URI;
+
+import org.eclipse.core.filesystem.EFS;
+import org.eclipse.core.filesystem.IFileStore;
+import org.eclipse.core.filesystem.IFileSystem;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.Status;
+
+/**
+ * Special subclass intended to shortcut when the URI we're pointing at uses a file: URI. We copy the contents to the
+ * intended saveLocation. We could just return the original path, but much of our code assumes that we can unzip and
+ * delete the "downloaded" file. If the user pointed at an existing file we don't want to do that, so for safety we just
+ * do a quick copy to the temp dir.
+ * 
+ * @author Chris Williams <cwilliams@appcelerator.com>
+ */
+class FileDownloadRequest extends ContentDownloadRequest
+{
+
+	public FileDownloadRequest(URI uri) throws CoreException
+	{
+		super(uri);
+	}
+
+	public FileDownloadRequest(URI uri, File saveTo) throws CoreException
+	{
+		super(uri, saveTo);
+	}
+
+	@Override
+	public void execute(IProgressMonitor monitor)
+	{
+		// We copy from the original URI to the new location (typically temp dir)
+		// TODO Use IOUtil.copyFile(source, destination) ? It may be faster
+
+		IFileSystem fs = EFS.getLocalFileSystem();
+		IFileStore src = fs.getStore(uri);
+		IFileStore destination = fs.getStore(getDownloadLocation());
+		try
+		{
+			src.copy(destination, EFS.OVERWRITE, monitor);
+			setResult(Status.OK_STATUS);
+		}
+		catch (CoreException e)
+		{
+			setResult(e.getStatus());
+		}
+	}
+}

--- a/plugins/com.aptana.core/src/com/aptana/core/util/CollectionsUtil.java
+++ b/plugins/com.aptana.core/src/com/aptana/core/util/CollectionsUtil.java
@@ -615,7 +615,12 @@ public class CollectionsUtil
 
 				Object valueObject = items[i + 1];
 				U value;
-				if (valueType.isAssignableFrom(valueObject.getClass()))
+				if (valueObject == null)
+				{
+					value = null;
+					map.put(key, value);
+				}
+				else if (valueType.isAssignableFrom(valueObject.getClass()))
 				{
 					value = valueType.cast(valueObject);
 

--- a/plugins/com.aptana.core/src/com/aptana/core/util/IOUtil.java
+++ b/plugins/com.aptana.core/src/com/aptana/core/util/IOUtil.java
@@ -202,7 +202,8 @@ public abstract class IOUtil
 			}
 		}
 
-		return new Status(IStatus.ERROR, CorePlugin.PLUGIN_ID, IStatus.ERROR, Messages.IOUtil_Source_Not_Directory_Error, null);
+		return new Status(IStatus.ERROR, CorePlugin.PLUGIN_ID, IStatus.ERROR,
+				Messages.IOUtil_Source_Not_Directory_Error, null);
 	}
 
 	private static int countFiles(File source)
@@ -340,7 +341,7 @@ public abstract class IOUtil
 	}
 
 	/**
-	 * Copy the contents of one file to another. Uses Attempts to use channels for files < 20Mb, uses streams for larger
+	 * Copy the contents of one file to another. Attempts to use channels for files < 20Mb, uses streams for larger
 	 * files. Closes the streams after transfer.
 	 * 
 	 * @param source

--- a/plugins/com.aptana.editor.js/src/com/aptana/editor/js/preferences/NodePreferencePage.java
+++ b/plugins/com.aptana.editor.js/src/com/aptana/editor/js/preferences/NodePreferencePage.java
@@ -8,7 +8,7 @@
 package com.aptana.editor.js.preferences;
 
 import java.lang.reflect.InvocationTargetException;
-import java.net.URL;
+import java.net.URI;
 import java.text.MessageFormat;
 import java.util.List;
 
@@ -192,7 +192,7 @@ public class NodePreferencePage extends FieldEditorPreferencePage implements IWo
 					final DownloadManager dm = new DownloadManager();
 					try
 					{
-						dm.addURL(new URL(NODE_JS_SOURCE_URL));
+						dm.addURI(new URI(NODE_JS_SOURCE_URL));
 						IStatus status = dm.start(monitor);
 						if (status.isOK())
 						{

--- a/plugins/com.aptana.js.core/src/com/aptana/js/internal/core/node/NodeJSService.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/internal/core/node/NodeJSService.java
@@ -8,8 +8,8 @@
 package com.aptana.js.internal.core.node;
 
 import java.io.File;
-import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.text.MessageFormat;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
@@ -35,7 +35,6 @@ import com.aptana.core.util.IProcessRunner;
 import com.aptana.core.util.PlatformUtil;
 import com.aptana.core.util.ProcessRunner;
 import com.aptana.core.util.ProcessStatus;
-import com.aptana.core.util.ProcessUtil;
 import com.aptana.core.util.StringUtil;
 import com.aptana.ide.core.io.downloader.DownloadManager;
 import com.aptana.js.core.JSCorePlugin;
@@ -155,15 +154,15 @@ public class NodeJSService implements INodeJSService
 		// Grab the URL for the platform
 		String rawURL = PlatformUtil.isWindows() ? WIN_NODE_URL : MAC_NODE_URL;
 		String extension = PlatformUtil.isWindows() ? WIN_EXTENSION : MAC_EXTENSION;
-		URL url;
+		URI uri;
 		try
 		{
-			url = new URL(rawURL);
+			uri = new URI(rawURL);
 		}
-		catch (MalformedURLException e)
+		catch (URISyntaxException e)
 		{
 			IdeLog.logError(JSCorePlugin.getDefault(),
-					MessageFormat.format("Bad Download URL for node: {0}", rawURL), e); //$NON-NLS-1$
+					MessageFormat.format("Bad Download URI for node: {0}", rawURL), e); //$NON-NLS-1$
 			return new Status(IStatus.ERROR, JSCorePlugin.PLUGIN_ID, MessageFormat.format(
 					Messages.NodeJSService_BadURLError, rawURL), e);
 		}
@@ -171,7 +170,7 @@ public class NodeJSService implements INodeJSService
 		try
 		{
 			// download the installer
-			File file = download(url, extension, sub.newChild(90));
+			File file = download(uri, extension, sub.newChild(90));
 			// run the installer
 			IStatus status;
 			if (PlatformUtil.isWindows())
@@ -239,21 +238,21 @@ public class NodeJSService implements INodeJSService
 	}
 
 	/**
-	 * Downloads a file from url, return the {@link File} on disk where it was saved.
+	 * Downloads a file from uri, return the {@link File} on disk where it was saved.
 	 * 
-	 * @param url
+	 * @param uri
 	 * @param monitor
 	 * @return
 	 * @throws CoreException
 	 */
-	private File download(URL url, String extension, IProgressMonitor monitor) throws CoreException
+	private File download(URI uri, String extension, IProgressMonitor monitor) throws CoreException
 	{
 		DownloadManager manager = new DownloadManager();
-		IPath path = Path.fromPortableString(url.getPath());
+		IPath path = Path.fromPortableString(uri.getPath());
 		String name = path.lastSegment();
 		File f = new File(FileUtil.getTempDirectory().toFile(), name + extension);
 		f.deleteOnExit();
-		manager.addURL(url, f);
+		manager.addURI(uri, f);
 		IStatus status = manager.start(monitor);
 		if (!status.isOK())
 		{

--- a/plugins/com.aptana.portal.ui/src/com/aptana/portal/ui/dispatch/configurationProcessors/InstallerConfigurationProcessor.java
+++ b/plugins/com.aptana.portal.ui/src/com/aptana/portal/ui/dispatch/configurationProcessors/InstallerConfigurationProcessor.java
@@ -8,8 +8,8 @@
 package com.aptana.portal.ui.dispatch.configurationProcessors;
 
 import java.io.File;
-import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -88,21 +88,21 @@ public abstract class InstallerConfigurationProcessor extends AbstractConfigurat
 		}
 		downloadedPaths = null;
 		DownloadManager downloadManager = new DownloadManager();
-		List<URL> urlsList = new ArrayList<URL>(URLs.length);
+		List<URI> urlsList = new ArrayList<URI>(URLs.length);
 		for (int i = 0; i < URLs.length; i++)
 		{
 			try
 			{
-				urlsList.add(new URL(urls[i]));
+				urlsList.add(new URI(urls[i]));
 			}
-			catch (MalformedURLException mue)
+			catch (URISyntaxException mue)
 			{
 				IdeLog.logError(PortalUIPlugin.getDefault(), mue);
 			}
 		}
 		try
 		{
-			downloadManager.addURLs(urlsList);
+			downloadManager.addURIs(urlsList);
 			IStatus status = downloadManager.start(progressMonitor);
 			if (status.isOK())
 			{

--- a/tests/com.aptana.core.io.tests/META-INF/MANIFEST.MF
+++ b/tests/com.aptana.core.io.tests/META-INF/MANIFEST.MF
@@ -6,5 +6,6 @@ Bundle-Version: 3.0.0.qualifier
 Bundle-Vendor: %providerName
 Fragment-Host: com.aptana.core.io
 Bundle-RequiredExecutionEnvironment: J2SE-1.5
-Require-Bundle: org.junit
+Require-Bundle: org.junit,
+ com.aptana.testing.mocks;bundle-version="1.0.0"
 Export-Package: com.aptana.core.io.tests

--- a/tests/com.aptana.core.io.tests/src/com/aptana/core/io/tests/AllTests.java
+++ b/tests/com.aptana.core.io.tests/src/com/aptana/core/io/tests/AllTests.java
@@ -10,11 +10,12 @@ package com.aptana.core.io.tests;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
+import com.aptana.ide.core.io.downloader.DownloadManagerTest;
 import com.aptana.ide.core.io.preferences.CloakingUtilsTest;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({ EFSUtilsTest.class, WorkspaceFileSystemTest.class, WorkspaceConnectionPointTest.class,
-		ConnectionPointManagerTest.class, CloakingUtilsTest.class })
+		ConnectionPointManagerTest.class, CloakingUtilsTest.class, DownloadManagerTest.class })
 public class AllTests
 {
 }

--- a/tests/com.aptana.core.io.tests/src/com/aptana/ide/core/io/downloader/DownloadManagerTest.java
+++ b/tests/com.aptana.core.io.tests/src/com/aptana/ide/core/io/downloader/DownloadManagerTest.java
@@ -1,0 +1,173 @@
+/**
+ * Aptana Studio
+ * Copyright (c) 2014 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the GNU Public License (GPL) v3 (with exceptions).
+ * Please see the license.html included with this distribution for details.
+ * Any modifications to this file must keep this entire header intact.
+ */
+package com.aptana.ide.core.io.downloader;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.MultiStatus;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.Status;
+import org.jmock.Expectations;
+import org.jmock.Mockery;
+import org.jmock.lib.legacy.ClassImposteriser;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.aptana.core.util.CollectionsUtil;
+import com.aptana.core.util.FileUtil;
+import com.aptana.ide.core.io.CoreIOPlugin;
+
+/**
+ * @author Chris Williams <cwilliams@appcelerator.com>
+ */
+public class DownloadManagerTest
+{
+	private Mockery context;
+	private DownloadManager dm;
+	private List<ContentDownloadRequest> requests;
+	private ContentDownloadRequest cdr;
+
+	@Before
+	public void setUp() throws Exception
+	{
+		context = new Mockery()
+		{
+			{
+				setImposteriser(ClassImposteriser.INSTANCE);
+			}
+		};
+		cdr = context.mock(ContentDownloadRequest.class);
+		requests = new ArrayList<ContentDownloadRequest>();
+		dm = new DownloadManager()
+		{
+			@Override
+			protected synchronized void addDownload(ContentDownloadRequest request)
+			{
+				requests.add(request);
+				super.addDownload(cdr);
+			}
+		};
+	}
+
+	@After
+	public void tearDown() throws Exception
+	{
+		cdr = null;
+		dm = null;
+		context = null;
+		requests = null;
+	}
+
+	@Test
+	public void testAddingFileURICreatesFileDownloadRequest() throws CoreException, URISyntaxException
+	{
+		dm.addURI(new URI("file:/fake/path/to/file.txt"));
+		assertEquals(1, requests.size());
+		assertTrue(requests.get(0) instanceof FileDownloadRequest);
+	}
+
+	@Test
+	public void testAddingNonFileURICreatesGenericContentDownloadRequest() throws CoreException, URISyntaxException
+	{
+		dm.addURI(new URI("http://example.com/fake/path/to/file.txt"));
+		assertEquals(1, requests.size());
+		assertTrue(requests.get(0) instanceof ContentDownloadRequest);
+	}
+
+	@Test
+	public void tesAddURIsAndURLsStartThenGetDownloadedPaths() throws CoreException, URISyntaxException
+	{
+		dm.addURI(new URI("http://example.com"));
+
+		final IPath downloadPath = Path.fromPortableString("/path/to/downloaded/file");
+		context.checking(new Expectations()
+		{
+			{
+				oneOf(cdr).execute(with(any(IProgressMonitor.class)));
+
+				oneOf(cdr).getResult();
+				will(returnValue(Status.OK_STATUS));
+
+				oneOf(cdr).getDownloadLocation();
+				will(returnValue(downloadPath));
+			}
+		});
+		IStatus result = dm.start(new NullProgressMonitor());
+		assertTrue(result.isOK());
+		List<IPath> paths = dm.getContentsLocations();
+		assertEquals(1, paths.size());
+		assertEquals(downloadPath, paths.get(0));
+		context.assertIsSatisfied();
+	}
+
+	// TODO Add tests for when user cancels in the middle of the process
+
+	@Test
+	public void testAddManyRequestsAndOneOfThemFailsToDownload() throws CoreException, URISyntaxException
+	{
+		dm.addURI(new URI("http://example.com/index.html"));
+		dm.addURI(new URI("http://example.com/fake_file_123.txt"),
+				FileUtil.getTempDirectory().append("fake_file_123.txt").toFile());
+		dm.addURIs(CollectionsUtil.newList(new URI("http://example.com/index.shtml")));
+
+		final IPath downloadPath1 = Path.fromPortableString("/path/to/downloaded/file1");
+		final IPath downloadPath2 = Path.fromPortableString("/path/to/downloaded/file2");
+		final IStatus errorStatus = new Status(IStatus.ERROR, CoreIOPlugin.PLUGIN_ID, "Failed to download");
+		context.checking(new Expectations()
+		{
+			{
+				exactly(3).of(cdr).execute(with(any(IProgressMonitor.class)));
+
+				exactly(3).of(cdr).getResult();
+				will(onConsecutiveCalls(returnValue(Status.OK_STATUS), returnValue(errorStatus),
+						returnValue(Status.OK_STATUS)));
+
+				exactly(2).of(cdr).getDownloadLocation();
+				will(onConsecutiveCalls(returnValue(downloadPath1), returnValue(downloadPath2)));
+			}
+		});
+		// One of the downloads will fail, so the returned status will not be OK
+		IStatus result = dm.start(new NullProgressMonitor());
+		assertFalse(result.isOK());
+		// Delve into the multi status and make sure that the first and third request are OK, 2nd was not
+		assertTrue(result.isMultiStatus());
+		MultiStatus multi = (MultiStatus) result;
+		IStatus[] children = multi.getChildren();
+		assertEquals(3, children.length);
+		assertTrue(children[0].isOK());
+		assertFalse(children[1].isOK());
+		assertTrue(children[2].isOK());
+
+		// Only two actually downloaded, let's ensure we got the paths we expect
+		List<IPath> paths = dm.getContentsLocations();
+		assertEquals(2, paths.size());
+		assertEquals(downloadPath1, paths.get(0));
+		assertEquals(downloadPath2, paths.get(1));
+		context.assertIsSatisfied();
+	}
+
+	@Test
+	public void testAttemptingToAddNullURLAddsNoRequest() throws CoreException
+	{
+		dm.addURL(null);
+		assertEquals(0, requests.size());
+	}
+}

--- a/tests/com.aptana.core.tests/src/com/aptana/core/util/CollectionsUtilTest.java
+++ b/tests/com.aptana.core.tests/src/com/aptana/core/util/CollectionsUtilTest.java
@@ -766,6 +766,23 @@ public class CollectionsUtilTest
 	}
 
 	@Test
+	public void testAddToMapWithNonNullKeyMappedToNullValue()
+	{
+		Map<String, String> map = CollectionsUtil.newMap("a", "b", "c", "d");
+		assertNotNull(map);
+
+		CollectionsUtil.addToMap(String.class, String.class, map, "e", null);
+		assertEquals("The map should have three items", 3, map.size());
+		assertTrue("'a' should exist in the map", map.containsKey("a"));
+		assertEquals("b", map.get("a"));
+		assertTrue("'b' should exist in the map", map.containsValue("b"));
+		assertTrue("'c' should exist in the map", map.containsKey("c"));
+		assertEquals("d", map.get("c"));
+		assertTrue("'d' should exist in the map", map.containsValue("d"));
+		assertNull(map.get("e"));
+	}
+
+	@Test
 	public void testAddToMapNullMap()
 	{
 		try


### PR DESCRIPTION
- Move away from use of URL to use of URI due to way URL may actually look up hostnames in some instances which can lead to nasty perf issues
- Add special case FileDownloadRequest for when we're asked to download from a file: URI - we just shortcut to use EFS and do a file copy so we avoid the ECF/proxy code.
- Add fix and unit test for adding a null value into a map in the newTypedMap/addToMap flow
- Add unit tests around DownloadManager
