### PR TITLE
TISTUD-6748 Titanium modules index is not being added to build path of Titanium/Alloy projects

### DIFF
--- a/plugins/com.aptana.buildpath.core/src/com/aptana/buildpath/core/BuildPathEntry.java
+++ b/plugins/com.aptana.buildpath.core/src/com/aptana/buildpath/core/BuildPathEntry.java
@@ -32,25 +32,6 @@ public class BuildPathEntry implements IBuildPathEntry
 		this.path = path;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 * @see java.lang.Object#equals(java.lang.Object)
-	 */
-	@Override
-	public boolean equals(Object arg0)
-	{
-		boolean result = false;
-
-		if (arg0 instanceof BuildPathEntry)
-		{
-			BuildPathEntry other = (BuildPathEntry) arg0;
-
-			result = displayName.equals(other.displayName) && path.equals(other.path);
-		}
-
-		return result;
-	}
-
 	/**
 	 * getDisplayName
 	 * 
@@ -69,16 +50,6 @@ public class BuildPathEntry implements IBuildPathEntry
 	public URI getPath()
 	{
 		return path;
-	}
-
-	/*
-	 * (non-Javadoc)
-	 * @see java.lang.Object#hashCode()
-	 */
-	@Override
-	public int hashCode()
-	{
-		return displayName.hashCode() * 31 + path.hashCode();
 	}
 
 	/**
@@ -109,5 +80,44 @@ public class BuildPathEntry implements IBuildPathEntry
 	public String toString()
 	{
 		return displayName + ":" + path.toString(); //$NON-NLS-1$
+	}
+
+	@Override
+	public int hashCode()
+	{
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((path == null) ? 0 : path.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj)
+	{
+		if (this == obj)
+		{
+			return true;
+		}
+		if (obj == null)
+		{
+			return false;
+		}
+		if (getClass() != obj.getClass())
+		{
+			return false;
+		}
+		BuildPathEntry other = (BuildPathEntry) obj;
+		if (path == null)
+		{
+			if (other.path != null)
+			{
+				return false;
+			}
+		}
+		else if (!path.equals(other.path))
+		{
+			return false;
+		}
+		return true;
 	}
 }

--- a/tests/com.aptana.buildpath.core.tests/src/com/aptana/buildpath/core/BuildPathEntryTest.java
+++ b/tests/com.aptana.buildpath.core.tests/src/com/aptana/buildpath/core/BuildPathEntryTest.java
@@ -34,6 +34,9 @@ public class BuildPathEntryTest
 		assertTrue(entry.equals(entry));
 		assertTrue(new BuildPathEntry(displayName, path).equals(entry));
 		assertTrue(entry.equals(new BuildPathEntry(displayName, path)));
+		// we ignore the display name for equality checks
+		assertTrue(entry.equals(new BuildPathEntry("some other display name", path)));
+		assertTrue(new BuildPathEntry("some other display name", path).equals(entry));
 	}
 
 	@Test


### PR DESCRIPTION
- We should only compare BuildPathEntry's by their path/URI, ignore display name for equals/hashcode checks.
- Add test that display name is ignored for BuildPathEntry equality checks
- Add a 30 second time based cache on the global whitelisted build paths. If one is added/remove manually, bust the cache immediately. It's getting called many times repeatedly when setting up indices on Titanium projects. The data should very rarely change (for example when we install new SDKs), so a small time-based cache may be useful to help eliminate the constant recalculation of the entries.
