### PR TITLE
Revert "TISTUD-7055 Toolbar: Border - A black border is appearing underneath the toolbar

### DIFF
--- a/plugins/com.aptana.theme/css/gtk_dark.css
+++ b/plugins/com.aptana.theme/css/gtk_dark.css
@@ -1,4 +1,4 @@
-@import url("dark.css");
+@import url("platform:/plugin/com.aptana.theme/css/dark.css");
 
 /* GTK specific */
 .MPartStack {

--- a/plugins/com.aptana.theme/css/gtk_dashboard.css
+++ b/plugins/com.aptana.theme/css/gtk_dashboard.css
@@ -1,4 +1,4 @@
-@import url("dashboard.css");
+@import url("platform:/plugin/com.aptana.theme/css/dashboard.css");
 
 /* GTK specific */
 .MPartStack {

--- a/plugins/com.aptana.theme/css/mac_dark.css
+++ b/plugins/com.aptana.theme/css/mac_dark.css
@@ -1,4 +1,4 @@
-@import url("dark.css");
+@import url("platform:/plugin/com.aptana.theme/css/dark.css");
 
 /* Mac specific */
 .MPartStack {

--- a/plugins/com.aptana.theme/css/mac_dashboard.css
+++ b/plugins/com.aptana.theme/css/mac_dashboard.css
@@ -1,4 +1,4 @@
-@import url("dashboard.css");
+@import url("platform:/plugin/com.aptana.theme/css/dashboard.css");
 
 /* Mac specific */
 .MPartStack {

--- a/plugins/com.aptana.theme/css/win_dark.css
+++ b/plugins/com.aptana.theme/css/win_dark.css
@@ -1,4 +1,4 @@
-@import url("dark.css");
+@import url("platform:/plugin/com.aptana.theme/css/dark.css");
 
 /* Windows specific */
 .MPartStack {

--- a/plugins/com.aptana.theme/css/win_dashboard.css
+++ b/plugins/com.aptana.theme/css/win_dashboard.css
@@ -1,4 +1,4 @@
-@import url("dashboard.css");
+@import url("platform:/plugin/com.aptana.theme/css/dashboard.css");
 
 /* Win specific */
 .MPartStack {


### PR DESCRIPTION
Complete platform URI is required to identify the imported css file, hence reverting the change. Verified with eclipse 4.4 version.

If we only provide the name(example: @import url("dark.css");), then it's going and looking for a particular css file in the eclipse default themes folder i.e org.eclipse.themes/css folder

This reverts commit 0b870a9741dffb853a6184c818cef841b3fca58d.