### PR TITLE
TISTUD-6696 Installing Studio dependencies fails when user has never run sudo before

### DIFF
--- a/plugins/com.aptana.core/src/com/aptana/core/util/SudoManager.java
+++ b/plugins/com.aptana.core/src/com/aptana/core/util/SudoManager.java
@@ -74,7 +74,7 @@ public class SudoManager
 			{
 				// Try running and pass password on STDIN
 				Process p = getProcessRunner().run(environment, SUDO, DISREGARD_CACHED_CREDENTIALS, SUDO_INPUT_PWD,
-						END_OF_OPTIONS, ECHO, ECHO_MESSAGE);
+						PASSWORD_PROMPT_FLAG, PROMPT_MSG, END_OF_OPTIONS, ECHO, ECHO_MESSAGE);
 				runnable = new SudoProcessRunnable(p, password, ECHO_MESSAGE);
 			}
 

--- a/plugins/com.aptana.core/src/com/aptana/core/util/SudoProcessRunnable.java
+++ b/plugins/com.aptana.core/src/com/aptana/core/util/SudoProcessRunnable.java
@@ -61,15 +61,18 @@ public class SudoProcessRunnable extends ProcessRunnable
 			 * to the sudo prompts. Otherwise, kill the existing sudo process and re-run the sudo process with a new
 			 * valid password.
 			 */
-			if ((line = br.readLine()) != null)
+			while (br.ready())
 			{
-				builder.append(line).append('\n');
-				if (line.contains(echoMessage))
+				if ((line = br.readLine()) != null)
 				{
-					status = 0;
+					builder.append(line).append('\n');
+					if (line.contains(echoMessage))
+					{
+						// We're good, we got our success message, mark exit code of 0, break the loop
+						status = 0;
+						break;
+					}
 				}
-				// pwdWriter.println(password);
-				// pwdWriter.flush();
 			}
 
 			p.destroy(); // Force kill the sudo command as it is still expecting for the other 2 attempts

--- a/tests/com.aptana.core.tests/src/com/aptana/core/util/SudoManagerTest.java
+++ b/tests/com.aptana.core.tests/src/com/aptana/core/util/SudoManagerTest.java
@@ -9,14 +9,15 @@ package com.aptana.core.util;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Status;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
+import org.jmock.lib.concurrent.Synchroniser;
 import org.jmock.lib.legacy.ClassImposteriser;
 import org.junit.After;
 import org.junit.Before;
@@ -28,6 +29,8 @@ public class SudoManagerTest
 	private SudoManager sudoManager;
 	private Mockery context;
 	private IProcessRunner processRunner;
+	private Process process;
+	private ByteArrayOutputStream out;
 
 	@Before
 	public void setUp()
@@ -38,7 +41,10 @@ public class SudoManagerTest
 				setImposteriser(ClassImposteriser.INSTANCE);
 			}
 		};
+		context.setThreadingPolicy(new Synchroniser());
 		processRunner = context.mock(IProcessRunner.class);
+		process = context.mock(Process.class);
+		out = new ByteArrayOutputStream();
 		sudoManager = new SudoManager()
 		{
 			@Override
@@ -46,34 +52,115 @@ public class SudoManagerTest
 			{
 				return processRunner;
 			}
-
-			@Override
-			protected IStatus getResult(ProcessRunnable runnable) throws InterruptedException
-			{
-				return Status.OK_STATUS;
-			}
 		};
+		context.checking(new Expectations()
+		{
+			{
+				atMost(1).of(process).destroy();
+			}
+		});
 	}
 
 	@After
 	public void tearDown()
 	{
 		sudoManager = null;
+		process = null;
+		out = null;
+		processRunner = null;
 	}
 
 	@Test
 	public void testAuthenticate() throws Exception
 	{
-		final Process process = context.mock(Process.class);
 		context.checking(new Expectations()
 		{
 			{
 				oneOf(processRunner).run(with(any(Map.class)),
-						with(new String[] { "sudo", "-k", "-S", "--", "echo", "SUCCESS" }));
+						with(new String[] { "sudo", "-k", "-S", "-p", "password:", "--", "echo", "SUCCESS" }));
 				will(returnValue(process));
+
+				oneOf(process).getInputStream();
+				will(returnValue(new ByteArrayInputStream(("password:SUCCESS").getBytes())));
+
+				oneOf(process).getOutputStream();
+				will(returnValue(out));
 			}
 		});
 		assertEquals(true, sudoManager.authenticate("fake".toCharArray()));
+		assertEquals("fake\n", out.toString()); // assert we wrote password to STDIN
+		context.assertIsSatisfied();
+	}
+
+	@Test
+	public void testAuthenticateWithBadPassword() throws Exception
+	{
+		context.checking(new Expectations()
+		{
+			{
+				oneOf(processRunner).run(with(any(Map.class)),
+						with(new String[] { "sudo", "-k", "-S", "-p", "password:", "--", "echo", "SUCCESS" }));
+				will(returnValue(process));
+
+				oneOf(process).getInputStream();
+				will(returnValue(new ByteArrayInputStream(("password:\nSorry, try again.\npassword:").getBytes())));
+
+				oneOf(process).getOutputStream();
+				will(returnValue(out));
+			}
+		});
+		assertEquals(false, sudoManager.authenticate("fake".toCharArray()));
+		assertEquals("fake\n", out.toString()); // assert we wrote password to STDIN
+		context.assertIsSatisfied();
+	}
+
+	@Test
+	public void testAuthenticateWithNoPassword() throws Exception
+	{
+		context.checking(new Expectations()
+		{
+			{
+				oneOf(processRunner).run(with(any(Map.class)),
+						with(new String[] { "sudo", "-k", "-n", "--", "echo", "SUCCESS" }));
+				will(returnValue(process));
+
+				oneOf(process).getInputStream();
+				will(returnValue(new ByteArrayInputStream(("SUCCESS").getBytes())));
+
+				oneOf(process).getOutputStream();
+				will(returnValue(out));
+			}
+		});
+		assertEquals(true, sudoManager.authenticate(null));
+		assertEquals("", out.toString()); // assert we wrote no password to STDIN
+		context.assertIsSatisfied();
+	}
+
+	@Test
+	public void testAuthenticateWithLecture() throws Exception
+	{
+		context.checking(new Expectations()
+		{
+			{
+				oneOf(processRunner).run(with(any(Map.class)),
+						with(new String[] { "sudo", "-k", "-S", "-p", "password:", "--", "echo", "SUCCESS" }));
+				will(returnValue(process));
+
+				oneOf(process).getInputStream();
+				will(returnValue(new ByteArrayInputStream(
+						("\nWARNING: Improper use of the sudo command could lead to data loss\n"
+								+ "or the deletion of important system files. Please double-check your\n"
+								+ "typing when using sudo. Type \"man sudo\" for more information.\n\n"
+								+ "To proceed, enter your password, or type Ctrl-C to abort.\n\n" + "password:SUCCESS")
+								.getBytes())));
+
+				oneOf(process).getOutputStream();
+				will(returnValue(out));
+			}
+		});
+		assertEquals(true, sudoManager.authenticate("fake".toCharArray()));
+		assertEquals("fake\n", out.toString()); // assert we wrote password to STDIN
+		context.assertIsSatisfied();
 	}
 
 	@Test


### PR DESCRIPTION
don't just read first line of output from sudo invocation. Read from stream while it's "ready" (won't block) until we see our echo message. Then bail out successfully. Otherwise if we hit point where no output is available and we haven't seen the expected successful echo message, then we kill the process and fail.
