### PR TITLE
Versions over Strings

### DIFF
--- a/plugins/com.aptana.core/src/com/aptana/core/util/VersionUtil.java
+++ b/plugins/com.aptana.core/src/com/aptana/core/util/VersionUtil.java
@@ -200,10 +200,15 @@ public final class VersionUtil
 	 * Parse the raw output and return a {@link Version} instance out of it.
 	 * 
 	 * @param rawOutput
-	 * @return A {@link Version} instance. Null if the output did not contain a parseable version number.
+	 * @return A {@link Version} instance. {@link Version#emptyVersion} if the output did not contain a parseable
+	 *         version number.
 	 */
 	public static Version parseVersion(String rawOutput)
 	{
+		if (StringUtil.isEmpty(rawOutput))
+		{
+			return Version.emptyVersion;
+		}
 		Pattern pattern = Pattern.compile(VERSION_SPLIT_PATTERN);
 		Matcher matcher = pattern.matcher(rawOutput);
 		if (matcher.find())
@@ -250,7 +255,7 @@ public final class VersionUtil
 				IdeLog.logError(CorePlugin.getDefault(), "Error parsing the version string - " + version, iae); //$NON-NLS-1$
 			}
 		}
-		return null;
+		return Version.emptyVersion;
 	}
 
 	/**
@@ -280,15 +285,8 @@ public final class VersionUtil
 		{
 			try
 			{
-				Version version = getVersion(installedVer);
-				if (version != null)
-				{
-					installed.put(installedVer, version);
-				}
-				else
-				{
-					installed.put(installedVer, Version.emptyVersion);
-				}
+				Version version = parseVersion(installedVer);
+				installed.put(installedVer, version);
 			}
 			catch (Exception e)
 			{
@@ -404,15 +402,22 @@ public final class VersionUtil
 	}
 
 	/**
-	 * Extract a Version out of a given version string. We are looking for a pattern that will match a version in a form
-	 * of a.b.c (or less).
+	 * Returns true is version object is null or is {@link Version#emptyVersion}
 	 * 
-	 * @param installedVer
-	 * @return The 'synthesized' version of the given version string; <code>null</code> if no version was detected.
+	 * @param version
+	 * @return
 	 */
-	public static Version getVersion(String version)
+	public static boolean isEmpty(Version version)
 	{
-		return VersionUtil.parseVersion(version);
+		if (version == null)
+		{
+			return true;
+		}
+		if (version.equals(Version.emptyVersion))
+		{
+			return true;
+		}
+		return false;
 	}
 
 }

