### PR TITLE
TISTUD-6837 Index translation key references in Titanium Mobile JS files

### DIFF
--- a/plugins/com.aptana.js.core/parsing/JS.grammar
+++ b/plugins/com.aptana.js.core/parsing/JS.grammar
@@ -454,9 +454,10 @@
 %typeof ShiftExpression, ShiftExpression_NoLBF, EqualityExpression, EqualityExpression_NoIn, EqualityExpression_NoLBF = "JSNode";
 %typeof LogicalAndExpression, LogicalAndExpression_NoIn, LogicalAndExpression_NoLBF, LogicalOrExpression, LogicalOrExpression_NoIn, LogicalOrExpression_NoLBF = "JSNode";
 %typeof BitwiseOrExpression, BitwiseOrExpression_NoIn, BitwiseOrExpression_NoLBF, BitwiseXorExpression, BitwiseXorExpression_NoIn, BitwiseXorExpression_NoLBF, BitwiseAndExpression, BitwiseAndExpression_NoIn, BitwiseAndExpression_NoLBF = "JSNode";
-%typeof MemberExpression, MemberExpression_NoLBF, NewExpression, CallExpression, CallExpression_NoLBF, Expression, Expression_NoIn, Expression_NoLBF, Statement, Statement_NoIf, Arguments, Block, Catch, Finally = "JSNode";
+%typeof MemberExpression, MemberExpression_NoLBF, NewExpression, CallExpression, CallExpression_NoLBF, Expression, Expression_NoIn, Expression_NoLBF, Statement, Statement_NoIf, Block, Catch, Finally = "JSNode";
 %typeof VariableDeclaration, VariableDeclaration_NoIn, PropertyName, PropertyAssignment, Elision, ElementList, FormalParameterList, FunctionParameters, FunctionBody, SourceElement = "JSNode";
 %typeof CaseClause, DefaultClause = "JSNode";
+%typeof Arguments = "JSArgumentsNode";
 
 %goal Program;
 

--- a/plugins/com.aptana.js.core/src/com/aptana/js/core/parsing/JSParser.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/core/parsing/JSParser.java
@@ -1858,7 +1858,7 @@ public class JSParser extends Parser implements IParser {
 					final Symbol _symbol_e = _symbols[offset + 2];
 					final JSNode e = (JSNode) _symbol_e.value;
 					final Symbol _symbol_a = _symbols[offset + 3];
-					final JSNode a = (JSNode) _symbol_a.value;
+					final JSArgumentsNode a = (JSArgumentsNode) _symbol_a.value;
 					
 			return new JSConstructNode(e, a);
 			}
@@ -1887,7 +1887,7 @@ public class JSParser extends Parser implements IParser {
 					final Symbol _symbol_e = _symbols[offset + 2];
 					final JSNode e = (JSNode) _symbol_e.value;
 					final Symbol _symbol_a = _symbols[offset + 3];
-					final JSNode a = (JSNode) _symbol_a.value;
+					final JSArgumentsNode a = (JSArgumentsNode) _symbol_a.value;
 					
 			return new JSConstructNode(e, a);
 			}
@@ -1910,7 +1910,7 @@ public class JSParser extends Parser implements IParser {
 					final Symbol _symbol_l = _symbols[offset + 1];
 					final JSNode l = (JSNode) _symbol_l.value;
 					final Symbol _symbol_r = _symbols[offset + 2];
-					final JSNode r = (JSNode) _symbol_r.value;
+					final JSArgumentsNode r = (JSArgumentsNode) _symbol_r.value;
 					
 			return new JSInvokeNode(l, r);
 			}
@@ -1919,7 +1919,7 @@ public class JSParser extends Parser implements IParser {
 					final Symbol _symbol_l = _symbols[offset + 1];
 					final JSNode l = (JSNode) _symbol_l.value;
 					final Symbol _symbol_r = _symbols[offset + 2];
-					final JSNode r = (JSNode) _symbol_r.value;
+					final JSArgumentsNode r = (JSArgumentsNode) _symbol_r.value;
 					
 			return new JSInvokeNode(l, r);
 			}
