### PR TITLE
TISTUD-6343 Android Configuration gives error message on Platform Configuration Wizard

### DIFF
--- a/plugins/com.aptana.core.epl/src/com/aptana/core/epl/downloader/ConnectionData.java
+++ b/plugins/com.aptana.core.epl/src/com/aptana/core/epl/downloader/ConnectionData.java
@@ -1,0 +1,36 @@
+/**
+ * Aptana Studio
+ * Copyright (c) 2014 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the GNU Public License (GPL) v3 (with exceptions).
+ * Please see the license.html included with this distribution for details.
+ * Any modifications to this file must keep this entire header intact.
+ */
+package com.aptana.core.epl.downloader;
+
+/**
+ * Connection about the retry count and delay.
+ * 
+ * @author Praveen Innamuri
+ */
+public class ConnectionData
+{
+
+	private final int retryCount;
+	private final long retryDelay;
+
+	public ConnectionData(int retryCount, long retryDelay)
+	{
+		this.retryCount = retryCount;
+		this.retryDelay = retryDelay;
+	}
+
+	public int getRetryCount()
+	{
+		return retryCount;
+	}
+
+	public long getRetryDelay()
+	{
+		return retryDelay;
+	}
+}

--- a/plugins/com.aptana.core.io/src/com/aptana/ide/core/io/downloader/ContentDownloadRequest.java
+++ b/plugins/com.aptana.core.io/src/com/aptana/ide/core/io/downloader/ContentDownloadRequest.java
@@ -24,6 +24,7 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.ecf.core.security.IConnectContext;
 import org.eclipse.osgi.util.NLS;
 
+import com.aptana.core.epl.downloader.ConnectionData;
 import com.aptana.core.epl.downloader.FileReader;
 import com.aptana.core.util.FileUtil;
 import com.aptana.core.util.StringUtil;
@@ -89,11 +90,16 @@ public class ContentDownloadRequest
 
 	public void execute(IProgressMonitor monitor)
 	{
+		execute(null, monitor);
+	}
+
+	public void execute(ConnectionData data, IProgressMonitor monitor)
+	{
 		if (monitor != null)
 		{
 			monitor.subTask(NLS.bind(Messages.ContentDownloadRequest_downloading, uri.toString()));
 		}
-		IStatus status = download(monitor);
+		IStatus status = download(data, monitor);
 		setResult(status);
 	}
 
@@ -103,13 +109,13 @@ public class ContentDownloadRequest
 	 * @param monitor
 	 * @return
 	 */
