### PR TITLE
Adds more support for handling require calls in JS

### DIFF
--- a/plugins/com.aptana.js.core/src/com/aptana/js/core/JSLanguageConstants.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/core/JSLanguageConstants.java
@@ -91,6 +91,8 @@ public class JSLanguageConstants
 	public static final String IN = "in"; //$NON-NLS-1$
 	public static final String GREATER_GREATER_EQUAL = ">>="; //$NON-NLS-1$
 
+	public static final String REQUIRE = "require"; //$NON-NLS-1$
+
 	public static final String[] KEYWORD_OPERATORS = new String[] { DELETE, INSTANCEOF, IN, NEW, TYPEOF, WITH };
 	@SuppressWarnings("nls")
 	public static final String[] SUPPORT_FUNCTIONS = new String[] { "small", "savePreferences", "slice", "sqrt",

--- a/plugins/com.aptana.js.core/src/com/aptana/js/core/inferencing/CommonJSResolver.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/core/inferencing/CommonJSResolver.java
@@ -7,9 +7,20 @@
  */
 package com.aptana.js.core.inferencing;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
+
+import com.aptana.core.util.StringUtil;
+import com.aptana.js.core.parsing.ast.JSArgumentsNode;
+import com.aptana.js.core.parsing.ast.JSGetPropertyNode;
+import com.aptana.js.core.parsing.ast.JSIdentifierNode;
+import com.aptana.js.core.parsing.ast.JSInvokeNode;
+import com.aptana.js.core.parsing.ast.JSStringNode;
+import com.aptana.parsing.ast.IParseNode;
 
 /**
  * Resolves a module id relative to a base module namespace root, ore if the path is explicitly relative, relative to
@@ -22,11 +33,11 @@ public class CommonJSResolver implements IRequireResolver
 
 	public IPath resolve(String moduleId, IProject project, IPath currentLocation, IPath indexRoot)
 	{
-		if (!currentLocation.toFile().isDirectory())
+		if (currentLocation == null || !currentLocation.toFile().isDirectory())
 		{
 			throw new IllegalArgumentException("current location must be a directory"); //$NON-NLS-1$
 		}
-		if (!indexRoot.toFile().isDirectory())
+		if (indexRoot == null || !indexRoot.toFile().isDirectory())
 		{
 			throw new IllegalArgumentException("module namespace root must be a directory"); //$NON-NLS-1$
 		}
@@ -41,7 +52,7 @@ public class CommonJSResolver implements IRequireResolver
 			// relative
 			return currentLocation.append(modulePath);
 		}
-		// absolute, so resolve releative to index root
+		// absolute, so resolve relative to index root
 		return indexRoot.append(modulePath);
 	}
 
@@ -49,6 +60,73 @@ public class CommonJSResolver implements IRequireResolver
 	{
 		// CommonJS will be our fallback. Should always apply.
 		return true;
+	}
+
+	// Grab the args of the parent and try to turn them into a string
+	// i.e. turn path.join('something', 'else.js') into 'something/else.js'
+	// path.join(__dirname, '..', 'blah.js') into './../blah.js'
+	/**
+	 * This is a helper method for determining the moduleId being referred to inside require calls. The easiest case is
+	 * a string argument, where we just return the value. The heuristic also accounts for path.join calls (looks for an
+	 * arg that invokes join on some owner with string arguments). The node being passed in is expected to be one of the
+	 * children of a JSArgumentsNode.
+	 * 
+	 * @param child
+	 * @return
+	 */
+	public static String getModuleId(IParseNode child)
+	{
+		// Try an heuristic for path.join calls
+		if (child instanceof JSInvokeNode)
+		{
+			JSInvokeNode invoke = (JSInvokeNode) child;
+			if (invoke.getChildCount() == 2)
+			{
+				IParseNode node = invoke.getChild(0);
+				if (node instanceof JSGetPropertyNode)
+				{
+					JSGetPropertyNode getProp = (JSGetPropertyNode) node;
+					IParseNode right = getProp.getRightHandSide();
+					if (right.getNameNode().getName().equals("join")) //$NON-NLS-1$
+					{
+						JSArgumentsNode joinArgs = (JSArgumentsNode) invoke.getChild(1);
+						List<String> items = new ArrayList<String>();
+						for (IParseNode joinArg : joinArgs)
+						{
+							String arg = getStringValue(joinArg);
+							items.add(arg);
+						}
+						return StringUtil.join("/", items); //$NON-NLS-1$
+					}
+				}
+			}
+		}
+		return getStringValue(child);
+	}
+
+	/**
+	 * For a given argument, what is teh string value to use when we build up the full path. Treat __dirname as
+	 * equivalent to "."
+	 * 
+	 * @param node
+	 * @return
+	 */
+	private static String getStringValue(IParseNode node)
+	{
+		if (node instanceof JSStringNode)
+		{
+			JSStringNode string = (JSStringNode) node;
+			return StringUtil.stripQuotes(string.getText());
+		}
+		if (node instanceof JSIdentifierNode)
+		{
+			JSIdentifierNode identifier = (JSIdentifierNode) node;
+			if (identifier.getNameNode().getName().equals("__dirname")) //$NON-NLS-1$
+			{
+				return "."; //$NON-NLS-1$
+			}
+		}
+		return null;
 	}
 
 }

