### PR TITLE
TISTUD-6918:Studio doesn't install all the components in one attempt If it installs Node

### DIFF
--- a/plugins/com.aptana.js.core/src/com/aptana/js/internal/core/node/NodeJSService.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/internal/core/node/NodeJSService.java
@@ -263,6 +263,7 @@ public class NodeJSService implements INodeJSService
 			return new Status(IStatus.ERROR, JSCorePlugin.PLUGIN_ID, e.getMessage(), e);
 		}
 		sub.done();
+		fNodeExePath = findValidExecutable();
 		fireNodeJSInstalled();
 		return Status.OK_STATUS;
 	}


### PR DESCRIPTION
Initially as node js is not installed, in NodeJSService fNodeExePath is null. Once node is installed properly we should set this variable so that other components waiting for install after node(but depending on node) can be installed properly
