### PR TITLE
TISTUD-7055 Toolbar: Border - A black border is appearing underneath the...

### DIFF
--- a/plugins/com.aptana.theme/css/gtk_dark.css
+++ b/plugins/com.aptana.theme/css/gtk_dark.css
@@ -1,4 +1,4 @@
-@import url("platform:/plugin/com.aptana.theme/css/dark.css");
+@import url("dark.css");
 
 /* GTK specific */
 .MPartStack {

--- a/plugins/com.aptana.theme/css/gtk_dashboard.css
+++ b/plugins/com.aptana.theme/css/gtk_dashboard.css
@@ -1,4 +1,4 @@
-@import url("platform:/plugin/com.aptana.theme/css/dashboard.css");
+@import url("dashboard.css");
 
 /* GTK specific */
 .MPartStack {

--- a/plugins/com.aptana.theme/css/mac_dark.css
+++ b/plugins/com.aptana.theme/css/mac_dark.css
@@ -1,4 +1,4 @@
-@import url("platform:/plugin/com.aptana.theme/css/dark.css");
+@import url("dark.css");
 
 /* Mac specific */
 .MPartStack {

--- a/plugins/com.aptana.theme/css/mac_dashboard.css
+++ b/plugins/com.aptana.theme/css/mac_dashboard.css
@@ -1,4 +1,4 @@
-@import url("platform:/plugin/com.aptana.theme/css/dashboard.css");
+@import url("dashboard.css");
 
 /* Mac specific */
 .MPartStack {

--- a/plugins/com.aptana.theme/css/win_dark.css
+++ b/plugins/com.aptana.theme/css/win_dark.css
@@ -1,4 +1,4 @@
-@import url("platform:/plugin/com.aptana.theme/css/dark.css");
+@import url("dark.css");
 
 /* Windows specific */
 .MPartStack {

--- a/plugins/com.aptana.theme/css/win_dashboard.css
+++ b/plugins/com.aptana.theme/css/win_dashboard.css
@@ -1,4 +1,4 @@
-@import url("platform:/plugin/com.aptana.theme/css/dashboard.css");
+@import url("dashboard.css");
 
 /* Win specific */
 .MPartStack {


### PR DESCRIPTION
After numerous attempts of changing various attributes of colors/keyline/borders, I finally figured out that the problem with the black border on toolbar is not because of missing color settings in our css style settings. It is rather because of invalid reference of parent css file. Eclipse is failing internally while trying to resolve the parent css file (light theme global properties).

Fixed the path in order to reference the relative path instead of absolute path.

![screen shot 2014-11-20 at 4 00 35 pm](https://cloud.githubusercontent.com/assets/2413570/5135612/1d08a9ce-70cf-11e4-9823-026fdaa9e417.png)
