### PR TITLE
TISTUD-6920 Content Assist not showing many of the methods and properties of objects

### DIFF
--- a/plugins/com.aptana.editor.js/src/com/aptana/editor/js/contentassist/JSContentAssistProcessor.java
+++ b/plugins/com.aptana.editor.js/src/com/aptana/editor/js/contentassist/JSContentAssistProcessor.java
@@ -710,7 +710,7 @@ public class JSContentAssistProcessor extends CommonContentAssistProcessor
 		Collection<PropertyElement> properties = getQueryHelper().getTypeMembers(allTypes);
 		URI projectURI = getProjectURI();
 		for (PropertyElement property : CollectionsUtil.filter(properties, new AndFilter<PropertyElement>(
-				isNotConstructorFilter, isVisibleFilter, isInstance ? isInstanceFilter : isStaticFilter)))
+				isNotConstructorFilter, isVisibleFilter)))
 		{
 			addProposal(proposals, property, offset, projectURI, null);
 		}


### PR DESCRIPTION
Though we are doing the right thing by filtering out the instance against class/static properties based on the node type, all the methods create<UI> (such as createButton, createList...) are categorized as instance method rather than class/static method in api.jsca file. In order to address this issue for 3.4.0, we need to undo the filtering so that we can show all the proposals in the content assist.

For future releases, we need to address them in api.jsca file.
