### PR TITLE
Fixes related to TISTUD-4119 Improve beta/rc update process

### DIFF
--- a/plugins/com.aptana.js.core/src/com/aptana/js/core/inferencing/CommonJSResolver.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/core/inferencing/CommonJSResolver.java
@@ -23,7 +23,7 @@ import com.aptana.js.core.parsing.ast.JSStringNode;
 import com.aptana.parsing.ast.IParseNode;
 
 /**
- * Resolves a module id relative to a base module namespace root, ore if the path is explicitly relative, relative to
+ * Resolves a module id relative to a base module namespace root, or if the path is explicitly relative, relative to
  * current location.
  * 
  * @author cwilliams

--- a/plugins/com.aptana.js.core/src/com/aptana/js/core/node/INodePackageManager.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/core/node/INodePackageManager.java
@@ -89,11 +89,36 @@ public interface INodePackageManager
 	 */
 	public IPath getModulesPath(String packageName) throws CoreException;
 
+	/**
+	 * Gets the latest installed version of a package.
+	 * 
+	 * @param packageName
+	 * @return
+	 * @throws CoreException
+	 */
 	public String getInstalledVersion(String packageName) throws CoreException;
 
 	public String getInstalledVersion(String packageName, boolean isGlobal, IPath workingDir) throws CoreException;
 
+	/**
+	 * Gets the latest version published for a package. Note that there may be "newer" RC/beta/alphas, but the NPM
+	 * "latest" pointer may not refer to them.
+	 * 
+	 * @param packageName
+	 * @return
+	 * @throws CoreException
+	 */
 	public String getLatestVersionAvailable(String packageName) throws CoreException;
+
+	/**
+	 * Gets the full list of published versions for a given package. NEVER RETURNS NULL! if anything goes wrong, we'll
+	 * throw a CoreException.
+	 * 
+	 * @param packageName
+	 * @return
+	 * @throws CoreException
+	 */
+	public List<String> getAvailableVersions(String packageName) throws CoreException;
 
 	public String getConfigValue(String key) throws CoreException;
 
@@ -191,14 +216,5 @@ public interface INodePackageManager
 	 */
 	public IPath findNpmPackagePath(String executableName, boolean appendExtension, List<IPath> searchLocations,
 			FileFilter fileFilter);
-
-	/**
-	 * Returns the list of available versions for a package, in ascending order.
-	 * 
-	 * @param packageName
-	 * @return
-	 */
-	public List<String> getVersions(String packageName);
-
 	// TODO Update
 }

--- a/tests/com.aptana.js.core.tests/src/com/aptana/js/internal/core/node/NodePackageManagerTest.java
+++ b/tests/com.aptana.js.core.tests/src/com/aptana/js/internal/core/node/NodePackageManagerTest.java
@@ -208,7 +208,7 @@ public class NodePackageManagerTest
 		final IStatus status = new Status(
 				IStatus.OK,
 				JSCorePlugin.PLUGIN_ID,
-				"/usr/local/lib\n└── titanium@3.2.1  (git://github.com/appcelerator/titanium.git#8e262ccbd20b4a049ab2bdffd98ff940592da224)");
+				"{\n  \"dependencies\": {\n    \"titanium\": {\n      \"version\": \"3.3.0\",\n      \"from\": \"titanium@*\",\n      \"resolved\": \"https://registry.npmjs.org/titanium/-/titanium-3.3.0.tgz\"\n    }\n  }\n}");
 		context.checking(new Expectations()
 		{
 			{
@@ -216,20 +216,20 @@ public class NodePackageManagerTest
 				will(returnValue(true));
 
 				oneOf(node).runInBackground(userHome, ShellExecutable.getEnvironment(),
-						CollectionsUtil.newList("/usr/bin/npm", "ls", "titanium", "--color", "false", "-g"));
+						CollectionsUtil.newList("/usr/bin/npm", "ls", "titanium", "--color", "false", "--json", "true", "-g"));
 				will(returnValue(status));
 			}
 		});
 
 		String returned = npm.getInstalledVersion("titanium", true, userHome);
