### PR TITLE
TISTUD-6974 3.4.0 GA upgrade or installation should alert users of dependancy for Xcode 6

### DIFF
--- a/plugins/com.aptana.core/src/com/aptana/core/util/VersionUtil.java
+++ b/plugins/com.aptana.core/src/com/aptana/core/util/VersionUtil.java
@@ -446,7 +446,10 @@ public final class VersionUtil
 			String minVersion = matcher.group(2);
 			// The versions are sometimes tagged as 24.x, which has to be changed to 24.0 in order to parse without any
 			// errors.
-			return minVersion.replace('x', '0');
+			if (!StringUtil.isEmpty(minVersion))
+			{
+				return minVersion.replace('x', '0');
+			}
 		}
 		return null;
 	}
@@ -468,7 +471,10 @@ public final class VersionUtil
 		if (matcher.matches())
 		{
 			String maxVersion = matcher.group(5);
-			return maxVersion.replace('x', '0');
+			if (!StringUtil.isEmpty(maxVersion))
+			{
+				return maxVersion.replace('x', '0');
+			}
 		}
 		return null;
 	}

--- a/tests/com.aptana.core.tests/src/com/aptana/core/util/VersionUtilTest.java
+++ b/tests/com.aptana.core.tests/src/com/aptana/core/util/VersionUtilTest.java
@@ -250,8 +250,8 @@ public class VersionUtilTest
 	public void testParsingMaxVersion() throws Exception
 	{
 		assertEquals("24", VersionUtil.parseMax(">=20.x <=24"));
-		assertEquals("24.x", VersionUtil.parseMax(">=20 <24.x"));
-		assertEquals("24.x", VersionUtil.parseMax("<=24.x"));
+		assertEquals("24.0", VersionUtil.parseMax(">=20 <24.x"));
+		assertEquals("24.0", VersionUtil.parseMax("<=24.x"));
 		assertEquals("24.9", VersionUtil.parseMax("<24.9"));
 		assertEquals(null, VersionUtil.parseMax(">=24"));
 	}
@@ -259,10 +259,10 @@ public class VersionUtilTest
 	@Test
 	public void testParsingMinVersion() throws Exception
 	{
-		assertEquals("24.x", VersionUtil.parseMin("24.x"));
-		assertEquals("20.x", VersionUtil.parseMin(">=20.x <=24"));
+		assertEquals("24.0", VersionUtil.parseMin("24.x"));
+		assertEquals("20.0", VersionUtil.parseMin(">=20.x <=24"));
 		assertEquals("20", VersionUtil.parseMin(">20 <=24.x"));
-		assertEquals("24.x", VersionUtil.parseMin(">=24.x"));
+		assertEquals("24.0", VersionUtil.parseMin(">=24.x"));
 		assertEquals("24.9", VersionUtil.parseMin(">24.9"));
 		assertEquals(null, VersionUtil.parseMin("<=24"));
 	}


### PR DESCRIPTION
Supporting changes to read the version dependencies such as "xcode":"6.x" to understand that 6.x is the minimum required version for that specific SDK.
Added tests.
