### PR TITLE
TISTUD-6883 Titanium updates are not installed when node is available, but npm is not available

### DIFF
--- a/plugins/com.aptana.js.core/src/com/aptana/js/core/node/INodeJSService.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/core/node/INodeJSService.java
@@ -28,6 +28,7 @@ public interface INodeJSService
 	public static final String LINUX_DOCS_URL = "http://go.appcelerator.com/Installing+Node.js"; //$NON-NLS-1$
 
 	public static final String NODE = "node"; //$NON-NLS-1$
+	public static final String NPM = "npm"; //$NON-NLS-1$
 
 	/**
 	 * Searches PATH find the node executable and return it. This is not guaranteed to be a valid version. Please check


### PR DESCRIPTION
When we check for NodeJS installation on the machine, we now will detect whether npm executable is available in the expected path. If npm is not available, then we will consider NodeJS installation as incomplete installation.
