### PR TITLE
TISTUD-6552 Download and index Node.js core modules for user (for version they have)

### DIFF
--- a/plugins/com.aptana.editor.js/src/com/aptana/editor/js/contentassist/JSContentAssistProcessor.java
+++ b/plugins/com.aptana.editor.js/src/com/aptana/editor/js/contentassist/JSContentAssistProcessor.java
@@ -389,6 +389,11 @@ public class JSContentAssistProcessor extends CommonContentAssistProcessor
 				replaceLength = replaceRange.getLength();
 			}
 
+			if (property.getOwningType().startsWith("$module"))
+			{
+				String path = getQueryHelper().getModulePath(property.getOwningType());
+				property.setOwningType(path);
+			}
 			PropertyElementProposal proposal = new PropertyElementProposal(property, offset, replaceLength, projectURI);
 			proposal.setTriggerCharacters(getProposalTriggerCharacters());
 			if (!StringUtil.isEmpty(overriddenLocation))

--- a/plugins/com.aptana.editor.js/src/com/aptana/editor/js/preferences/NodePreferencePage.java
+++ b/plugins/com.aptana.editor.js/src/com/aptana/editor/js/preferences/NodePreferencePage.java
@@ -8,9 +8,7 @@
 package com.aptana.editor.js.preferences;
 
 import java.lang.reflect.InvocationTargetException;
-import java.net.URI;
 import java.text.MessageFormat;
-import java.util.List;
 
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -41,9 +39,7 @@ import org.eclipse.ui.preferences.ScopedPreferenceStore;
 
 import com.aptana.core.logging.IdeLog;
 import com.aptana.core.util.StringUtil;
-import com.aptana.core.util.TarUtil;
 import com.aptana.editor.js.JSPlugin;
-import com.aptana.ide.core.io.downloader.DownloadManager;
 import com.aptana.js.core.JSCorePlugin;
 import com.aptana.js.core.node.INodeJS;
 import com.aptana.js.core.node.INodeJSService;
@@ -174,13 +170,6 @@ public class NodePreferencePage extends FieldEditorPreferencePage implements IWo
 
 	private void downloadNodeJS()
 	{
-		// First, ask for the location that the source will be extracted into.
-		final IPath selectedDir = getDirectory();
-		if (selectedDir == null)
-		{
-			return;
-		}
-
 		final ProgressMonitorDialog downloadProgressMonitor = new ProgressMonitorDialog(UIUtils.getActiveShell());
 		try
 		{
@@ -189,34 +178,26 @@ public class NodePreferencePage extends FieldEditorPreferencePage implements IWo
 
 				public void run(IProgressMonitor monitor) throws InvocationTargetException, InterruptedException
 				{
-					final DownloadManager dm = new DownloadManager();
 					try
 					{
-						dm.addURI(new URI(NODE_JS_SOURCE_URL));
-						IStatus status = dm.start(monitor);
+						final INodeJS node = getDetectedPath();
+						IStatus status = node.downloadSource(monitor);
 						if (status.isOK())
 						{
-							// We got the source code. Now we need to extract it and set the value in the text field (or
-							// the preferences, in case the dialog was closed).
-							List<IPath> contentPaths = dm.getContentsLocations();
-							status = TarUtil.extractTGZFile(contentPaths.get(0), selectedDir);
-							if (status.isOK())
+							// Set the path in the editor field
+							Control control = NodePreferencePage.this.getControl();
+							if (control != null && !control.isDisposed())
 							{
-								// Set the path in the editor field
-								Control control = NodePreferencePage.this.getControl();
-								if (control != null && !control.isDisposed())
+								UIUtils.runInUIThread(new Runnable()
 								{
-									UIUtils.runInUIThread(new Runnable()
-									{
 
-										public void run()
-										{
-											sourceEditor.setStringValue(selectedDir.append(NODE_JS_ROOT_NAME)
-													.toOSString());
-										}
-									});
-								}
+									public void run()
+									{
+										sourceEditor.setStringValue(node.getSourcePath().toOSString());
+									}
+								});
 							}
+
 						}
 					}
 					catch (Exception e)

--- a/plugins/com.aptana.js.core/src/com/aptana/js/core/index/JSFileIndexingParticipant.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/core/index/JSFileIndexingParticipant.java
@@ -418,7 +418,20 @@ public class JSFileIndexingParticipant extends AbstractFileIndexingParticipant
 					PropertyElement propElement = infer.getSymbolPropertyElement(exports, property, sub.newChild(work));
 					moduleExportsType.addProperty(propElement);
 				}
+				// FIXME Somehow the owning type name is getting reset to just "exports" and not the fully guid name
+				// through the inference process!
+				List<PropertyElement> props = moduleExportsType.getProperties();
+				for (PropertyElement prop : props)
+				{
+					prop.setOwningType(moduleExportsType.getName());
+				}
 			}