--- a/plugins/com.aptana.js.core/src/com/aptana/js/core/inferencing/JSNodeTypeInferrer.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/core/inferencing/JSNodeTypeInferrer.java
@@ -29,6 +29,7 @@ import com.aptana.core.util.CollectionsUtil;
 import com.aptana.core.util.StringUtil;
 import com.aptana.core.util.URIUtil;
 import com.aptana.index.core.Index;
+import com.aptana.js.core.JSLanguageConstants;
 import com.aptana.js.core.JSTypeConstants;
 import com.aptana.js.core.index.JSIndexQueryHelper;
 import com.aptana.js.core.model.FunctionElement;
@@ -764,19 +765,16 @@ public class JSNodeTypeInferrer extends JSTreeWalker
 		IParseNode child = node.getExpression();
 		if (child instanceof JSNode)
 		{
-			// TODO hang the "require" string as a constant somewhere!
-			if (child instanceof JSIdentifierNode && "require".equals(child.getNameNode().getName())) //$NON-NLS-1$
+			if (child instanceof JSIdentifierNode && JSLanguageConstants.REQUIRE.equals(child.getNameNode().getName()))
 			{
 				// it's a requires!
 				JSArgumentsNode args = (JSArgumentsNode) node.getArguments();
 				IParseNode[] children = args.getChildren();
 				for (IParseNode arg : children)
 				{
-					if (arg instanceof JSStringNode)
+					String moduleId = CommonJSResolver.getModuleId(arg);
+					if (!StringUtil.isEmpty(moduleId))
 					{
-						JSStringNode string = (JSStringNode) arg;
-						String moduleId = StringUtil.stripQuotes(string.getText());
-
 						IPath absolutePath = resolve(moduleId);
 						String typeName = _queryHelper.getModuleType(absolutePath);
 						if (typeName != null)

--- a/tests/com.aptana.js.core.tests/src/com/aptana/js/core/inferencing/CommonJSResolverTest.java
+++ b/tests/com.aptana.js.core.tests/src/com/aptana/js/core/inferencing/CommonJSResolverTest.java
@@ -1,0 +1,99 @@
+package com.aptana.js.core.inferencing;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.IPath;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.aptana.core.util.FileUtil;
+import com.aptana.js.core.parsing.JSParseState;
+import com.aptana.js.core.parsing.JSParser;
+import com.aptana.js.core.parsing.ast.JSStringNode;
+import com.aptana.parsing.ParseResult;
+import com.aptana.parsing.ast.IParseNode;
+
+public class CommonJSResolverTest
+{
+
+	private CommonJSResolver resolver;
+	private IProject project = null;
+	private IPath wd = FileUtil.getTempDirectory();
+	private IPath indexRoot;
+
+	@Before
+	public void setup()
+	{
+		resolver = new CommonJSResolver();
+		indexRoot = FileUtil.getTempDirectory().append("indexRoot" + System.currentTimeMillis());
+		indexRoot.toFile().mkdir();
+	}
+
+	@After
+	public void teardown()
+	{
+		resolver = null;
+		FileUtil.deleteRecursively(indexRoot.toFile());
+	}
+
+	@Test
+	public void testResolveAddsImplicitJSExtension()
+	{
+		assertEquals(wd.append("moduleId.js"), resolver.resolve("./moduleId", project, wd, indexRoot));
+	}
+
+	@Test
+	public void testResolveRelativePath()
+	{
+		assertEquals(wd.append("moduleId.js"), resolver.resolve("./moduleId.js", project, wd, indexRoot));
+	}
+
+	@Test
+	public void testResolveAbsolutePath()
+	{
+		assertEquals(indexRoot.append("moduleId.js"), resolver.resolve("moduleId.js", project, wd, indexRoot));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testResolveWithNonExistantCurrentLocationThrowsException()
+	{
+		wd = FileUtil.getTempDirectory().append("somethingThatDoesntExist");
+		assertEquals(indexRoot.append("moduleId.js"), resolver.resolve("moduleId.js", project, wd, indexRoot));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testResolveWithNonExistantIndexRootThrowsException()
+	{
+		FileUtil.deleteRecursively(indexRoot.toFile());
+		assertEquals(indexRoot.append("moduleId.js"), resolver.resolve("moduleId.js", project, wd, indexRoot));
+	}
+
+	@Test
+	public void testGetModuleIdWithSimpleStringArgToRequire()
+	{
+		assertEquals("moduleId", CommonJSResolver.getModuleId(new JSStringNode("moduleId")));
+	}
+
+	@Test
+	public void testGetModuleIdWithPathJoinInvokeInsideRequire() throws Exception
+	{
+		JSParser parser = new JSParser();
+		JSParseState parseState = new JSParseState("require(path.join('path', 'to', 'file.js'));");
+		ParseResult pr = parser.parse(parseState);
+		IParseNode node = pr.getRootNode().getChild(0).getChild(1).getChild(0);
+		assertEquals("path/to/file.js", CommonJSResolver.getModuleId(node));
+	}
+
+	@Test
+	public void testGetModuleIdWithPathJoinInvokeUsingDirNameReferenceInsideRequire() throws Exception
+	{
+		JSParser parser = new JSParser();
+		JSParseState parseState = new JSParseState("require(path.join(__dirname, 'path', 'to', 'file.js'));");
+		ParseResult pr = parser.parse(parseState);
+		IParseNode node = pr.getRootNode().getChild(0).getChild(1).getChild(0);
+		assertEquals("./path/to/file.js", CommonJSResolver.getModuleId(node));
+	}
+
+}

--- a/tests/com.aptana.js.core.tests/src/com/aptana/js/core/inferencing/CoreInferencingTests.java
+++ b/tests/com.aptana.js.core.tests/src/com/aptana/js/core/inferencing/CoreInferencingTests.java
@@ -1,42 +1,14 @@
 package com.aptana.js.core.inferencing;
 
-import org.junit.runners.Suite.SuiteClasses;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestResult;
-import junit.framework.TestSuite;
+import org.junit.runners.Suite.SuiteClasses;
 
 @RunWith(Suite.class)
-@SuiteClasses({ConstructorInferencingTest.class, DocumentationTest.class, DynamicTypeInferencingTest.class, FunctionInferencingTest.class, InferencingBugsTest.class, JSTypeUtilTest.class, ObjectInferencingTest.class, OperatorInferencingTest.class, PrimitiveInferencingTest.class, RecursiveInferencingTest.class, })
+@SuiteClasses({ CommonJSResolverTest.class, ConstructorInferencingTest.class, DocumentationTest.class,
+		DynamicTypeInferencingTest.class, FunctionInferencingTest.class, InferencingBugsTest.class,
+		JSTypeUtilTest.class, ObjectInferencingTest.class, OperatorInferencingTest.class,
+		PrimitiveInferencingTest.class, RecursiveInferencingTest.class, })
 public class CoreInferencingTests
 {
-
-//	public static Test suite()
-//	{
-//		TestSuite suite = new TestSuite(CoreInferencingTests.class.getName())
-//		{
-//			@Override
-//			public void runTest(Test test, TestResult result)
-//			{
-//				System.err.println("Running test: " + test.toString());
-//				super.runTest(test, result);
-//			}
-//		};
-//		//$JUnit-BEGIN$
-//		suite.addTestSuite(ConstructorInferencingTest.class);
-//		suite.addTestSuite(DocumentationTest.class);
-//		suite.addTestSuite(DynamicTypeInferencingTest.class);
-//		suite.addTestSuite(FunctionInferencingTest.class);
-//		suite.addTestSuite(InferencingBugsTest.class);
-//		suite.addTestSuite(JSTypeUtilTest.class);
-//		suite.addTestSuite(ObjectInferencingTest.class);
-//		suite.addTestSuite(OperatorInferencingTest.class);
-//		suite.addTestSuite(PrimitiveInferencingTest.class);
-//		suite.addTestSuite(RecursiveInferencingTest.class);
-//		//$JUnit-END$
-//		return suite;
-//	}
-//
 }


### PR DESCRIPTION
This came from frustration at getting no CA and not being able to jump to files while doing some hyperloop work.
- able to better support hyperlinks jumping to the referenced file in the require call (can do F3 on require to jump to that file).
- able to infer the type exported by the required module/file for require calls that aren't just simple strings arguments, but use path.join to build the string up.