-		assertEquals("3.2.1", returned);
+		assertEquals("3.3.0", returned);
 		context.assertIsSatisfied();
 	}
 
 	@Test
 	public void testGetInstalledVersionIsNotInstalled() throws CoreException
 	{
-		final IStatus status = new Status(IStatus.OK, JSCorePlugin.PLUGIN_ID, "/usr/local/lib\n└── (empty)");
+		final IStatus status = new Status(IStatus.OK, JSCorePlugin.PLUGIN_ID, "{}");
 		context.checking(new Expectations()
 		{
 			{
@@ -237,7 +237,7 @@ public class NodePackageManagerTest
 				will(returnValue(true));
 
 				oneOf(node).runInBackground(userHome, ShellExecutable.getEnvironment(),
-						CollectionsUtil.newList("/usr/bin/npm", "ls", "titanium", "--color", "false", "-g"));
+						CollectionsUtil.newList("/usr/bin/npm", "ls", "titanium", "--color", "false", "--json", "true", "-g"));
 				will(returnValue(status));
 			}
 		});
@@ -258,7 +258,7 @@ public class NodePackageManagerTest
 				will(returnValue(true));
 
 				oneOf(node).runInBackground(userHome, ShellExecutable.getEnvironment(),
-						CollectionsUtil.newList("/usr/bin/npm", "ls", "titanium", "--color", "false", "-g"));
+						CollectionsUtil.newList("/usr/bin/npm", "ls", "titanium", "--color", "false", "--json", "true", "-g"));
 				will(returnValue(status));
 			}
 		});
@@ -270,7 +270,7 @@ public class NodePackageManagerTest
 	@Test
 	public void testIsInstalledCheckWhenNotInstalled() throws CoreException
 	{
-		final IStatus status = new Status(IStatus.OK, JSCorePlugin.PLUGIN_ID, "/usr/local/lib\n└── (empty)");
+		final IStatus status = new Status(IStatus.OK, JSCorePlugin.PLUGIN_ID, "{}");
 		context.checking(new Expectations()
 		{
 			{
@@ -278,7 +278,7 @@ public class NodePackageManagerTest
 				will(returnValue(true));
 
 				oneOf(node).runInBackground(null, ShellExecutable.getEnvironment(),
-						CollectionsUtil.newList("/usr/bin/npm", "ls", "titanium", "--color", "false", "-g"));
+						CollectionsUtil.newList("/usr/bin/npm", "ls", "titanium", "--color", "false", "--json", "true", "-g"));
 				will(returnValue(status));
 			}
 		});
@@ -293,7 +293,7 @@ public class NodePackageManagerTest
 		final IStatus status = new Status(
 				IStatus.OK,
 				JSCorePlugin.PLUGIN_ID,
-				"/usr/local/lib\n└── titanium@3.2.1  (git://github.com/appcelerator/titanium.git#8e262ccbd20b4a049ab2bdffd98ff940592da224)");
+				"{\n  \"dependencies\": {\n    \"titanium\": {\n      \"version\": \"3.3.0\",\n      \"from\": \"titanium@*\",\n      \"resolved\": \"https://registry.npmjs.org/titanium/-/titanium-3.3.0.tgz\"\n    }\n  }\n}");
 		context.checking(new Expectations()
 		{
 			{
@@ -301,7 +301,7 @@ public class NodePackageManagerTest
 				will(returnValue(true));
 
 				oneOf(node).runInBackground(null, ShellExecutable.getEnvironment(),
-						CollectionsUtil.newList("/usr/bin/npm", "ls", "titanium", "--color", "false", "-g"));
+						CollectionsUtil.newList("/usr/bin/npm", "ls", "titanium", "--color", "false", "--json", "true", "-g"));
 				will(returnValue(status));
 			}
 		});
@@ -326,7 +326,7 @@ public class NodePackageManagerTest
 
 				// Pretend that ls fails for some reason
 				oneOf(node).runInBackground(null, ShellExecutable.getEnvironment(),
-						CollectionsUtil.newList("/usr/bin/npm", "ls", "titanium", "--color", "false", "-g"));
+						CollectionsUtil.newList("/usr/bin/npm", "ls", "titanium", "--color", "false", "--json", "true", "-g"));
 				will(returnValue(status));
 
 				// Falls back to checking list


### PR DESCRIPTION
- Allow getting the full list of available versions for an NPM package using #getAvailableVersions
- Remove INodePackageManager#getVersions and use #getAvailableVersions instead - it actually works
- Make #getInstalledVersion and #getAvailableVersions both use --json true args to force json output and then parse the output as JSON for more robust output handling.