+			PropertyElement exportsElement = new PropertyElement();
+			exportsElement.setIsInstanceProperty(true);
+			exportsElement.setHasAllUserAgents();
+			exportsElement.setName("exports"); //$NON-NLS-1$
+			exportsElement.addType(moduleExportsType.getName());
+			moduleType.addProperty(exportsElement);
 		}
 
 		sub.setWorkRemaining(10);

--- a/plugins/com.aptana.js.core/src/com/aptana/js/core/index/JSIndexQueryHelper.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/core/index/JSIndexQueryHelper.java
@@ -20,6 +20,7 @@ import java.util.Set;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Path;
 
 import com.aptana.buildpath.core.BuildPathManager;
 import com.aptana.buildpath.core.IBuildPathEntry;
@@ -465,6 +466,43 @@ public class JSIndexQueryHelper
 			if (!CollectionsUtil.isEmpty(functions))
 			{
 				return functions.iterator().next();
+			}
+		}
+		return null;
+	}
+
+	public String getModulePath(String generatedModuleId)
+	{
+		if (generatedModuleId == null || generatedModuleId.isEmpty())
+		{
+			return null;
+		}
+		if (generatedModuleId.endsWith(".exports"))
+		{
+			generatedModuleId = generatedModuleId.substring(0, generatedModuleId.length() - 8);
+		}
+
+		for (Index index : indices)
+		{
+			// Look up our mapping from generated type names to documents
+			List<QueryResult> results = index.query(new String[] { IJSIndexConstants.MODULE_DEFINITION },
+					generatedModuleId, SearchPattern.EXACT_MATCH | SearchPattern.CASE_SENSITIVE);
+			if (results != null && !results.isEmpty())
+			{
+				QueryResult match = results.get(0);
+				Set<String> docs = match.getDocuments();
+				if (docs != null && !docs.isEmpty())
+				{
+					String uri = docs.iterator().next();
+					String root = index.getRoot().toString();
+					if (uri.startsWith(root))
+					{
+						uri = uri.substring(root.length());
+					}
+					// Remove the .js extension
+					return Path.fromOSString(uri).removeFileExtension().toPortableString();
+				}
+
 			}
 		}
 		return null;

--- a/plugins/com.aptana.js.core/src/com/aptana/js/core/inferencing/JSNodeTypeInferrer.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/core/inferencing/JSNodeTypeInferrer.java
@@ -763,6 +763,7 @@ public class JSNodeTypeInferrer extends JSTreeWalker
 						if (typeName != null)
 						{
 							this.addType(typeName);
+							return;
 						}
 					}
 				}

--- a/plugins/com.aptana.js.core/src/com/aptana/js/core/node/INodeJS.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/core/node/INodeJS.java
@@ -11,9 +11,10 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 
-import com.aptana.core.util.ProcessUtil;
+import com.aptana.core.util.IProcessRunner;
 
 /**
  * This represents an installation of NodeJS. There may be multiple installs on the user's machine. Just because you
@@ -47,6 +48,8 @@ public interface INodeJS
 	public IPath getPath();
 
 	/**
+	 * Returns the result of running node -v, typical output will be "v0.10.13"
+	 * 
 	 * @return
 	 */
 	public String getVersion();
@@ -67,7 +70,7 @@ public interface INodeJS
 
 	/**
 	 * Run something under NodeJS. Under the hood calls out to
-	 * {@link ProcessUtil#runInBackground(String, IPath, Map, String...)}
+	 * {@link IProcessRunner#runInBackground(String, IPath, Map, String...)}
 	 * 
 	 * @param args
 	 * @return
@@ -76,11 +79,20 @@ public interface INodeJS
 
 	/**
 	 * Run something under NodeJS. Under the hood calls out to
-	 * {@link ProcessUtil#runInBackground(String, IPath, Map, String...)}
+	 * {@link IProcessRunner#runInBackground(String, IPath, Map, String...)}
 	 * 
 	 * @param env
 	 * @param args
 	 * @return
 	 */
 	public IStatus runInBackground(IPath workingDir, Map<String, String> environment, List<String> args);
