### PR TITLE
TISTUD-6584 Importing sample apps from Dashboard or Samples gives interm...

### DIFF
--- a/plugins/com.aptana.samples.ui/src/com/aptana/samples/ui/project/NewSampleProjectWizard.java
+++ b/plugins/com.aptana.samples.ui/src/com/aptana/samples/ui/project/NewSampleProjectWizard.java
@@ -344,21 +344,20 @@ public class NewSampleProjectWizard extends BasicNewResourceWizard implements IE
 					IdeLog.logError(SamplesUIPlugin.getDefault(), e);
 				}
 
-				doPostProjectCreation(newProject);
-
 				// Stop tracking the git repo
-				DisconnectHandler.disconnect(newProject, null);
+				DisconnectHandler.disconnect(projectHandle, null);
 				// Delete the .gitignore file and the .git folder
-				File toDelete = new File(newProject.getLocation().toFile(), GitRepository.GITIGNORE);
+				File toDelete = new File(projectHandle.getLocation().toFile(), GitRepository.GITIGNORE);
 				if (toDelete.exists())
 				{
 					toDelete.delete();
 				}
-				toDelete = new File(newProject.getLocation().toFile(), GitRepository.GIT_DIR);
+				toDelete = new File(projectHandle.getLocation().toFile(), GitRepository.GIT_DIR);
 				if (toDelete.exists())
 				{
 					FileUtil.deleteRecursively(toDelete);
 				}
+				doPostProjectCreation(projectHandle);
 			}
 		});
 		job.schedule();


### PR DESCRIPTION
Finally. Finally ! There is a very small timing window issue between 3 threads running in parallel -
- After a sample project is imported through git repository, a thread is handling a new git repo added event.
- We try to disconnect the sample project after it is imported.
- Git label lightweight decorator is trying to calculate the changed resources and refreshing the contents.

All those 3 threads are trying to refresh the git contents and we have a thread executor that was set to execute maximum of 3 tasks at a time. There are instances that we end up trying to execute the disposed thread executor (after sample project is disconnected) and at other instances, 1st and 3rd thread tried to over-execute more than 3 tasks at the same time.

The fix here addresses the timing issues and give little more time before we brutally shutdown the thread executor.
