### PR TITLE
TISTUD-6834 Add F3 command to jump from string keys in i18n files to usage

### DIFF
--- a/plugins/com.aptana.editor.common/src/com/aptana/editor/common/AbstractThemeableEditor.java
+++ b/plugins/com.aptana.editor.common/src/com/aptana/editor/common/AbstractThemeableEditor.java
@@ -345,8 +345,10 @@ public abstract class AbstractThemeableEditor extends AbstractFoldingEditor impl
 		fSelectionChangedListener.install(getSelectionProvider());
 		fThemeListener = new PropertyChangeListener();
 		ThemePlugin.getDefault().getPreferenceStore().addPropertyChangeListener(fThemeListener);
+
+		String partId = getEditorSite().getId();
 		this.fThemeableEditorFindBarExtension.activateContexts(new String[] { ScriptingActivator.EDITOR_CONTEXT_ID,
-				ScriptingUIPlugin.SCRIPTING_CONTEXT_ID });
+				ScriptingUIPlugin.SCRIPTING_CONTEXT_ID, partId + ".context" }); //$NON-NLS-1$
 
 		if (isWordWrapEnabled())
 		{

--- a/plugins/com.aptana.editor.findbar/src/com/aptana/editor/findbar/impl/FindBarActions.java
+++ b/plugins/com.aptana.editor.findbar/src/com/aptana/editor/findbar/impl/FindBarActions.java
@@ -20,6 +20,7 @@ import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.commands.NotEnabledException;
 import org.eclipse.core.commands.NotHandledException;
 import org.eclipse.core.commands.ParameterizedCommand;
+import org.eclipse.core.commands.contexts.Context;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.e4.ui.services.EContextService;
@@ -48,6 +49,7 @@ import org.eclipse.ui.handlers.IHandlerService;
 import org.eclipse.ui.keys.IBindingService;
 import org.eclipse.ui.texteditor.ITextEditor;
 
+import com.aptana.core.logging.IdeLog;
 import com.aptana.core.util.CollectionsUtil;
 import com.aptana.core.util.StringUtil;
 import com.aptana.editor.findbar.FindBarPlugin;
@@ -651,6 +653,15 @@ public class FindBarActions
 				editorContextIds.clear();
 				for (String contextId : contextIds)
 				{
+					Context ctxt = contextService.getContext(contextId);
+					if (!ctxt.isDefined())
+					{
+						// Dynamically define context!
+						ctxt.define("Dynamic context: " + contextId, null, /* ScriptingActivator.EDITOR_CONTEXT_ID */
+								"com.aptana.editor.context");
+						IdeLog.logInfo(FindBarPlugin.getDefault(), "Dynamically generated context: " + contextId);
+					}
+
 					editorContextIds.add(contextId);
 					contextService.activateContext(contextId);
 				}

--- a/plugins/com.aptana.editor.js/plugin.xml
+++ b/plugins/com.aptana.editor.js/plugin.xml
@@ -17,6 +17,14 @@
       </editor>
    </extension>
    <extension
+         point="org.eclipse.ui.contexts">
+      <context
+            id="com.aptana.editor.js.context"
+            name="JS Editor"
+            parentId="com.aptana.editor.context">
+      </context>
+   </extension>
+   <extension
          point="org.eclipse.core.runtime.preferences">
       <initializer
             class="com.aptana.editor.js.preferences.PreferenceInitializer">
@@ -57,7 +65,7 @@
       </key>
       <key
             commandId="com.aptana.editor.js.openDeclaration"
-            contextId="com.aptana.scripting.context"
+            contextId="com.aptana.editor.js.context"
             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
             sequence="F3">
       </key>


### PR DESCRIPTION
Register a dynamic context based on the editor id for all Aptana/Appcelerator editors. The context generated is the editor id plus the suffix ".context". This allows us to associate keybindings with specific editors (so we can do an F3 binding for JS that is different from the one for xml editors).