+
+	/**
+	 * The path to the source code for this install.
+	 * 
+	 * @return
+	 */
+	public IPath getSourcePath();
+
+	public IStatus downloadSource(IProgressMonitor monitor);
 }

--- a/plugins/com.aptana.js.core/src/com/aptana/js/core/node/INodeJSService.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/core/node/INodeJSService.java
@@ -22,7 +22,6 @@ public interface INodeJSService
 
 	public static interface Listener
 	{
-
 		public void nodeJSInstalled();
 	}
 

--- a/plugins/com.aptana.js.core/src/com/aptana/js/internal/core/build/NodeJSSourceContributor.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/internal/core/build/NodeJSSourceContributor.java
@@ -15,17 +15,14 @@ import java.util.List;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
-import org.eclipse.core.runtime.Platform;
 
 import com.aptana.buildpath.core.BuildPathEntry;
 import com.aptana.buildpath.core.IBuildPathContributor;
 import com.aptana.buildpath.core.IBuildPathEntry;
 import com.aptana.core.logging.IdeLog;
-import com.aptana.core.util.StringUtil;
 import com.aptana.js.core.JSCorePlugin;
+import com.aptana.js.core.node.INodeJS;
 import com.aptana.js.core.node.INodePackageManager;
-import com.aptana.js.core.preferences.IPreferenceConstants;
 
 public class NodeJSSourceContributor implements IBuildPathContributor
 {
@@ -49,15 +46,22 @@ public class NodeJSSourceContributor implements IBuildPathContributor
 			}
 		}
 
-		String value = Platform.getPreferencesService().getString(JSCorePlugin.PLUGIN_ID,
-				IPreferenceConstants.NODEJS_SOURCE_PATH, null, null);
-		if (!StringUtil.isEmpty(value))
+		INodeJS node = getNode();
+		if (node != null)
 		{
-			IPath nodeSrcPath = Path.fromOSString(value);
-			IPath path = nodeSrcPath.append("lib"); //$NON-NLS-1$	
-			entries.add(new BuildPathEntry(Messages.NodeJSSourceContributor_Name, path.toFile().toURI()));
+			IPath sourcePath = node.getSourcePath();
+			if (sourcePath != null)
+			{
+				IPath path = sourcePath.append("lib"); //$NON-NLS-1$	
+				entries.add(new BuildPathEntry(Messages.NodeJSSourceContributor_Name, path.toFile().toURI()));
+			}
 		}
 		return entries;
+	}
+
+	protected INodeJS getNode()
+	{
+		return JSCorePlugin.getDefault().getNodeJSService().getValidExecutable();
 	}
 
 	protected INodePackageManager getNodePackageManager()

