### PR TITLE
TISTUD-6877

### DIFF
--- a/plugins/com.aptana.usage/src/com/aptana/usage/IStudioAnalytics.java
+++ b/plugins/com.aptana.usage/src/com/aptana/usage/IStudioAnalytics.java
@@ -1,0 +1,8 @@
+package com.aptana.usage;
+
+public interface IStudioAnalytics
+{
+
+	public abstract void sendEvent(AnalyticsEvent event);
+
+}

--- a/plugins/com.aptana.usage/src/com/aptana/usage/StudioAnalytics.java
+++ b/plugins/com.aptana.usage/src/com/aptana/usage/StudioAnalytics.java
@@ -14,20 +14,33 @@ import org.eclipse.core.runtime.Platform;
 import com.aptana.core.util.EclipseUtil;
 import com.aptana.usage.internal.AnalyticsHandlersManager;
 
-public class StudioAnalytics
+public class StudioAnalytics implements IStudioAnalytics
 {
 
-	private static StudioAnalytics instance;
-
-	public synchronized static StudioAnalytics getInstance()
+	/**
+	 * @deprecated Use {@link UsagePlugin#getStudioAnalytics()}
+	 * @return
+	 */
+	public static IStudioAnalytics getInstance()
 	{
-		if (instance == null)
+		UsagePlugin plugin = UsagePlugin.getDefault();
+		if (plugin == null)
 		{
-			instance = new StudioAnalytics();
+			return new IStudioAnalytics()
+			{
+				public void sendEvent(AnalyticsEvent event)
+				{
+					// do nothing. We're shutting down. Unfortunately that means this event will get dropped.
+				}
+			};
 		}
-		return instance;
+		return plugin.getStudioAnalytics();
 	}
 
+	/*
+	 * (non-Javadoc)
+	 * @see com.aptana.usage.IStudioAnalytics#sendEvent(com.aptana.usage.AnalyticsEvent)
+	 */
 	public void sendEvent(AnalyticsEvent event)
 	{
 		if (Platform.inDevelopmentMode() && !EclipseUtil.isTesting())

--- a/plugins/com.aptana.usage/src/com/aptana/usage/UsagePlugin.java
+++ b/plugins/com.aptana.usage/src/com/aptana/usage/UsagePlugin.java
@@ -39,6 +39,7 @@ public class UsagePlugin extends Plugin
 	private SendPingJob job;
 	private AnalyticsInfoManager fAnalyticsInfoManager;
 	private AnalyticsLogger fAnalyticsLogger;
+	private StudioAnalytics fStudioAnalytics;
 
 	/**
 	 * The constructor
@@ -76,6 +77,7 @@ public class UsagePlugin extends Plugin
 		}
 		finally
 		{
+			fStudioAnalytics = null;
 			fAnalyticsLogger = null;
 			fAnalyticsInfoManager = null;
 			plugin = null;
@@ -146,6 +148,15 @@ public class UsagePlugin extends Plugin
 		}
 	}
 
+	public synchronized IStudioAnalytics getStudioAnalytics()
+	{
+		if (fStudioAnalytics == null)
+		{
+			fStudioAnalytics = new StudioAnalytics();
+		}
+		return fStudioAnalytics;
+	}
+
 	public synchronized IAnalyticsInfoManager getAnalyticsInfoManager()
 	{
 		if (fAnalyticsInfoManager == null)
@@ -159,7 +170,7 @@ public class UsagePlugin extends Plugin
 	{
 		if (fAnalyticsLogger == null)
 		{
-			fAnalyticsLogger = new AnalyticsLogger(getStateLocation().append("events"));
+			fAnalyticsLogger = new AnalyticsLogger(getStateLocation().append("events")); //$NON-NLS-1$
 		}
 		return fAnalyticsLogger;
 	}


### PR DESCRIPTION
TISTUD-6877 NPE in Log when Studio is shutdown
- guard against null (which shoudl only happen when we're trying to log an analytics event while the platform is shutting down and usage plugin has already "stopped").
- extract and interface for StudioAnalytics
- deprecate StudioAnalytics.getInstance, the plugin should manage the lifecycle of the instance.
- Callers should do UsagePlugin.getDefault().getStudioAnalytics to grab instance, hiding bheind interface. They should deal with potential null ref to plugin since it may be shutting/shut down.

Basically I don't think we have any way of properly dealing with the veent we're trying to send in a case like this, we basically just drop it.
