### PR TITLE
TISTUD-6972 Studio hangs with incorrect password during update

### DIFF
--- a/tests/com.aptana.core.tests/src/com/aptana/core/util/SudoManagerTest.java
+++ b/tests/com.aptana.core.tests/src/com/aptana/core/util/SudoManagerTest.java
@@ -7,14 +7,22 @@
 package com.aptana.core.util;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
+import org.eclipse.core.runtime.CoreException;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.jmock.lib.concurrent.Synchroniser;
@@ -64,10 +72,21 @@ public class SudoManagerTest
 	@After
 	public void tearDown()
 	{
-		sudoManager = null;
-		process = null;
-		out = null;
-		processRunner = null;
+		try
+		{
+			if (context != null)
+			{
+				context.assertIsSatisfied();
+			}
+		}
+		finally
+		{
+			context = null;
+			sudoManager = null;
+			process = null;
+			out = null;
+			processRunner = null;
+		}
 	}
 
 	@Test
@@ -81,7 +100,7 @@ public class SudoManagerTest
 				will(returnValue(process));
 
 				oneOf(process).getInputStream();
-				will(returnValue(new ByteArrayInputStream(("password:SUCCESS").getBytes())));
+				will(returnValue(new ByteArrayInputStream(("password:SUCCESS\n").getBytes())));
 
 				oneOf(process).getOutputStream();
 				will(returnValue(out));
@@ -89,12 +108,34 @@ public class SudoManagerTest
 		});
 		assertEquals(true, sudoManager.authenticate("fake".toCharArray()));
 		assertEquals("fake\n", out.toString()); // assert we wrote password to STDIN
-		context.assertIsSatisfied();
 	}
 
-	@Test
+	@Test(timeout=5000)
 	public void testAuthenticateWithBadPassword() throws Exception
 	{
+		ExecutorService executor = Executors.newFixedThreadPool(2);
+		final PipedOutputStream pipedOut = new PipedOutputStream();
+		final PipedInputStream in = new PipedInputStream(pipedOut);
+		Runnable writeTask = new Runnable()
+		{
+			public void run()
+			{
+				try
+				{
+					Thread.sleep(1000);
+					pipedOut.write("password:".getBytes());
+					Thread.sleep(50);
+					pipedOut.write("Sorry, try again.\n".getBytes());
+					Thread.sleep(500);
+					pipedOut.write("password:".getBytes());
+				}
+				catch (Exception e)
+				{
+					e.printStackTrace();
+				}
+			}
+		};
+
 		context.checking(new Expectations()
 		{
 			{
@@ -103,15 +144,44 @@ public class SudoManagerTest
 				will(returnValue(process));
 
 				oneOf(process).getInputStream();
-				will(returnValue(new ByteArrayInputStream(("password:\nSorry, try again.\npassword:").getBytes())));
+				will(returnValue(in));
 
 				oneOf(process).getOutputStream();
 				will(returnValue(out));
 			}
 		});
-		assertEquals(false, sudoManager.authenticate("fake".toCharArray()));
-		assertEquals("fake\n", out.toString()); // assert we wrote password to STDIN
-		context.assertIsSatisfied();
+
+		Runnable testTask = new Runnable()
+		{
+			public void run()
+			{
+				try
+				{
+					assertFalse("Should return false indicating password was incorrect",
+							sudoManager.authenticate("fake".toCharArray()));
+					assertEquals("fake\n", out.toString()); // assert we wrote password to STDIN
+				}
+				catch (CoreException e)
+				{
+					fail(e.getMessage());
+				}
+			}
+		};
+		Future testFuture = executor.submit(testTask);
+		Future f = executor.submit(writeTask);
+		try
+		{
+			while (!testFuture.isDone())
+			{
+				Thread.sleep(100);
+			}
+		}
+		finally
+		{
+			f.cancel(true);
+			pipedOut.close();
+			in.close();
+		}
 	}
 
 	@Test
@@ -125,15 +195,13 @@ public class SudoManagerTest
 				will(returnValue(process));
 
 				oneOf(process).getInputStream();
-				will(returnValue(new ByteArrayInputStream(("SUCCESS").getBytes())));
+				will(returnValue(new ByteArrayInputStream(("password:SUCCESS\n").getBytes())));
 
-				oneOf(process).getOutputStream();
-				will(returnValue(out));
+				never(process).getOutputStream(); // no password to write
 			}
 		});
-		assertEquals(true, sudoManager.authenticate(null));
+		assertTrue(sudoManager.authenticate(null));
 		assertEquals("", out.toString()); // assert we wrote no password to STDIN
-		context.assertIsSatisfied();
 	}
 
 	@Test
@@ -151,7 +219,7 @@ public class SudoManagerTest
 						("\nWARNING: Improper use of the sudo command could lead to data loss\n"
 								+ "or the deletion of important system files. Please double-check your\n"
 								+ "typing when using sudo. Type \"man sudo\" for more information.\n\n"
-								+ "To proceed, enter your password, or type Ctrl-C to abort.\n\n" + "password:SUCCESS")
+								+ "To proceed, enter your password, or type Ctrl-C to abort.\n\n" + "password:SUCCESS\n")
 								.getBytes())));
 
 				oneOf(process).getOutputStream();
@@ -160,7 +228,6 @@ public class SudoManagerTest
 		});
 		assertEquals(true, sudoManager.authenticate("fake".toCharArray()));
 		assertEquals("fake\n", out.toString()); // assert we wrote password to STDIN
-		context.assertIsSatisfied();
 	}
 
 	@Test


### PR DESCRIPTION
DO NOT USE readLine() when we know a stream may block. We have no way to guarantee that it won't block ( we can check ready()/available() but that just means there are more bytes, not that we also have an EOL/EOF char in those bytes). So I had to move to reading char by char and breaking it up by lines myself with checks after each read to ensure the next read wouldn't block.