--- a/plugins/com.aptana.git.core/src/com/aptana/git/core/model/GitExecutable.java
+++ b/plugins/com.aptana.git.core/src/com/aptana/git/core/model/GitExecutable.java
@@ -458,11 +458,6 @@ public class GitExecutable
 	public Version version()
 	{
 		String versionString = GitExecutable.versionForPath(gitPath);
-		if (versionString == null)
-		{
-			return Version.emptyVersion;
-		}
-
 		try
 		{
 			return VersionUtil.parseVersion(versionString);

--- a/plugins/com.aptana.portal.ui/src/com/aptana/portal/ui/dispatch/configurationProcessors/InstallerConfigurationProcessor.java
+++ b/plugins/com.aptana.portal.ui/src/com/aptana/portal/ui/dispatch/configurationProcessors/InstallerConfigurationProcessor.java
@@ -145,7 +145,7 @@ public abstract class InstallerConfigurationProcessor extends AbstractConfigurat
 		}
 		Map<String, String> appVersionMap = new HashMap<String, String>();
 		Version version = VersionUtil.parseVersion(versionedFileLocation);
-		if (version != null)
+		if (!VersionUtil.isEmpty(version))
 		{
 			appVersionMap.put(IPortalPreferences.CACHED_VERSION_PROPERTY, version.toString());
 			appVersionMap.put(IPortalPreferences.CACHED_LOCATION_PROPERTY, installDir);

--- a/plugins/com.aptana.portal.ui/src/com/aptana/portal/ui/dispatch/configurationProcessors/JavaScriptLibraryInstallProcessor.java
+++ b/plugins/com.aptana.portal.ui/src/com/aptana/portal/ui/dispatch/configurationProcessors/JavaScriptLibraryInstallProcessor.java
@@ -29,13 +29,11 @@ import org.eclipse.jface.window.Window;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.progress.UIJob;
-import org.osgi.framework.Version;
 
 import com.aptana.configurations.processor.ConfigurationStatus;
 import com.aptana.core.logging.IdeLog;
 import com.aptana.core.util.EclipseUtil;
 import com.aptana.core.util.IOUtil;
-import com.aptana.core.util.VersionUtil;
 import com.aptana.portal.ui.PortalUIPlugin;
 import com.aptana.portal.ui.dispatch.configurationProcessors.installer.JavaScriptImporterOptionsDialog;
 
@@ -60,33 +58,6 @@ public class JavaScriptLibraryInstallProcessor extends InstallerConfigurationPro
 	protected String getApplicationName()
 	{
 		return libraryName;
-	}
-
-	/**
-	 * Returns the library's version.<br>
-	 * The version extraction will begin by trying to find a version in the library name. If failed, this call will try
-	 * to locate a version pattern in the download URLs. And if that fails, the method returns null.
-	 * 
-	 * @return The library's version; Null, if none is found.
-	 */
-	protected Version getLibraryVersion()
-	{
-		Version version = VersionUtil.parseVersion(getApplicationName());
-		if (version == null)
-		{
-			for (String url : this.urls)
-			{
-				if (version == null)
-				{
-					version = VersionUtil.parseVersion(url);
-				}
-				else
-				{
-					break;
-				}
-			}
-		}
-		return version;
 	}
 
 	/**

--- a/plugins/com.aptana.portal.ui/src/com/aptana/portal/ui/dispatch/configurationProcessors/VersionsConfigurationProcessor.java
+++ b/plugins/com.aptana.portal.ui/src/com/aptana/portal/ui/dispatch/configurationProcessors/VersionsConfigurationProcessor.java
@@ -103,7 +103,7 @@ public class VersionsConfigurationProcessor extends AbstractConfigurationProcess
 			if (commandResult != null)
 			{
 				Version version = VersionUtil.parseVersion(commandResult.toString());
-				if (version != null)
+				if (!VersionUtil.isEmpty(version))
 				{
 					Version minVersion = VersionUtil.parseVersion(attrItems.get(app));
 					String compatibility = (version.compareTo(minVersion) >= 0) ? COMPATIBILITY_OK

--- a/tests/com.aptana.core.tests/src/com/aptana/core/util/VersionUtilTest.java
+++ b/tests/com.aptana.core.tests/src/com/aptana/core/util/VersionUtilTest.java
@@ -25,6 +25,36 @@ public class VersionUtilTest
 	}
 
 	@Test
+	public void testParseVersionNull()
+	{
+		assertVersion(0, 0, 0, "", VersionUtil.parseVersion(null));
+	}
+
+	@Test
+	public void testParseVersionEmpty()
+	{
+		assertVersion(0, 0, 0, "", VersionUtil.parseVersion(""));
+	}
+
+	@Test
+	public void testIsEmptyNull()
+	{
+		assertTrue(VersionUtil.isEmpty(null));
+	}
+
+	@Test
+	public void testIsEmptyVersionEmptyVersion()
+	{
+		assertTrue(VersionUtil.isEmpty(Version.emptyVersion));
+	}
+
+	@Test
+	public void testIsEmpty()
+	{
+		assertFalse(VersionUtil.isEmpty(new Version(1, 0, 0)));
+	}
+
+	@Test
 	public void testParseVersionWithMajorMinorMicro()
 	{
 		assertVersion(3, 0, 24, VersionUtil.parseVersion("3.0.24"));


### PR DESCRIPTION
Make VersionUtil.parseVersion return Version.emptyVersion when there's an issue, not null. Update all callers. Add VersionUtil.isEmpty to check if version object is null or equal to Version.emptyVersion.
