### PR TITLE
TISTUD-7428 Studio launches Mobile Web in browser but returns "Connec…

### DIFF
--- a/plugins/com.aptana.webserver.core/META-INF/MANIFEST.MF
+++ b/plugins/com.aptana.webserver.core/META-INF/MANIFEST.MF
@@ -15,14 +15,14 @@ Bundle-ActivationPolicy: lazy
 Eclipse-LazyStart: true
 Export-Package: com.aptana.webserver.core,
  com.aptana.webserver.core.preferences
-Import-Package: org.apache.http,
+Import-Package: org.apache.http;version="4.2.0",
  org.apache.http.entity;version="4.2.0",
- org.apache.http.impl,
+ org.apache.http.impl;version="4.2.0",
  org.apache.http.impl.nio;version="4.2.0",
  org.apache.http.impl.nio.reactor;version="4.2.0",
- org.apache.http.nio,
+ org.apache.http.nio;version="4.2.0",
  org.apache.http.nio.entity;version="4.2.0",
  org.apache.http.nio.protocol;version="4.2.0",
- org.apache.http.nio.reactor,
- org.apache.http.params,
- org.apache.http.protocol
+ org.apache.http.nio.reactor;version="4.2.0",
+ org.apache.http.params;version="4.2.0",
+ org.apache.http.protocol;version="4.2.0"


### PR DESCRIPTION
…tion Refused"

Finally narrowed down the issue to the sneaky and silent exception thrown when we try to initialize the local webserver. New Eclipse base ships with a new version of ``org.apache.httpcomponents.httpcore and org.apache.httpcomponents.httpclient``. However, Studio has tight dependency on the older versions of those plugins. When we attempt to start the server, the class loader fails to initialize as  ``BasicHttpParams`` class is already from the other plugin/version. We are enforcing to make sure the webserver plugin requires those classes only from the older version.

Though it works on my development environment, I'm curious to verify it on standalone once the fix is pushed.