--- a/plugins/com.aptana.js.core/src/com/aptana/js/internal/core/index/JSIndexWriter.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/internal/core/index/JSIndexWriter.java
@@ -213,6 +213,14 @@ public class JSIndexWriter extends IndexWriter
 			// write properties
 			for (PropertyElement property : type.getProperties())
 			{
+				if (!property.getOwningType().equals(type.getName()))
+				{
+					// Should we enforce that the property's owning type must match the type name?
+					IdeLog.logWarning(JSCorePlugin.getDefault(), MessageFormat.format(
+							"Property is attached to type {0}, but states it's owning type is {1}", type.getName(),
+							property.getOwningType()));
+				}
+				// property.setOwningType(type.getName()); // enforce that the property's owning type is correct
 				if (property instanceof FunctionElement)
 				{
 					this.writeFunction(index, (FunctionElement) property, location);

--- a/plugins/com.aptana.js.core/src/com/aptana/js/internal/core/inferencing/NodeModuleResolver.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/internal/core/inferencing/NodeModuleResolver.java
@@ -18,21 +18,14 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
-import org.eclipse.core.runtime.Platform;
-import org.eclipse.core.runtime.preferences.IEclipsePreferences;
-import org.eclipse.core.runtime.preferences.IEclipsePreferences.IPreferenceChangeListener;
-import org.eclipse.core.runtime.preferences.IEclipsePreferences.PreferenceChangeEvent;
-import org.eclipse.core.runtime.preferences.InstanceScope;
 
 import com.aptana.core.ShellExecutable;
 import com.aptana.core.logging.IdeLog;
 import com.aptana.core.util.ArrayUtil;
 import com.aptana.core.util.CollectionsUtil;
 import com.aptana.core.util.PathUtil;
-import com.aptana.core.util.StringUtil;
 import com.aptana.js.core.JSCorePlugin;
 import com.aptana.js.core.inferencing.AbstractRequireResolver;
-import com.aptana.js.core.preferences.IPreferenceConstants;
 
 /**
  * See http://nodejs.org/api/modules.html#modules_all_together
@@ -56,12 +49,6 @@ public class NodeModuleResolver extends AbstractRequireResolver
 			"util", "vm", "zlib");
 
 	private IPath location;
-
-	/**
-	 * Cache the node src path, listen for changes to update it
-	 */
-	private IPreferenceChangeListener fNodeSrcPathListener;
-	private IPath fNodeSrcPath;
 
 	public IPath resolve(String moduleId, IProject project, IPath location, IPath indexRoot)
 	{
@@ -109,42 +96,7 @@ public class NodeModuleResolver extends AbstractRequireResolver
 
 	protected synchronized IPath nodeSrcPath()
 	{
-		// Cache value and hook pref listener
-		if (fNodeSrcPathListener == null)
-		{
-			fNodeSrcPathListener = new IEclipsePreferences.IPreferenceChangeListener()
-			{
-				public void preferenceChange(PreferenceChangeEvent event)
-				{
-					if (IPreferenceConstants.NODEJS_SOURCE_PATH.equals(event.getKey()))
-					{
-						String value = (String) event.getNewValue();
-						if (StringUtil.isEmpty(value))
-						{
-							fNodeSrcPath = null;
-						}
-						else
-						{
-							fNodeSrcPath = Path.fromOSString(value);
-						}
-					}
-				}
-			};
-			InstanceScope.INSTANCE.getNode(JSCorePlugin.PLUGIN_ID).addPreferenceChangeListener(fNodeSrcPathListener);
-
-			String value = Platform.getPreferencesService().getString(JSCorePlugin.PLUGIN_ID,
-					IPreferenceConstants.NODEJS_SOURCE_PATH, null, null);
-			if (StringUtil.isEmpty(value))
-			{
-				fNodeSrcPath = null;
-			}
-			else
-			{
-				fNodeSrcPath = Path.fromOSString(value);
-			}
-		}
-
-		return fNodeSrcPath;
+		return JSCorePlugin.getDefault().getNodeJSService().getValidExecutable().getSourcePath();
 	}
 
 	private boolean isCore(String text)

--- a/plugins/com.aptana.js.core/src/com/aptana/js/internal/core/node/NodeJS.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/internal/core/node/NodeJS.java
@@ -7,20 +7,35 @@
  */
 package com.aptana.js.internal.core.node;
 
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
 import java.text.MessageFormat;
 import java.util.List;
 import java.util.Map;
 
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
+import org.eclipse.osgi.service.datalocation.Location;
 
 import com.aptana.core.ShellExecutable;
+import com.aptana.core.util.IProcessRunner;
+import com.aptana.core.util.ProcessRunner;
 import com.aptana.core.util.ProcessUtil;
+import com.aptana.core.util.StringUtil;
+import com.aptana.core.util.TarUtil;
 import com.aptana.core.util.VersionUtil;
+import com.aptana.ide.core.io.downloader.DownloadManager;
 import com.aptana.js.core.JSCorePlugin;
 import com.aptana.js.core.node.INodeJS;
 import com.aptana.js.core.node.INodePackageManager;
+import com.aptana.js.core.preferences.IPreferenceConstants;
 
 /**
  * @author cwilliams
@@ -55,13 +70,83 @@ public class NodeJS implements INodeJS
 		{
 			return version;
 		}
-		version = ProcessUtil.outputForCommand(path.toOSString(), null, "-v"); //$NON-NLS-1$
+		IStatus result = createProcessRunner().runInBackground(path.toOSString(), "-v"); //$NON-NLS-1$
+		version = result.getMessage();
 		return version;
+	}
+
+	protected IProcessRunner createProcessRunner()
+	{
+		return new ProcessRunner();
 	}
 
 	public boolean exists()
 	{
 		return path != null && path.toFile().isFile();
+	}
+
+	public IStatus downloadSource(IProgressMonitor monitor)
+	{
+		// Check if it already exists.
+		IPath path = getSourcePath();
+		if (path != null && path.toFile().isDirectory())
+		{
+			return Status.OK_STATUS;
+		}
+
+		try
+		{
+			String version = getVersion();
+			if (StringUtil.isEmpty(version))
+			{
+				return new Status(IStatus.ERROR, JSCorePlugin.PLUGIN_ID,
+						"Can't download source for unknown version of Node.JS");
+			}
+			String url = MessageFormat.format("http://nodejs.org/dist/{0}/node-{0}.tar.gz", version);
+			DownloadManager manager = new DownloadManager();
+			manager.addURI(URI.create(url));
+			IStatus result = manager.start(monitor);
+			if (result.isOK())
+			{
+				List<IPath> files = manager.getContentsLocations();
+				// FIXME Is this the right place to store this? It's across workspaces. It may be read-only!
+				Location config = Platform.getConfigurationLocation();
+				if (config.isReadOnly())
+				{
+					config = Platform.getUserLocation(); // fall back to user?
+				}
+				try
+				{
+					if (config.lock())
+					{
+
+						URL locationURL = config.getDataArea("com.aptana.js.core/node");
+						File locationFile = new File(locationURL.getFile());
+						locationFile.mkdirs();
+						// FIXME Can we get progress on the untar?
+						TarUtil.extractTGZFile(files.get(0), Path.fromOSString(locationFile.getAbsolutePath()));
+					}
+					else
+					{
+						// wait until lock is available or fail
+					}
+				}
+				finally
+				{
+					config.release();
+				}
+
+			}
+			return result;
+		}
+		catch (CoreException e)
+		{
+			return e.getStatus();
+		}
+		catch (IOException e)
+		{
+			return new Status(IStatus.ERROR, JSCorePlugin.PLUGIN_ID, e.getMessage(), e);
+		}
 	}
 
 	public IStatus runInBackground(String... args)
@@ -110,4 +195,40 @@ public class NodeJS implements INodeJS
 				Messages.NodeJSService_InvalidVersionError, path, version, MIN_NODE_VERSION), null);
 	}
 
+	public IPath getSourcePath()
+	{
+		// FIXME can't we search for this ourselves?
+		String value = Platform.getPreferencesService().getString(JSCorePlugin.PLUGIN_ID,
+				IPreferenceConstants.NODEJS_SOURCE_PATH, null, null);
+		if (!StringUtil.isEmpty(value))
+		{
+			return Path.fromOSString(value);
+		}
+		// TODO Look in the place we download it to
+		try
+		{
+			String version = getVersion();
+			if (!StringUtil.isEmpty(version))
+			{
+				// FIXME Is this the right place to store this? It's across workspaces. It may be read-only!
+				Location config = Platform.getConfigurationLocation();
+				if (config.isReadOnly())
+				{
+					config = Platform.getUserLocation(); // fall back to user?
+				}
+
+				URL locationURL = config.getDataArea("com.aptana.js.core/node/node-" + version);
+				File locationFile = new File(locationURL.getFile());
+				if (locationFile.isDirectory())
+				{
+					return Path.fromOSString(locationFile.getAbsolutePath());
+				}
+			}
+		}
+		catch (IOException e)
+		{
+			// ignore
+		}
+		return null;
+	}
 }


### PR DESCRIPTION
- Fix indexing issue with modules where the properties hanging off the exports global were getting their owning type set to just "exports" and not the name of the module id's exports property type.
- Add a check for writing a property to index where the owning type doesn't match the type it's actually hanging off of in the model.
- Implement downloading the node JS source and finding the source in the place where we download it.
- Fix up CA proposals for things hanging off modules. Hack to convert our autogenerated guid for the module to the basename of the module file where it was defined.

This PR addresses some CA/indexing issues around CommonJS modules, and moves from a single NodeJS source path to a per-version path for sources. It does _not_ however auto-download the source. There's a button in prefs to download the sources for the NodeJS install set up in prefs.
