### PR TITLE
TISTUD-6885 Multiline Search: Selecting 'Search selection' using the gear icon does not activate the feature in the search bar

### DIFF
--- a/plugins/com.aptana.editor.findbar/src/com/aptana/editor/findbar/impl/FindBarOption.java
+++ b/plugins/com.aptana.editor.findbar/src/com/aptana/editor/findbar/impl/FindBarOption.java
@@ -219,9 +219,18 @@ abstract class FindBarOption extends SelectionAdapter implements SelectionListen
 		{
 			public void widgetSelected(SelectionEvent e)
 			{
-				if (isCheckable() && !StringUtil.isEmpty(preferencesKey))
+				if (isCheckable())
 				{
-					FindBarDecorator.findBarConfiguration.toggle(preferencesKey);
+					if (!StringUtil.isEmpty(preferencesKey))
+					{
+						FindBarDecorator.findBarConfiguration.toggle(preferencesKey);
+					}
+					// Search Selection is a checkable but does not store the selection
+					// in the preferences
+					else
+					{
+						toolItem.setSelection(!(toolItem.getSelection()));
+					}
 				}
 				else
 				{


### PR DESCRIPTION
The menu selection and tool bar item selection were not in sync. Also Search selection needs special  handling as its a checkable but the preference for it is not stored.
