### PR TITLE
TISTUD-6324 Load and store new property constant values from JSCA in JS' model for properties


### DIFF
--- a/plugins/com.aptana.index.core/src/com/aptana/index/core/IndexUtil.java
+++ b/plugins/com.aptana.index.core/src/com/aptana/index/core/IndexUtil.java
@@ -8,6 +8,8 @@
 package com.aptana.index.core;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -20,6 +22,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.SubMonitor;
 
+import com.aptana.core.IMap;
 import com.aptana.core.logging.IdeLog;
 import com.aptana.core.util.ArrayUtil;
 import com.aptana.core.util.CollectionsUtil;
@@ -91,7 +94,7 @@ public class IndexUtil
 					// Wrap loop because if newInstance fails once, it will fail for all iterations
 					try
 					{
-						for (Object value : (List) object)
+						for (Object value : objects)
 						{
 							if (value instanceof Map)
 							{
@@ -126,25 +129,34 @@ public class IndexUtil
 	 * @param list
 	 * @return
 	 */
+	@SuppressWarnings("unchecked")
 	public static List<String> createList(Object object)
 	{
 		List<String> result = null;
-
-		if (object != null && object.getClass().isArray())
+		if (object != null)
 		{
-			Object[] objects = (Object[]) object;
-
-			if (objects.length > 0)
+			Collection<Object> objects = null;
+			if (object.getClass().isArray())
 			{
-				result = new ArrayList<String>();
+				objects = Arrays.asList((Object[]) object);
+			}
+			else if (object instanceof Collection)
+			{
+				objects = (Collection<Object>) object;
+			}
 
-				for (Object value : (Object[]) object)
+			if (!CollectionsUtil.isEmpty(objects))
+			{
+				return CollectionsUtil.map(objects, new IMap<Object, String>()
 				{
-					result.add(value.toString());
-				}
+					@Override
+					public String map(Object item)
+					{
+						return item.toString();
+					}
+				});
 			}
 		}
-
 		return result;
 	}
 

--- a/plugins/com.aptana.js.core/src/com/aptana/js/core/model/EventPropertyElement.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/core/model/EventPropertyElement.java
@@ -7,21 +7,25 @@
  */
 package com.aptana.js.core.model;
 
+import java.util.List;
 import java.util.Map;
 
+import com.aptana.core.util.CollectionsUtil;
 import com.aptana.core.util.SourcePrinter;
 import com.aptana.core.util.StringUtil;
+import com.aptana.index.core.IndexUtil;
 import com.aptana.jetty.util.epl.ajax.JSON.Output;
 
 /**
  * EventProperty
  */
-public class EventPropertyElement extends BaseElement
+public class EventPropertyElement extends BaseElement implements IHasPredefinedValues
 {
 
 	private static final String TYPE_PROPERTY = "type"; //$NON-NLS-1$
 
 	private String _type;
+	private List<String> _constants;
 
 	/**
 	 * EventProperty
@@ -41,6 +45,7 @@ public class EventPropertyElement extends BaseElement
 		super.fromJSON(object);
 
 		this.setType(StringUtil.getStringValue(object.get(TYPE_PROPERTY)));
+		this._constants = IndexUtil.createList(object.get(CONSTANTS_PROPERTY));
 	}
 
 	/**
@@ -49,6 +54,16 @@ public class EventPropertyElement extends BaseElement
 	public String getType()
 	{
 		return this._type;
+	}
+
+	/**
+	 * getConstants
+	 * 
+	 * @return
+	 */
+	public List<String> getConstants()
+	{
+		return CollectionsUtil.getListValue(this._constants);
 	}
 
 	/**
@@ -70,6 +85,7 @@ public class EventPropertyElement extends BaseElement
 		super.toJSON(out);
 
 		out.add(TYPE_PROPERTY, this.getType());
+		out.add(CONSTANTS_PROPERTY, this.getConstants());
 	}
 
 	/**

--- a/plugins/com.aptana.js.core/src/com/aptana/js/core/model/IHasPredefinedValues.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/core/model/IHasPredefinedValues.java
@@ -1,0 +1,25 @@
+/**
+ * Aptana Studio
+ * Copyright (c) 2014 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the GNU Public License (GPL) v3 (with exceptions).
+ * Please see the license.html included with this distribution for details.
+ * Any modifications to this file must keep this entire header intact.
+ */
+package com.aptana.js.core.model;
+
+import java.util.List;
+
+/**
+ * A marking interface to know that this model element has a set of possible predefined values that can be used.
+ * 
+ * @author Chris Williams <cwilliams@appcelerator.com>
+ */
+public interface IHasPredefinedValues
+{
+	/**
+	 * Property name used to store the list/array of String values in JSCA
+	 */
+	static final String CONSTANTS_PROPERTY = "constants"; //$NON-NLS-1$
+
+	public List<String> getConstants();
+}

--- a/plugins/com.aptana.js.core/src/com/aptana/js/core/model/ParameterElement.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/core/model/ParameterElement.java
@@ -17,8 +17,12 @@ import com.aptana.index.core.IndexUtil;
 import com.aptana.jetty.util.epl.ajax.JSON.Convertible;
 import com.aptana.jetty.util.epl.ajax.JSON.Output;
 
-public class ParameterElement implements Convertible
+public class ParameterElement implements Convertible, IHasPredefinedValues
 {
+	/**
+	 * JSCA Uses "type" holding one String, we used "types" holding a list/array of Strings
+	 */
+	private static final String TYPE = "type"; //$NON-NLS-1$
 	private static final String TYPES_PROPERTY = "types"; //$NON-NLS-1$
 	private static final String DESCRIPTION_PROPERTY = "description"; //$NON-NLS-1$
 	private static final String USAGE_PROPERTY = "usage"; //$NON-NLS-1$
@@ -28,6 +32,7 @@ public class ParameterElement implements Convertible
 	private List<String> _types;
 	private String _usage;
 	private String _description;
+	private List<String> _constants;
 
 	/**
 	 * ParameterElement
@@ -64,11 +69,12 @@ public class ParameterElement implements Convertible
 		this.setName(StringUtil.getStringValue(object.get(NAME_PROPERTY)));
 		this.setUsage(StringUtil.getStringValue(object.get(USAGE_PROPERTY)));
 		this.setDescription(StringUtil.getStringValue(object.get(DESCRIPTION_PROPERTY)));
+		this._constants = IndexUtil.createList(object.get(CONSTANTS_PROPERTY));
 
 		// JSCA contains a single "type" value
-		if (object.containsKey("type"))
+		if (object.containsKey(TYPE))
 		{
-			this._types = CollectionsUtil.newList((String) object.get("type"));
+			this._types = CollectionsUtil.newList((String) object.get(TYPE));
 		}
 		else
 		{
@@ -101,6 +107,16 @@ public class ParameterElement implements Convertible
 	public List<String> getTypes()
 	{
 		return CollectionsUtil.getListValue(this._types);
+	}
+
+	/**
+	 * getConstants
+	 * 
+	 * @return
+	 */
+	public List<String> getConstants()
+	{
+		return CollectionsUtil.getListValue(this._constants);
 	}
 
 	/**
@@ -149,6 +165,7 @@ public class ParameterElement implements Convertible
 		out.add(USAGE_PROPERTY, this.getUsage());
 		out.add(DESCRIPTION_PROPERTY, this.getDescription());
 		out.add(TYPES_PROPERTY, this.getTypes());
+		out.add(CONSTANTS_PROPERTY, this.getConstants());
 	}
 
 	/*
@@ -161,9 +178,6 @@ public class ParameterElement implements Convertible
 		{
 			return "[" + this.getName() + "]"; //$NON-NLS-1$ //$NON-NLS-2$
 		}
-		else
-		{
-			return this.getName();
-		}
+		return this.getName();
 	}
 }

--- a/plugins/com.aptana.js.core/src/com/aptana/js/core/model/PropertyElement.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/core/model/PropertyElement.java
@@ -20,7 +20,7 @@ import com.aptana.index.core.IndexUtil;
 import com.aptana.jetty.util.epl.ajax.JSON.Output;
 import com.aptana.js.core.JSTypeConstants;
 
-public class PropertyElement extends BaseElement
+public class PropertyElement extends BaseElement implements IHasPredefinedValues
 {
 
 	private static final String EXAMPLES_PROPERTY = "examples"; //$NON-NLS-1$
@@ -36,6 +36,7 @@ public class PropertyElement extends BaseElement
 	private boolean _isInternal;
 	private List<ReturnTypeElement> _types;
 	private List<String> _examples;
+	private List<String> _constants;
 
 	/**
 	 * PropertyElement
@@ -58,6 +59,7 @@ public class PropertyElement extends BaseElement
 		this._isInternal = base.isInternal();
 		this._types = new ArrayList<ReturnTypeElement>(base.getTypes());
 		this._examples = new ArrayList<String>(base.getExamples());
+		this._constants = new ArrayList<String>(base.getConstants());
 	}
 
 	/**
@@ -143,10 +145,7 @@ public class PropertyElement extends BaseElement
 		{
 			return ObjectUtil.areEqual(toSource(), ((PropertyElement) obj).toSource());
 		}
-		else
-		{
-			return super.equals(obj);
-		}
+		return super.equals(obj);
 	}
 
 	/*
@@ -167,6 +166,7 @@ public class PropertyElement extends BaseElement
 
 		this._types = IndexUtil.createList(object.get(TYPES_PROPERTY), ReturnTypeElement.class);
 		this._examples = IndexUtil.createList(object.get(EXAMPLES_PROPERTY));
+		this._constants = IndexUtil.createList(object.get(CONSTANTS_PROPERTY));
 	}
 
 	/**
@@ -177,6 +177,16 @@ public class PropertyElement extends BaseElement
 	public List<String> getExamples()
 	{
 		return CollectionsUtil.getListValue(this._examples);
+	}
+
+	/**
+	 * getConstants
+	 * 
+	 * @return
+	 */
+	public List<String> getConstants()
+	{
+		return CollectionsUtil.getListValue(this._constants);
 	}
 
 	/**
@@ -300,6 +310,7 @@ public class PropertyElement extends BaseElement
 		out.add(IS_INTERNAL_PROPERTY, this.isInternal());
 		out.add(TYPES_PROPERTY, this.getTypes());
 		out.add(EXAMPLES_PROPERTY, this.getExamples());
+		out.add(CONSTANTS_PROPERTY, this.getConstants());
 	}
 
 	/**

--- a/tests/com.aptana.js.core.tests/indexing/arbitrary_property.jsca
+++ b/tests/com.aptana.js.core.tests/indexing/arbitrary_property.jsca
@@ -1,7 +1,7 @@
 {
 	"types": [
 		{
-			"name": "Titanium.UI",
+			"name": "Titanium",
 			"extends": "Something",
 			"events": [
 				{

--- a/tests/com.aptana.js.core.tests/indexing/event_property_with_constants.jsca
+++ b/tests/com.aptana.js.core.tests/indexing/event_property_with_constants.jsca
@@ -1,0 +1,61 @@
+{
+	"types": [
+		{
+			"name": "Titanium",
+			"extends": "Something",
+			"events": [
+                {
+                    "name": "beforeload", 
+                    "deprecated": false, 
+                    "properties": [
+                        {
+                            "name": "bubbles", 
+                            "deprecated": false, 
+                            "type": "Boolean", 
+                            "description": "<p>True if the event will try to bubble up if possible.</p>"
+                        }, 
+                        {
+                            "name": "cancelBubble", 
+                            "deprecated": false, 
+                            "type": "Boolean", 
+                            "description": "<p>Set to true to stop the event from bubbling.</p>"
+                        }, 
+                        {
+                            "name": "navigationType", 
+                            "deprecated": false, 
+                            "type": "Number", 
+                            "constants": [
+                                "Titanium.UI.iOS.WEBVIEW_NAVIGATIONTYPE_LINK_CLICKED", 
+                                "Titanium.UI.iOS.WEBVIEW_NAVIGATIONTYPE_FORM_SUBMITTED", 
+                                "Titanium.UI.iOS.WEBVIEW_NAVIGATIONTYPE_BACK_FORWARD", 
+                                "Titanium.UI.iOS.WEBVIEW_NAVIGATIONTYPE_RELOAD", 
+                                "Titanium.UI.iOS.WEBVIEW_NAVIGATIONTYPE_FORM_RESUBMITTED", 
+                                "Titanium.UI.iOS.WEBVIEW_NAVIGATIONTYPE_OTHER"
+                            ], 
+                            "description": "<p>Constant indicating the user's action.</p>"
+                        }, 
+                        {
+                            "name": "source", 
+                            "deprecated": false, 
+                            "type": "Object", 
+                            "description": "<p>Source object that fired the event.</p>"
+                        }, 
+                        {
+                            "name": "type", 
+                            "deprecated": false, 
+                            "type": "String", 
+                            "description": "<p>Name of the event fired.</p>"
+                        }, 
+                        {
+                            "name": "url", 
+                            "deprecated": false, 
+                            "type": "", 
+                            "description": "<p>URL of the web document being loaded.</p>"
+                        }
+                    ], 
+                    "description": "<p>Fired before the web view starts loading its content.</p>"
+                }
+			]
+		}
+	]
+}

--- a/tests/com.aptana.js.core.tests/indexing/implicit_owner.jsca
+++ b/tests/com.aptana.js.core.tests/indexing/implicit_owner.jsca
@@ -1,0 +1,8 @@
+{
+	"types": [
+		{
+			"name": "Titanium.UI",
+			"extends": "Something"
+		}
+	]
+}

--- a/tests/com.aptana.js.core.tests/indexing/parameter_with_constants.jsca
+++ b/tests/com.aptana.js.core.tests/indexing/parameter_with_constants.jsca
@@ -1,0 +1,89 @@
+{
+	"types": [
+		{
+			"name": "Titanium",
+			"extends": "Something",
+			"functions": [
+				{
+                    "name": "convertUnits", 
+                    "isInternal": false, 
+                    "parameters": [
+                        {
+                            "name": "convertFromValue", 
+                            "usage": "required", 
+                            "type": "String", 
+                            "description": "<p>Measurement and optional unit to convert from, i.e. 160, \"120dip\".  Percentages are \nnot accepted.</p>"
+                        }, 
+                        {
+                            "name": "convertToUnits", 
+                            "usage": "required", 
+                            "type": "String", 
+                            "description": "<p>Desired unit for the conversion result. Use one of the unit constants in Titanium.UI.</p>",
+                        	"constants": [
+                        				"Titanium.UI.UNIT_CM",
+                        				"Titanium.UI.UNIT_DIP",
+                        				"Titanium.UI.UNIT_IN",
+                        				"Titanium.UI.UNIT_MM",
+                        				"Titanium.UI.UNIT_PX"
+                        	]
+                        }
+                    ], 
+                    "deprecated": false, 
+                    "since": [
+                        {
+                            "name": "Titanium Mobile SDK - Android", 
+                            "version": "2.0.0"
+                        }, 
+                        {
+                            "name": "Titanium Mobile SDK - iPhone", 
+                            "version": "2.0.0"
+                        }, 
+                        {
+                            "name": "Titanium Mobile SDK - iPad", 
+                            "version": "2.0.0"
+                        }, 
+                        {
+                            "name": "Titanium Mobile SDK - Mobile Web", 
+                            "version": "2.0.0"
+                        }, 
+                        {
+                            "name": "Titanium Mobile SDK - Tizen", 
+                            "version": "3.1"
+                        }
+                    ], 
+                    "returnTypes": [
+                        {
+                            "type": "Number", 
+                            "description": ""
+                        }
+                    ], 
+                    "isConstructor": false, 
+                    "isClassProperty": false, 
+                    "examples": [], 
+                    "userAgents": [
+                        {
+                            "platform": "android"
+                        }, 
+                        {
+                            "platform": "iphone"
+                        }, 
+                        {
+                            "platform": "ipad"
+                        }, 
+                        {
+                            "platform": "mobileweb"
+                        }, 
+                        {
+                            "platform": "tizen"
+                        }
+                    ], 
+                    "exceptions": [], 
+                    "references": [], 
+                    "isMethod": true, 
+                    "isInstanceProperty": true, 
+                    "description": "<p>Converts one type of unit to another using the metrics of the main display.</p>"
+                }
+			]
+		}
+	]
+}

--- a/tests/com.aptana.js.core.tests/indexing/property_with_constants.jsca
+++ b/tests/com.aptana.js.core.tests/indexing/property_with_constants.jsca
@@ -1,0 +1,44 @@
+{
+	"types": [
+		{
+			"name": "Titanium",
+			"extends": "Something",
+			"properties": [
+				{
+                    "name": "appearance", 
+                    "since": [
+                        {
+                            "name": "Titanium Mobile SDK - iPhone", 
+                            "version": "0.8"
+                        }, 
+                        {
+                            "name": "Titanium Mobile SDK - iPad", 
+                            "version": "0.8"
+                        }
+                    ], 
+                    "isInternal": false, 
+                    "permission": "read-write", 
+                    "deprecated": false, 
+                    "isInstanceProperty": true, 
+                    "examples": [], 
+                    "userAgents": [
+                        {
+                            "platform": "iphone"
+                        }, 
+                        {
+                            "platform": "ipad"
+                        }
+                    ], 
+                    "type": "Number", 
+                    "isClassProperty": false, 
+                    "availability": "always", 
+                    "constants": [
+                        "Titanium.UI.KEYBOARD_APPEARANCE_ALERT", 
+                        "Titanium.UI.KEYBOARD_APPEARANCE_DEFAULT"
+                    ], 
+                    "description": "<p>Determines the appearance of the keyboard displayed when this text area is focused.</p>"
+                }
+			]
+		}
+	]
+}

--- a/tests/com.aptana.js.core.tests/src/com/aptana/js/internal/core/index/InternalCoreIndexTests.java
+++ b/tests/com.aptana.js.core.tests/src/com/aptana/js/internal/core/index/InternalCoreIndexTests.java
@@ -1,35 +1,11 @@
 package com.aptana.js.internal.core.index;
 
-import org.junit.runners.Suite.SuiteClasses;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestResult;
-import junit.framework.TestSuite;
+import org.junit.runners.Suite.SuiteClasses;
 
 @RunWith(Suite.class)
-@SuiteClasses({JSIndexTest.class, JSMetadataIndexWriterTest.class, MetadataTest.class, })
+@SuiteClasses({ JSIndexTest.class, JSMetadataIndexWriterTest.class, MetadataTest.class, JSCAParserTest.class })
 public class InternalCoreIndexTests
 {
-
-//	public static Test suite()
-//	{
-//		TestSuite suite = new TestSuite(InternalCoreIndexTests.class.getName())
-//		{
-//			@Override
-//			public void runTest(Test test, TestResult result)
-//			{
-//				System.err.println("Running test: " + test.toString());
-//				super.runTest(test, result);
-//			}
-//		};
-//		// $JUnit-BEGIN$
-//		suite.addTestSuite(JSIndexTest.class);
-//		suite.addTestSuite(JSMetadataIndexWriterTest.class);
-//		suite.addTestSuite(MetadataTest.class);
-//		// $JUnit-END$
-//		return suite;
-//	}
-//
 }

--- a/tests/com.aptana.js.core.tests/src/com/aptana/js/internal/core/index/JSCAParserTest.java
+++ b/tests/com.aptana.js.core.tests/src/com/aptana/js/internal/core/index/JSCAParserTest.java
@@ -7,19 +7,28 @@
  */
 package com.aptana.js.internal.core.index;
 
-import org.junit.After;
-import org.junit.Test;
-import org.junit.Before;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
 import java.net.URL;
 import java.util.List;
 
-import junit.framework.TestCase;
-
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Path;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
+import com.aptana.core.IFilter;
+import com.aptana.core.IMap;
+import com.aptana.core.util.CollectionsUtil;
 import com.aptana.js.core.JSCorePlugin;
+import com.aptana.js.core.model.EventElement;
+import com.aptana.js.core.model.EventPropertyElement;
+import com.aptana.js.core.model.FunctionElement;
+import com.aptana.js.core.model.ParameterElement;
+import com.aptana.js.core.model.PropertyElement;
 import com.aptana.js.core.model.TypeElement;
 
 public class JSCAParserTest
@@ -30,7 +39,6 @@ public class JSCAParserTest
 	@Before
 	public void setUp() throws Exception
 	{
-//		super.setUp();
 		parser = new JSCAParser();
 	}
 
@@ -38,20 +46,114 @@ public class JSCAParserTest
 	public void tearDown() throws Exception
 	{
 		parser = null;
-//		super.tearDown();
 	}
 
 	@Test
 	public void testTISTUD5079() throws Exception
 	{
-		URL url = FileLocator.find(JSCorePlugin.getDefault().getBundle(),
-				Path.fromPortableString("indexing/arbitrary_property.jsca"), null);
-
-		// Ensure we can parse a JSCA fle that has an arbitrary property we don't recognize (we just ignore it).
-		IJSCAModel model = parser.parse(url.openStream());
+		// Ensure we can parse a JSCA file that has an arbitrary property we don't recognize (we just ignore it).
+		IJSCAModel model = parse("indexing/arbitrary_property.jsca");
 
 		List<TypeElement> types = model.getTypes();
 		assertEquals(1, types.size());
+	}
+
+	@Test
+	public void testCreatesImplicitOwningType() throws Exception
+	{
+		// We define a "Titanium.UI type, but not "Titanium" explicitly, it generates it for us.
+		IJSCAModel model = parse("indexing/implicit_owner.jsca");
+
+		List<TypeElement> types = model.getTypes();
+		assertEquals(2, types.size());
+		List<String> typeNames = CollectionsUtil.map(types, new IMap<TypeElement, String>()
+		{
+			public String map(TypeElement item)
+			{
+				return item.getName();
+			}
+		});
+		assertTrue(typeNames.contains("Titanium.UI"));
+		assertTrue(typeNames.contains("Titanium"));
+	}
+
+	@Test
+	public void testParsePropertyWithConstants() throws Exception
+	{
+		IJSCAModel model = parse("indexing/property_with_constants.jsca");
+
+		List<TypeElement> types = model.getTypes();
+		assertEquals(1, types.size());
+		TypeElement type = types.get(0);
+		PropertyElement prop = type.getProperty("appearance");
+		List<String> constants = prop.getConstants();
+		assertEquals(2, constants.size());
+		assertTrue(constants.contains("Titanium.UI.KEYBOARD_APPEARANCE_ALERT"));
+		assertTrue(constants.contains("Titanium.UI.KEYBOARD_APPEARANCE_DEFAULT"));
+	}
+
+	@Test
+	public void testParseEventPropertyWithConstants() throws Exception
+	{
+		IJSCAModel model = parse("indexing/event_property_with_constants.jsca");
+
+		List<TypeElement> types = model.getTypes();
+		assertEquals(1, types.size());
+		TypeElement type = types.get(0);
+		EventElement event = type.getEvent("beforeload");
+		List<EventPropertyElement> properties = event.getProperties();
+		EventPropertyElement navType = CollectionsUtil.find(properties, new IFilter<EventPropertyElement>()
+		{
+			public boolean include(EventPropertyElement item)
+			{
+
+				return item.getName().equals("navigationType");
+			}
+		});
+		List<String> constants = navType.getConstants();
+		assertEquals(6, constants.size());
+		assertTrue(constants.contains("Titanium.UI.iOS.WEBVIEW_NAVIGATIONTYPE_LINK_CLICKED"));
+		assertTrue(constants.contains("Titanium.UI.iOS.WEBVIEW_NAVIGATIONTYPE_FORM_SUBMITTED"));
+		assertTrue(constants.contains("Titanium.UI.iOS.WEBVIEW_NAVIGATIONTYPE_BACK_FORWARD"));
+		assertTrue(constants.contains("Titanium.UI.iOS.WEBVIEW_NAVIGATIONTYPE_RELOAD"));
+		assertTrue(constants.contains("Titanium.UI.iOS.WEBVIEW_NAVIGATIONTYPE_FORM_RESUBMITTED"));
+		assertTrue(constants.contains("Titanium.UI.iOS.WEBVIEW_NAVIGATIONTYPE_OTHER"));
+	}
+
+	@Test
+	public void testParameterWithConstants() throws Exception
+	{
+		IJSCAModel model = parse("indexing/parameter_with_constants.jsca");
+
+		List<TypeElement> types = model.getTypes();
+		assertEquals(1, types.size());
+		TypeElement type = types.get(0);
+		FunctionElement func = (FunctionElement) type.getProperty("convertUnits");
+		List<ParameterElement> params = func.getParameters();
+		ParameterElement param = CollectionsUtil.find(params, new IFilter<ParameterElement>()
+		{
+			public boolean include(ParameterElement item)
+			{
+
+				return item.getName().equals("convertToUnits");
+			}
+		});
+
+		List<String> constants = param.getConstants();
+		assertEquals(5, constants.size());
+		assertTrue(constants.contains("Titanium.UI.UNIT_CM"));
+		assertTrue(constants.contains("Titanium.UI.UNIT_DIP"));
+		assertTrue(constants.contains("Titanium.UI.UNIT_IN"));
+		assertTrue(constants.contains("Titanium.UI.UNIT_MM"));
+		assertTrue(constants.contains("Titanium.UI.UNIT_PX"));
+	}
+
+	protected IJSCAModel parse(String filePath) throws IOException
+	{
+		URL url = FileLocator.find(JSCorePlugin.getDefault().getBundle(), Path.fromPortableString(filePath), null);
+
+		IJSCAModel model = parser.parse(url.openStream());
+		return model;
 	}
 
 }

--- a/tests/com.aptana.js.core.tests/src/com/aptana/js/internal/core/index/JSIndexTest.java
+++ b/tests/com.aptana.js.core.tests/src/com/aptana/js/internal/core/index/JSIndexTest.java
@@ -7,9 +7,12 @@
  */
 package com.aptana.js.internal.core.index;
 
-import org.junit.After;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -17,17 +20,18 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-import junit.framework.TestCase;
-
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
+import org.junit.After;
+import org.junit.Test;
 
 import com.aptana.core.CorePlugin;
 import com.aptana.core.IUserAgent;
 import com.aptana.core.IUserAgentManager;
+import com.aptana.core.util.CollectionsUtil;
 import com.aptana.core.util.IOUtil;
 import com.aptana.core.util.StringUtil;
 import com.aptana.index.core.Index;
@@ -42,7 +46,11 @@ import com.aptana.js.core.JSCorePlugin;
 import com.aptana.js.core.index.IJSIndexConstants;
 import com.aptana.js.core.index.JSFileIndexingParticipant;
 import com.aptana.js.core.index.JSIndexQueryHelper;
+import com.aptana.js.core.model.EventElement;
+import com.aptana.js.core.model.EventPropertyElement;
 import com.aptana.js.core.model.FunctionElement;
+import com.aptana.js.core.model.IHasPredefinedValues;
+import com.aptana.js.core.model.ParameterElement;
 import com.aptana.js.core.model.PropertyElement;
 import com.aptana.js.core.model.TypeElement;
 import com.aptana.js.core.model.UserAgentElement;
@@ -287,6 +295,162 @@ public class JSIndexTest
 		// make sure the name is correct
 		PropertyElement retrievedProperty = properties.get(0);
 		assertEquals(propertyName, retrievedProperty.getName());
+	}
+
+	@Test
+	public void testPropertyWithConstantValues()
+	{
+		String typeName = "MyClass";
+		String propertyName = "myProperty";
+
+		// create type
+		TypeElement type = new TypeElement();
+		type.setName(typeName);
+
+		// create property within type
+		PropertyElement property = createProperty("name", propertyName, IHasPredefinedValues.CONSTANTS_PROPERTY,
+				CollectionsUtil.newList("Titanium.UI.FILL", "Titanium.UI.ALIGN"));
+		type.addProperty(property);
+
+		// write type to index
+		this.writeType(type);
+
+		// then retrieve it
+		List<TypeElement> retrievedTypes = this.getType(typeName);
+		TypeElement retrievedType = retrievedTypes.get(0);
+
+		assertNotNull(retrievedType);
+		assertEquals(typeName, retrievedType.getName());
+
+		// make sure we have one property
+		List<PropertyElement> properties = retrievedType.getProperties();
+		assertNotNull(properties);
+		assertEquals(1, properties.size());
+
+		// make sure the name is correct
+		PropertyElement retrievedProperty = properties.get(0);
+		assertEquals(propertyName, retrievedProperty.getName());
+		// Check constants
+		List<String> constants = retrievedProperty.getConstants();
+		assertEquals(2, constants.size());
+		assertTrue(constants.contains("Titanium.UI.FILL"));
+		assertTrue(constants.contains("Titanium.UI.ALIGN"));
+	}
+
+	private PropertyElement createProperty(Object... objects)
+	{
+		PropertyElement property = new PropertyElement();
+		Map<String, Object> map = CollectionsUtil.newTypedMap(String.class, Object.class, objects);
+		property.fromJSON(map);
+		return property;
+	}
+
+	@Test
+	public void testEventPropertyWithConstantValues()
+	{
+		String typeName = "MyClass";
+		String functionName = "convertUnits";
+		String paramName = "convertToUnits";
+		List<String> constants = CollectionsUtil.newList("Titanium.UI.UNIT_CM", "Titanium.UI.UNIT_MM",
+				"Titanium.UI.UNIT_DIP", "Titanium.UI.UNIT_IN", "Titanium.UI.UNIT_PX");
+
+		// create type
+		TypeElement type = new TypeElement();
+		type.setName(typeName);
+
+		// create function within type
+		FunctionElement function = new FunctionElement();
+		function.setName(functionName);
+
+		ParameterElement parameter = new ParameterElement();
+		parameter.setName(paramName);
+		parameter.fromJSON(CollectionsUtil.newTypedMap(String.class, Object.class,
+				IHasPredefinedValues.CONSTANTS_PROPERTY, constants));
+		function.addParameter(parameter);
+
+		type.addProperty(function);
+
+		// write type to index
+		this.writeType(type);
+
+		// then retrieve it
+		List<TypeElement> retrievedTypes = this.getType(typeName);
+		TypeElement retrievedType = retrievedTypes.get(0);
+
+		assertNotNull(retrievedType);
+		assertEquals(typeName, retrievedType.getName());
+
+		// make sure we have one property
+		List<PropertyElement> properties = retrievedType.getProperties();
+		assertNotNull(properties);
+		assertEquals(1, properties.size());
+
+		// make sure the name is correct
+		PropertyElement retrievedProperty = properties.get(0);
+		assertEquals(functionName, retrievedProperty.getName());
+		assertTrue(retrievedProperty instanceof FunctionElement);
+		FunctionElement retrievedFunction = (FunctionElement) retrievedProperty;
+		List<ParameterElement> retrievedParams = retrievedFunction.getParameters();
+		assertNotNull(retrievedParams);
+		assertEquals(1, retrievedParams.size());
+
+		ParameterElement retrievedParam = retrievedParams.get(0);
+
+		// Check constants
+		List<String> retrievedConstants = retrievedParam.getConstants();
+		assertEquals(constants.size(), retrievedConstants.size());
+		for (String constant : constants)
+		{
+			assertTrue(retrievedConstants.contains(constant));
+		}
+	}
+
+	@Test
+	public void testFunctionParameterWithConstantValues()
+	{
+		String typeName = "MyClass";
+		String eventName = "event";
+		String propertyName = "eventProperty";
+
+		// create type
+		TypeElement type = new TypeElement();
+		type.setName(typeName);
+
+		EventElement ee = new EventElement();
+		ee.setName(eventName);
+		EventPropertyElement epe = new EventPropertyElement();
+		epe.fromJSON(CollectionsUtil.newTypedMap(String.class, Object.class, IHasPredefinedValues.CONSTANTS_PROPERTY,
+				CollectionsUtil.newList("Titanium.UI.FILL", "Titanium.UI.ALIGN")));
+		epe.setName(propertyName);
+		ee.addProperty(epe);
+
+		type.addEvent(ee);
+
+		// write type to index
+		this.writeType(type);
+
+		// then retrieve it
+		List<TypeElement> retrievedTypes = this.getType(typeName);
+		TypeElement retrievedType = retrievedTypes.get(0);
+
+		assertNotNull(retrievedType);
+		assertEquals(typeName, retrievedType.getName());
+
+		EventElement retrievedEvent = retrievedType.getEvent(eventName);
+		assertNotNull(retrievedEvent);
+
+		List<EventPropertyElement> retrievedProps = retrievedEvent.getProperties();
+		assertNotNull(retrievedProps);
+		assertEquals(1, retrievedProps.size());
+
+		// make sure the name is correct
+		EventPropertyElement retrievedProperty = retrievedProps.get(0);
+		assertEquals(propertyName, retrievedProperty.getName());
+		// Check constants
+		List<String> constants = retrievedProperty.getConstants();
+		assertEquals(2, constants.size());
+		assertTrue(constants.contains("Titanium.UI.FILL"));
+		assertTrue(constants.contains("Titanium.UI.ALIGN"));
 	}
 
 	@Test


### PR DESCRIPTION
- Added unit tests that we parse the new "constants" values from JSCA for selected elements
- Added unit tests that those values get written to the index
- Added an IHasPredefinedValues interface to mark the model elements that can hold these values
