### PR TITLE
TISTUD-6591 Alloy: Update content assist to support leftNavButtons and r...

### DIFF
--- a/plugins/com.aptana.editor.xml/src/com/aptana/editor/xml/contentassist/XMLContentAssistProcessor.java
+++ b/plugins/com.aptana.editor.xml/src/com/aptana/editor/xml/contentassist/XMLContentAssistProcessor.java
@@ -520,7 +520,7 @@ public class XMLContentAssistProcessor extends CommonContentAssistProcessor
 		// account for last position returning an empty IDocument default partition
 		int lexemeProviderOffset = (offset >= documentLength) ? documentLength - 1 : offset;
 
-		return new XMLLexemeProvider(document, lexemeProviderOffset, new XMLTagScanner()
+		return new XMLLexemeProvider(document, lexemeProviderOffset, 0, new XMLTagScanner()
 		{
 			@Override
 			protected IToken createToken(XMLTokenType type)

--- a/plugins/com.aptana.editor.xml/src/com/aptana/editor/xml/internal/XMLLexemeProvider.java
+++ b/plugins/com.aptana.editor.xml/src/com/aptana/editor/xml/internal/XMLLexemeProvider.java
@@ -41,7 +41,7 @@ public class XMLLexemeProvider extends LexemeProvider<XMLTokenType>
 	 */
 	public XMLLexemeProvider(IDocument document, int offset, ITokenScanner scanner)
 	{
-		super(document, offset, 0, scanner);
+		super(document, offset, scanner);
 	}
 
 	/**


### PR DESCRIPTION
Adding support to let us grab the parent node under the current offset. This will helps us to allow a few elements only for a specific parent. For example, RightNavButtons should be allowed only under Window element.
