### PR TITLE
TISTUD-7428 Studio launches Mobile Web in browser but returns "Connection Refused"

### DIFF
--- a/plugins/com.aptana.webserver.core/META-INF/MANIFEST.MF
+++ b/plugins/com.aptana.webserver.core/META-INF/MANIFEST.MF
@@ -9,20 +9,22 @@ Require-Bundle: org.eclipse.core.filesystem,
  com.aptana.core,
  com.aptana.core.epl;visibility:=reexport,
  com.aptana.core.io,
- org.eclipse.debug.core;visibility:=reexport
+ org.eclipse.debug.core;visibility:=reexport,
+ org.apache.httpcomponents.httpclient;bundle-version="[4.2.2,4.2.2]",
+ org.apache.httpcomponents.httpcore;bundle-version="[4.2.2,4.2.2]"
 Bundle-RequiredExecutionEnvironment: J2SE-1.5
 Bundle-ActivationPolicy: lazy
 Eclipse-LazyStart: true
 Export-Package: com.aptana.webserver.core,
  com.aptana.webserver.core.preferences
-Import-Package: org.apache.http;version="4.2.0",
- org.apache.http.entity;version="4.2.0",
- org.apache.http.impl;version="4.2.0",
- org.apache.http.impl.nio;version="4.2.0",
- org.apache.http.impl.nio.reactor;version="4.2.0",
- org.apache.http.nio;version="4.2.0",
- org.apache.http.nio.entity;version="4.2.0",
- org.apache.http.nio.protocol;version="4.2.0",
- org.apache.http.nio.reactor;version="4.2.0",
- org.apache.http.params;version="4.2.0",
- org.apache.http.protocol;version="4.2.0"
+Import-Package: org.apache.http;version="[4.2.2,4.2.2]",
+ org.apache.http.entity;version="[4.2.2,4.2.2]",
+ org.apache.http.impl;version="[4.2.2,4.2.2]",
+ org.apache.http.impl.nio;version="[4.2.2,4.2.2]",
+ org.apache.http.impl.nio.reactor;version="[4.2.2,4.2.2]",
+ org.apache.http.nio;version="[4.2.2,4.2.2]",
+ org.apache.http.nio.entity;version="[4.2.2,4.2.2]",
+ org.apache.http.nio.protocol;version="[4.2.2,4.2.2]",
+ org.apache.http.nio.reactor;version="[4.2.2,4.2.2]",
+ org.apache.http.params;version="[4.2.2,4.2.2]",
+ org.apache.http.protocol;version="[4.2.2,4.2.2]"


### PR DESCRIPTION
 After digging into this mobileweb launch issue, I found out Eclipse ships its customized plugin of apache.httpcomponents.httpcore and apache.httpcomponents.httpclient - which is a way trimmed version from the original apache plugins. Since those versions (4.3.1) are higher than our required (4.2.2), we end up loading a few of the classes from eclipse's apache classes. Then, we attempt to load the rest of classes from 4.2.2, we end up getting LinkageError due to mismatch of version numbers of same type. Tried to enforce both the min and max versions in manifest to make sure we only depend on our shipped apache, and trying to avoid loading the classes from Eclipse's shipped apache bundles.