### PR TITLE
TISTUD-7426:Handle ACS key replacement confirmation through studio

### DIFF
--- a/plugins/com.aptana.ui/src/com/aptana/ui/dialogs/InputMessageDialog.java
+++ b/plugins/com.aptana.ui/src/com/aptana/ui/dialogs/InputMessageDialog.java
@@ -7,7 +7,6 @@
  */
 package com.aptana.ui.dialogs;
 
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -55,6 +54,7 @@ public class InputMessageDialog extends MessageDialog
 	protected static final String CHECKBOX = "checkbox"; //$NON-NLS-1$
 	protected static final String PASSWORD = "password"; //$NON-NLS-1$
 	protected static final String INPUT = "input"; //$NON-NLS-1$
+	protected static final String CONFIRMATION = "confirm"; // MessageDialog.CONFIRM already there! //$NON-NLS-1$
 
 	/**
 	 * Attributes.

--- a/plugins/com.aptana.ui/src/com/aptana/ui/dialogs/MultipleInputMessageDialog.java
+++ b/plugins/com.aptana.ui/src/com/aptana/ui/dialogs/MultipleInputMessageDialog.java
@@ -209,6 +209,10 @@ public class MultipleInputMessageDialog extends InputMessageDialog
 				combo.setSelection(new StructuredSelection(values.get(0)));
 				GridDataFactory.fillDefaults().align(SWT.FILL, SWT.CENTER).grab(true, false).applyTo(valueComp);
 			}
+			else if (CONFIRMATION.equals(inputType))
+			{
+				input.add(Boolean.TRUE);
+			}
 
 			userInput.putPOJO(responseKey, input);
 
@@ -240,7 +244,11 @@ public class MultipleInputMessageDialog extends InputMessageDialog
 				List<Object> input = (List<Object>) controls;
 
 				Object firstElement = CollectionsUtil.getFirstElement(input);
-				if (firstElement instanceof Text)
+				if (firstElement instanceof Boolean)
+				{
+					response.put(fieldName, (Boolean) firstElement);
+				}
+				else if (firstElement instanceof Text)
 				{
 					response.put(fieldName, ((Text) firstElement).getText());
 


### PR DESCRIPTION
While importing external projects by default studio is sending --no-services param, so services will not be enabled during the import.

When user click on on 'Enable Services' button from tiApp.xml editor, it will check whether it's required to replace ACS keys or not, If yes, user will be prompted with a confirmation dialog box and perform the appropriate action based on the user input.