@@ -1948,7 +1948,7 @@ public class JSParser extends Parser implements IParser {
 					final Symbol _symbol_l = _symbols[offset + 1];
 					final JSNode l = (JSNode) _symbol_l.value;
 					final Symbol _symbol_r = _symbols[offset + 2];
-					final JSNode r = (JSNode) _symbol_r.value;
+					final JSArgumentsNode r = (JSArgumentsNode) _symbol_r.value;
 					
 			return new JSInvokeNode(l, r);
 			}
@@ -1957,7 +1957,7 @@ public class JSParser extends Parser implements IParser {
 					final Symbol _symbol_l = _symbols[offset + 1];
 					final JSNode l = (JSNode) _symbol_l.value;
 					final Symbol _symbol_r = _symbols[offset + 2];
-					final JSNode r = (JSNode) _symbol_r.value;
+					final JSArgumentsNode r = (JSArgumentsNode) _symbol_r.value;
 					
 			return new JSInvokeNode(l, r);
 			}

--- a/plugins/com.aptana.js.core/src/com/aptana/js/core/parsing/ast/JSConstructNode.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/core/parsing/ast/JSConstructNode.java
@@ -38,6 +38,7 @@ public class JSConstructNode extends JSNode
 	 */
 	public IParseNode getArguments()
 	{
+		// FIXME This is either a JSArgumentsNode or JSEmptyNode
 		return this.getChild(1);
 	}
 

--- a/plugins/com.aptana.js.core/src/com/aptana/js/core/parsing/ast/JSGetPropertyNode.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/core/parsing/ast/JSGetPropertyNode.java
@@ -17,7 +17,7 @@ public class JSGetPropertyNode extends JSBinaryOperatorNode
 	 * @param left
 	 * @param right
 	 */
-	public JSGetPropertyNode(JSNode left, Symbol operator, JSNode right)
+	public JSGetPropertyNode(JSNode left, Symbol operator, JSIdentifierNode right)
 	{
 		super(left, operator, right);
 
@@ -32,5 +32,10 @@ public class JSGetPropertyNode extends JSBinaryOperatorNode
 	public void accept(JSTreeWalker walker)
 	{
 		walker.visit(this);
+	}
+
+	public JSIdentifierNode getProperty()
+	{
+		return (JSIdentifierNode) getRightHandSide();
 	}
 }

--- a/plugins/com.aptana.js.core/src/com/aptana/js/core/parsing/ast/JSInvokeNode.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/core/parsing/ast/JSInvokeNode.java
@@ -7,18 +7,18 @@
  */
 package com.aptana.js.core.parsing.ast;
 
-import com.aptana.parsing.ast.IParseNode;
 
 public class JSInvokeNode extends JSNode
 {
 	/**
 	 * JSInvokeNode
 	 * 
-	 * @param children
+	 * @param expression
+	 * @param args
 	 */
-	public JSInvokeNode(JSNode... children)
+	public JSInvokeNode(JSNode expression, JSArgumentsNode args)
 	{
-		super(IJSNodeTypes.INVOKE, children);
+		super(IJSNodeTypes.INVOKE, expression, args);
 	}
 
 	/*
@@ -36,9 +36,9 @@ public class JSInvokeNode extends JSNode
 	 * 
 	 * @return
 	 */
-	public IParseNode getArguments()
+	public JSArgumentsNode getArguments()
 	{
-		return this.getChild(1);
+		return (JSArgumentsNode) this.getChild(1);
 	}
 
 	/**
@@ -46,8 +46,8 @@ public class JSInvokeNode extends JSNode
 	 * 
 	 * @return
 	 */
-	public IParseNode getExpression()
+	public JSNode getExpression()
 	{
-		return this.getChild(0);
+		return (JSNode) this.getChild(0);
 	}
 }


### PR DESCRIPTION
Make some minor adjustments to JS parser to get more detailed type info on some children nodes. (Specifically a JSInvokeNode always has two children, and the second is a JSArgumentsNode. Also, the second child of a JSGetpropertyNode is always a JSIdentifierNode)
