### PR TITLE
Fixes for broken nightly tests around JS CA

### DIFF
--- a/plugins/com.aptana.editor.js/src/com/aptana/editor/js/contentassist/JSContentAssistProcessor.java
+++ b/plugins/com.aptana.editor.js/src/com/aptana/editor/js/contentassist/JSContentAssistProcessor.java
@@ -50,6 +50,7 @@ import com.aptana.editor.js.text.JSFlexLexemeProvider;
 import com.aptana.index.core.Index;
 import com.aptana.js.core.IJSConstants;
 import com.aptana.js.core.JSLanguageConstants;
+import com.aptana.js.core.JSTypeConstants;
 import com.aptana.js.core.index.IJSIndexConstants;
 import com.aptana.js.core.index.JSIndexQueryHelper;
 import com.aptana.js.core.inferencing.JSNodeTypeInferrer;
@@ -340,7 +341,6 @@ public class JSContentAssistProcessor extends CommonContentAssistProcessor
 			if (left instanceof JSIdentifierNode)
 			{
 				// FIXME Track back to last assignment to determine better
-				// cheat and assume identifiers beginning with upper case letter are types.
 				JSIdentifierNode ident = (JSIdentifierNode) left;
 				String name = ident.getNameNode().getName();
 				if ("$".equals(name) || "Ti".equals(name) || "jQuery".equals(name)) // HACK for jQuery
@@ -351,7 +351,15 @@ public class JSContentAssistProcessor extends CommonContentAssistProcessor
 					return false;
 				}
 				Collection<TypeElement> types = getQueryHelper().getTypes(name, false);
-				return CollectionsUtil.isEmpty(types); // if there are no types by this name, assume it's an instance
+				// FIXME If the type was defined using an object literal, the actual reference is an instance! How the
+				// hell do I handle that?
+				if (CollectionsUtil.isEmpty(types))
+				{
+					// if there are no types by this name, assume it's an instance
+					return true;
+				}
+				// cheat and assume identifiers beginning with upper case letter are types?
+				return !Character.isUpperCase(name.charAt(0));
 			}
 			return true;
 		}


### PR DESCRIPTION
I broke a couple tests in the nightly integration suite for JS CA. These are quick HACKY fixes for those.

The general problem is that right now I'm using simple heuristics for determining if we're referring to a type or an instance of a type for CA. These are updated to work for our tests and most common usage, but the ideal is to actually track back an identifier to it's last assignment/definition to determine if we're referring to a type that as set up as a constructor function, or a type that was defined using an object literal (where the type and var name are the sane,, but the var actually refers to an instance of that type).
