### PR TITLE
TISTUD-7010 Prompt for Node.ACS CLI installation if acs app is launched ...

### DIFF
--- a/plugins/com.aptana.ui/src/com/aptana/ui/SudoUIManager.java
+++ b/plugins/com.aptana.ui/src/com/aptana/ui/SudoUIManager.java
@@ -87,7 +87,8 @@ public class SudoUIManager
 									return UIUtils.getActiveShell();
 								}
 							}, promptMessage);
-							if (sudoDialog.open() == Dialog.OK)
+							int open = sudoDialog.open();
+							if (open == Dialog.OK)
 							{
 								if (sudoMngr.authenticate(sudoDialog.getPassword()))
 								{
@@ -98,6 +99,10 @@ public class SudoUIManager
 									// Re-run the authentication dialog as long as user attempts to provide password.
 									retry = true;
 								}
+							}
+							else if (open == Dialog.CANCEL)
+							{
+								throw new CoreException(Status.CANCEL_STATUS);
 							}
 							promptMessage = Messages.Sudo_Invalid_Password_Prompt;
 						}


### PR DESCRIPTION
Found during the testing of TISTUD-7010. If the user cancels the sudo password prompt, then we keep on prompting the user for max number of attempts.
