### PR TITLE
TISTUD-6696 First time sudo prompt still fails to authenticate the user.

### DIFF
--- a/plugins/com.aptana.core/src/com/aptana/core/util/SudoProcessRunnable.java
+++ b/plugins/com.aptana.core/src/com/aptana/core/util/SudoProcessRunnable.java
@@ -64,7 +64,6 @@ public class SudoProcessRunnable extends ProcessRunnable
 			while ((line = br.readLine()) != null)
 			{
 				builder.append(line).append('\n');
-				System.out.println(line);
 				if (line.contains(echoMessage))
 				{
 					// We're good, we got our success message, mark exit code of 0, break the loop


### PR DESCRIPTION
There is a timing issue with the current way of reading the output stream from the sudo password prompt. We might end up loosing the last line of password lecture/prompt when we loop to verify whether stream is ready to read.