-	private IStatus download(IProgressMonitor monitor)
+	private IStatus download(ConnectionData data, IProgressMonitor monitor)
 	{
 		// perform the download
 		try
 		{
 			// Use ECF FileTransferJob implementation to get the remote file.
-			FileReader reader = createReader();
+			FileReader reader = createReader(data);
 			OutputStream anOutputStream = createOutputStream(this.saveTo);
 			reader.readInto(this.uri, anOutputStream, 0, monitor);
 			// check that job ended ok - throw exceptions otherwise
@@ -141,9 +147,9 @@ public class ContentDownloadRequest
 		return Status.OK_STATUS;
 	}
 
-	protected FileReader createReader()
+	protected FileReader createReader(ConnectionData data)
 	{
-		return new FileReader(context);
+		return new FileReader(data, context);
 	}
 
 	protected OutputStream createOutputStream(File dest) throws FileNotFoundException

--- a/plugins/com.aptana.core.io/src/com/aptana/ide/core/io/downloader/DownloadManager.java
+++ b/plugins/com.aptana.core.io/src/com/aptana/ide/core/io/downloader/DownloadManager.java
@@ -25,6 +25,7 @@ import org.eclipse.core.runtime.MultiStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubMonitor;
 
+import com.aptana.core.epl.downloader.ConnectionData;
 import com.aptana.core.util.CollectionsUtil;
 import com.aptana.ide.core.io.CoreIOPlugin;
 
@@ -39,6 +40,7 @@ public class DownloadManager
 {
 	private List<ContentDownloadRequest> downloads;
 	private List<IPath> completedDownloadsPaths;
+	private ConnectionData connectData;
 
 	/**
 	 * Constructs a new DownloadManager
@@ -176,6 +178,16 @@ public class DownloadManager
 	}
 
 	/**
+	 * Sets the number of retry attempts in case if we are fail to download the file.
+	 * 
+	 * @param retryCount
+	 */
+	public void setConnectionData(ConnectionData connectData)
+	{
+		this.connectData = connectData;
+	}
+
+	/**
 	 * Download the remote content.
 	 * 
 	 * @param monitor
@@ -199,7 +211,7 @@ public class DownloadManager
 			// basically do a no-op and return the original path (or copy to intended saveLocation)
 
 			ContentDownloadRequest request = iterator.next();
-			request.execute(subMonitor.newChild(1));
+			request.execute(connectData, subMonitor.newChild(1));
 			IStatus result = request.getResult();
 			if (result != null)
 			{

--- a/tests/com.aptana.core.epl.tests/src/com/aptana/core/epl/downloader/FileReaderTest.java
+++ b/tests/com.aptana.core.epl.tests/src/com/aptana/core/epl/downloader/FileReaderTest.java
@@ -54,7 +54,7 @@ public class FileReaderTest
 		out = context.mock(OutputStream.class);
 		uri = URI.create("http://example.com/index.html");
 		jobManager = context.mock(IJobManager.class);
-		reader = new FileReader(cc)
+		reader = new FileReader(null, cc)
 		{
 			@Override
 			protected IRetrieveFileTransferFactory getRetrieveFileTransferFactory()

--- a/tests/com.aptana.core.io.tests/src/com/aptana/ide/core/io/downloader/ContentDownloadRequestTest.java
+++ b/tests/com.aptana.core.io.tests/src/com/aptana/ide/core/io/downloader/ContentDownloadRequestTest.java
@@ -17,6 +17,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.aptana.core.epl.downloader.ConnectionData;
 import com.aptana.core.epl.downloader.FileReader;
 
 public class ContentDownloadRequestTest
@@ -53,7 +54,7 @@ public class ContentDownloadRequestTest
 			}
 
 			@Override
-			protected FileReader createReader()
+			protected FileReader createReader(ConnectionData data)
 			{
 				return reader;
 			}

--- a/tests/com.aptana.core.io.tests/src/com/aptana/ide/core/io/downloader/DownloadManagerTest.java
+++ b/tests/com.aptana.core.io.tests/src/com/aptana/ide/core/io/downloader/DownloadManagerTest.java
@@ -31,6 +31,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.aptana.core.epl.downloader.ConnectionData;
 import com.aptana.core.util.CollectionsUtil;
 import com.aptana.core.util.FileUtil;
 import com.aptana.ide.core.io.CoreIOPlugin;
@@ -101,7 +102,7 @@ public class DownloadManagerTest
 		context.checking(new Expectations()
 		{
 			{
-				oneOf(cdr).execute(with(any(IProgressMonitor.class)));
+				oneOf(cdr).execute(with(aNull(ConnectionData.class)), with(any(IProgressMonitor.class)));
 
 				oneOf(cdr).getResult();
 				will(returnValue(Status.OK_STATUS));
@@ -134,7 +135,7 @@ public class DownloadManagerTest
 		context.checking(new Expectations()
 		{
 			{
-				exactly(3).of(cdr).execute(with(any(IProgressMonitor.class)));
+				exactly(3).of(cdr).execute(with(aNull(ConnectionData.class)), with(any(IProgressMonitor.class)));
 
 				exactly(3).of(cdr).getResult();
 				will(onConsecutiveCalls(returnValue(Status.OK_STATUS), returnValue(errorStatus),
@@ -180,7 +181,7 @@ public class DownloadManagerTest
 		context.checking(new Expectations()
 		{
 			{
-				exactly(1).of(cdr).execute(with(any(IProgressMonitor.class)));
+				exactly(1).of(cdr).execute(with(aNull(ConnectionData.class)), with(any(IProgressMonitor.class)));
 
 				exactly(1).of(cdr).getResult();
 				will(returnValue(Status.OK_STATUS));


### PR DESCRIPTION
Tried to introduce the pause and resume events through Eclipse communication framework. However, Windows might not send the pause/resume when the computer goes sleep or wakes up.

When Windows goes sleep, it suspend the network connections first and then, slowly it suspend the applications. So, the download process fails to reach the network connection and as there are fewer retry attempts and less retry delay, it fails quickly. If we can bump up the retry counts and increase the retry delay, then there is a good chance that the Studio will be suspended before it fails with network connection error.

To address the situation of Android SDK installation failure,  I have bumped up the retry attempts and delay, hoping that would address in most cases - at least, my basic testing on Windows VM works. Yay!
