### PR TITLE
TISTUD-6789 Studio should rely on CLI to register the app with 360 after project creation

### DIFF
--- a/plugins/com.aptana.js.core/src/com/aptana/js/core/node/INodePackageManager.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/core/node/INodePackageManager.java
@@ -24,6 +24,9 @@ public interface INodePackageManager
 
 	public static final String GLOBAL_ARG = "-g"; //$NON-NLS-1$
 	public static final String PARSEABLE_ARG = "-p"; //$NON-NLS-1$
+	public static final String SILENT_ARG = "-s"; //$NON-NLS-1$
+	public static final String PREFIX_PATH = "--prefix"; //$NON-NLS-1$
+
 	/**
 	 * Folder where modules live.
 	 */
@@ -91,7 +94,7 @@ public interface INodePackageManager
 	 * @return the node modules path
 	 * @throws CoreException
 	 */
-	public IPath getModulesPath(String packageName) throws CoreException;
+	public IPath getModulesPath(String packageName, boolean isGlobal, String... args) throws CoreException;
 
 	/**
 	 * Gets the latest installed version of a package.

--- a/plugins/com.aptana.js.core/src/com/aptana/js/internal/core/node/NodePackageManager.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/internal/core/node/NodePackageManager.java
@@ -470,9 +470,22 @@ public class NodePackageManager implements INodePackageManager
 		return listing.contains(packageName);
 	}
 
-	public IPath getModulesPath(String packageName) throws CoreException
+	/**
+	 * FIXME Add Unit tests.
+	 */
+	public IPath getModulesPath(String packageName, boolean isGlobal, String... args) throws CoreException
 	{
-		IStatus status = runInBackground(PARSEABLE_ARG, LIST, packageName, GLOBAL_ARG);
+		List<String> processArgs = CollectionsUtil.newList(PARSEABLE_ARG, LIST, packageName, SILENT_ARG);
+		if (isGlobal)
+		{
+			CollectionsUtil.addToList(processArgs, GLOBAL_ARG);
+		}
+		if (args != null)
+		{
+			CollectionsUtil.addToList(processArgs, args);
+		}
+
+		IStatus status = runInBackground(CollectionsUtil.toArray(processArgs));
 		if (!status.isOK())
 		{
 			throw new CoreException(new Status(IStatus.ERROR, JSCorePlugin.PLUGIN_ID, MessageFormat.format(

--- a/plugins/com.aptana.projects/src/com/aptana/projects/wizards/AbstractProjectWizardContributor.java
+++ b/plugins/com.aptana.projects/src/com/aptana/projects/wizards/AbstractProjectWizardContributor.java
@@ -7,6 +7,9 @@
  */
 package com.aptana.projects.wizards;
 
+import java.util.Collections;
+import java.util.List;
+
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
@@ -48,6 +51,12 @@ public abstract class AbstractProjectWizardContributor implements IProjectWizard
 	public IStatus performWizardFinish(IProject project, IProgressMonitor monitor)
 	{
 		return Status.OK_STATUS;
+	}
+
+	@SuppressWarnings("unchecked")
+	public List<String> getArguments()
+	{
+		return Collections.EMPTY_LIST;
 	}
 
 	public void finalizeWizardPage(IWizardPage page)

--- a/plugins/com.aptana.projects/src/com/aptana/projects/wizards/IProjectWizardContributor.java
+++ b/plugins/com.aptana.projects/src/com/aptana/projects/wizards/IProjectWizardContributor.java
@@ -7,6 +7,8 @@
  */
 package com.aptana.projects.wizards;
 
+import java.util.List;
+
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IExecutableExtension;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -22,21 +24,21 @@ public interface IProjectWizardContributor extends IExecutableExtension
 
 	/**
 	 * Responsible for creating the project wizard pages
-	 * 
+	 *
 	 * @return
 	 */
 	public IWizardPage createWizardPage(Object data);
 
 	/**
 	 * Performs any specific finalization on all wizard pages
-	 * 
+	 *
 	 * @param page
 	 */
 	public void finalizeWizardPage(IWizardPage page);
 
 	/**
 	 * Responsible for contributing UI to the project creation page of the wizard
-	 * 
+	 *
 	 * @param data
 	 * @param page
 	 * @param parent
@@ -45,7 +47,7 @@ public interface IProjectWizardContributor extends IExecutableExtension
 
 	/**
 	 * Responsible for contributing UI to a Sample project creation page of the wizard
-	 * 
+	 *
 	 * @param data
 	 * @param page
 	 * @param parent
@@ -54,14 +56,22 @@ public interface IProjectWizardContributor extends IExecutableExtension
 
 	/**
 	 * Called to update the UI for the contributor
-	 * 
+	 *
 	 * @param data
 	 */
 	public void updateProjectCreationPage(Object data);
 
 	/**
+	 * Based on the current user selection of the options, it returns list of possible additional command line options
+	 * for creating a project.
+	 *
+	 * @return
+	 */
+	public List<String> getArguments();
+
+	/**
 	 * Validates the project settings
-	 * 
+	 *
 	 * @param data
 	 * @return
 	 */
@@ -69,7 +79,7 @@ public interface IProjectWizardContributor extends IExecutableExtension
 
 	/**
 	 * Returns the check whether this nature ids passed matches the contributor natureid
-	 * 
+	 *
 	 * @param natureIds
 	 * @return
 	 */
@@ -77,7 +87,7 @@ public interface IProjectWizardContributor extends IExecutableExtension
 
 	/**
 	 * Performs the work to finish the wizard. Provides an optional monitor to record progress
-	 * 
+	 *
 	 * @param project
 	 * @param monitor
 	 * @return

--- a/plugins/com.aptana.projects/src/com/aptana/projects/wizards/ProjectWizardContributionManager.java
+++ b/plugins/com.aptana.projects/src/com/aptana/projects/wizards/ProjectWizardContributionManager.java
@@ -27,8 +27,10 @@ import org.eclipse.jface.wizard.IWizardPage;
 import org.eclipse.jface.wizard.WizardPage;
 import org.eclipse.swt.widgets.Composite;
 
+import com.aptana.core.IFilter;
 import com.aptana.core.logging.IdeLog;
 import com.aptana.core.util.ArrayUtil;
+import com.aptana.core.util.CollectionsUtil;
 import com.aptana.projects.ProjectsPlugin;
 
 /**
@@ -208,6 +210,18 @@ public class ProjectWizardContributionManager
 				}
 			}
 		}
+	}
+
+	public List<IProjectWizardContributor> getContributors(final String[] natureIds)
+	{
+		return CollectionsUtil.filter(contributors, new IFilter<IProjectWizardContributor>()
+		{
+			public boolean include(IProjectWizardContributor item)
+			{
+				return item.hasNatureId(natureIds);
+			}
+		});
+
 	}
 
 	public IStatus performProjectFinish(IProject project, IProgressMonitor monitor)


### PR DESCRIPTION
Two supporting changes in order to facilitate the entire project creation workflow 

- NodePackageManager supports getting the module path of a package based on the specified requirements. Some of the required ones are : global and passing in the prefix path. For example, Alloy modules path will not be available from global anymore. The Alloy package module path can found only under ``~/.appcelerator/install/<version>/package`` as a local package.
- Creating a Mobile Project now supports contributors to provide the command line options. Previously, the contributors are just asked to do some action post project creation. Now, since we need to pass in additional flags such as --org-id and --no-services, the contributors should add additional command line flags.