### PR TITLE
TISTUD-6815:Studio does not recognize installed npm packages if there are unmet dependencies with npm

### DIFF
--- a/plugins/com.aptana.js.core/src/com/aptana/js/internal/core/node/NodePackageManager.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/internal/core/node/NodePackageManager.java
@@ -93,6 +93,11 @@ public class NodePackageManager implements INodePackageManager
 	private static final String JSON = "--json"; //$NON-NLS-1$
 
 	/**
+	 * Special switch/config option to set the loglevel to silent so that warnings/errors are not displayed..
+	 */
+	private static final String SILENT = "-s"; //$NON-NLS-1$
+
+	/**
 	 * config value to pass after {@value #JSON} to get json output
 	 */
 	private static final String TRUE = "true"; //$NON-NLS-1$
@@ -474,7 +479,8 @@ public class NodePackageManager implements INodePackageManager
 	public String getInstalledVersion(String packageName, boolean global, IPath workingDir) throws CoreException
 	{
 		IPath npmPath = checkedNPMPath();
-		List<String> args = CollectionsUtil.newList(npmPath.toOSString(), "ls", packageName, COLOR, FALSE, JSON, TRUE); //$NON-NLS-1$
+		List<String> args = CollectionsUtil.newList(npmPath.toOSString(),
+				"ls", packageName, COLOR, FALSE, JSON, TRUE, SILENT); //$NON-NLS-1$
 		if (global)
 		{
 			args.add(GLOBAL_ARG);
@@ -482,12 +488,27 @@ public class NodePackageManager implements INodePackageManager
 		IStatus status = nodeJS.runInBackground(workingDir, ShellExecutable.getEnvironment(), args);
 		if (!status.isOK())
 		{
-			throw new CoreException(new Status(IStatus.ERROR, JSCorePlugin.PLUGIN_ID, MessageFormat.format(
-					Messages.NodePackageManager_FailedToDetermineInstalledVersion, packageName, status.getMessage())));
+			// Sometimes due to unrelated un-met dependencies the status is not OK but the
+			// version information is still present so try first to read it. Log the issue
+			// so that user knows he has a problem with NPM
+			String version = getVersion(packageName, status.getMessage());
+			if (StringUtil.isEmpty(version))
+			{
+				throw new CoreException(new Status(IStatus.ERROR, JSCorePlugin.PLUGIN_ID,
+						MessageFormat.format(Messages.NodePackageManager_FailedToDetermineInstalledVersion,
+								packageName, status.getMessage())));
+			}
+			IdeLog.logError(JSCorePlugin.getDefault(), status.getMessage());
+			return version;
 		}
+
+		return getVersion(packageName, status.getMessage());
+	}
+
+	private String getVersion(String packageName, String output) throws CoreException
+	{
 		try
 		{
-			String output = status.getMessage();
 			JSONObject json = (JSONObject) new JSONParser().parse(output);
 			if (!json.containsKey("dependencies"))
 			{

--- a/tests/com.aptana.js.core.tests/src/com/aptana/js/internal/core/node/NodePackageManagerTest.java
+++ b/tests/com.aptana.js.core.tests/src/com/aptana/js/internal/core/node/NodePackageManagerTest.java
@@ -326,13 +326,40 @@ public class NodePackageManagerTest
 						userHome,
 						ShellExecutable.getEnvironment(),
 						CollectionsUtil.newList("/usr/bin/npm", "ls", "titanium", "--color", "false", "--json", "true",
-								"-g"));
+								"-s", "-g"));
 				will(returnValue(status));
 			}
 		});
 
 		String returned = npm.getInstalledVersion("titanium", true, userHome);
 		assertEquals("3.3.0", returned);
+		context.assertIsSatisfied();
+	}
+
+	@Test
+	public void testGetInstalledVersionWithUnmetDependencies() throws CoreException
+	{
+		final IStatus status = new Status(
+				IStatus.ERROR,
+				JSCorePlugin.PLUGIN_ID,
+				"{\n \"problems\": [ \n \"invalid: titanium@3.4.1 /usr/local/lib/node_modules/titanium\" \n ], \n \"dependencies\": {\n    \"titanium\": {\n      \"version\": \"3.4.1\",\n      \"from\": \"titanium@*\",\n      \"invalid\": true,\n  \"problems\": [ \n \"invalid: titanium@3.4.1 /usr/local/lib/node_modules/titanium\" \n ] \n  }\n  }\n}");
+		context.checking(new Expectations()
+		{
+			{
+				oneOf(file).exists();
+				will(returnValue(true));
+
+				oneOf(node).runInBackground(
+						userHome,
+						ShellExecutable.getEnvironment(),
+						CollectionsUtil.newList("/usr/bin/npm", "ls", "titanium", "--color", "false", "--json", "true",
+								"-s", "-g"));
+				will(returnValue(status));
+			}
+		});
+
+		String returned = npm.getInstalledVersion("titanium", true, userHome);
+		assertEquals("3.4.1", returned);
 		context.assertIsSatisfied();
 	}
 
@@ -350,7 +377,7 @@ public class NodePackageManagerTest
 						userHome,
 						ShellExecutable.getEnvironment(),
 						CollectionsUtil.newList("/usr/bin/npm", "ls", "titanium", "--color", "false", "--json", "true",
-								"-g"));
+								"-s", "-g"));
 				will(returnValue(status));
 			}
 		});
@@ -374,7 +401,7 @@ public class NodePackageManagerTest
 						userHome,
 						ShellExecutable.getEnvironment(),
 						CollectionsUtil.newList("/usr/bin/npm", "ls", "titanium", "--color", "false", "--json", "true",
-								"-g"));
+								"-s", "-g"));
 				will(returnValue(status));
 			}
 		});
@@ -397,7 +424,7 @@ public class NodePackageManagerTest
 						null,
 						ShellExecutable.getEnvironment(),
 						CollectionsUtil.newList("/usr/bin/npm", "ls", "titanium", "--color", "false", "--json", "true",
-								"-g"));
+								"-s", "-g"));
 				will(returnValue(status));
 			}
 		});
@@ -423,7 +450,7 @@ public class NodePackageManagerTest
 						null,
 						ShellExecutable.getEnvironment(),
 						CollectionsUtil.newList("/usr/bin/npm", "ls", "titanium", "--color", "false", "--json", "true",
-								"-g"));
+								"-s", "-g"));
 				will(returnValue(status));
 			}
 		});
@@ -451,7 +478,7 @@ public class NodePackageManagerTest
 						null,
 						ShellExecutable.getEnvironment(),
 						CollectionsUtil.newList("/usr/bin/npm", "ls", "titanium", "--color", "false", "--json", "true",
-								"-g"));
+								"-s", "-g"));
 				will(returnValue(status));
 
 				// Falls back to checking list


### PR DESCRIPTION
The following changes were made
1. We use the -s  flag with npm ls now so that the error and info are not sent along with the JSON
2. Whenever we get a non OK status(due to unmet dependencies) we first try and see if we can read the version info from the JSON. In case we can we report it back and log an error. If we don't have the version info we just throw CoreException
