### PR TITLE
TISTUD-7521:iOS debugger connection refused with SDKs 3.5.0 and 3.5.1

### DIFF
--- a/plugins/com.aptana.js.debug.core/src/com/aptana/js/debug/core/internal/model/JSDebugTarget.java
+++ b/plugins/com.aptana.js.debug.core/src/com/aptana/js/debug/core/internal/model/JSDebugTarget.java
@@ -390,8 +390,7 @@ public class JSDebugTarget extends JSDebugElement implements IJSDebugTarget, IBr
 		}
 		try
 		{
-			IResource resource = getWorkspaceRoot()
-					.findMember(Path.fromOSString(generatedLocation.getPath()));
+			IResource resource = getWorkspaceRoot().findMember(Path.fromOSString(generatedLocation.getPath()));
 			return sourceMap.getOriginalMapping(resource, sourceLine);
 		}
 		catch (Exception e)
@@ -1250,8 +1249,7 @@ public class JSDebugTarget extends JSDebugElement implements IJSDebugTarget, IBr
 	private void handleDetailFormattersChange() throws DebugException
 	{
 		StringBuffer sb = new StringBuffer(DETAIL_FORMATTERS);
-		for (DetailFormatter detailFormatter : getDebugOptionsManager()
-				.getDetailFormatters())
+		for (DetailFormatter detailFormatter : getDebugOptionsManager().getDetailFormatters())
 		{
 			if (!detailFormatter.isEnabled())
 			{
@@ -1325,8 +1323,7 @@ public class JSDebugTarget extends JSDebugElement implements IJSDebugTarget, IBr
 			if (ILaunchManager.DEBUG_MODE.equals(mode))
 			{
 				/* restore breakpoints */
-				for (IBreakpoint breakpoint : getBreakpointManager()
-						.getBreakpoints(getModelIdentifier()))
+				for (IBreakpoint breakpoint : getBreakpointManager().getBreakpoints(getModelIdentifier()))
 				{
 					breakpointAdded(breakpoint);
 				}
@@ -1547,8 +1544,7 @@ public class JSDebugTarget extends JSDebugElement implements IJSDebugTarget, IBr
 	 */
 	public void breakpointManagerEnablementChanged(boolean enabled)
 	{
-		for (IBreakpoint breakpoint : getBreakpointManager()
-				.getBreakpoints(getModelIdentifier()))
+		for (IBreakpoint breakpoint : getBreakpointManager().getBreakpoints(getModelIdentifier()))
 		{
 			if (enabled)
 			{
@@ -1867,8 +1863,8 @@ public class JSDebugTarget extends JSDebugElement implements IJSDebugTarget, IBr
 								"Generated mapping while adding breakpoint for {0}:{1} is {2}:{3}", resource,
 								lineNumber, generatedMapping.getFile(), generatedMapping.getLineNumber()),
 								com.aptana.debug.core.IDebugScopes.DEBUG);
-						IResource mappedResource = getWorkspaceRoot()
-								.findMember(resource.getProject().getFullPath().append(generatedMapping.getFile()));
+						IResource mappedResource = getWorkspaceRoot().findMember(
+								resource.getProject().getFullPath().append(generatedMapping.getFile()));
 						if (mappedResource != null)
 						{
 							resource = mappedResource;
@@ -2089,8 +2085,7 @@ public class JSDebugTarget extends JSDebugElement implements IJSDebugTarget, IBr
 	 */
 	protected IBreakpoint findBreakpointAt(URI fileName, int lineNumber)
 	{
-		IBreakpoint[] breakpoints = getBreakpointManager()
-				.getBreakpoints(getModelIdentifier());
+		IBreakpoint[] breakpoints = getBreakpointManager().getBreakpoints(getModelIdentifier());
 		IBreakpoint breakpoint = findBreakpointIn(fileName, lineNumber, breakpoints);
 		if (breakpoint != null)
 		{
@@ -2180,39 +2175,42 @@ public class JSDebugTarget extends JSDebugElement implements IJSDebugTarget, IBr
 		try
 		{
 			URI uri = new URI(sourceFile);
-			String scheme = uri.getScheme();
-			if (FILE.equals(scheme))
+			if (!uri.isOpaque())
 			{
-				File osFile = new File(uri.getSchemeSpecificPart());
-				resolved = EFSUtils.getLocalFileStore(osFile).toURI();
-			}
-			else if (HTTP.equals(scheme) && uriMapper != null)
-			{
-				IFileStore fileStore = uriMapper.resolve(uri);
-				if (fileStore != null)
+				String scheme = uri.getScheme();
+				if (FILE.equals(scheme))
 				{
-					resolved = fileStore.toURI();
+					File osFile = new File(uri.getSchemeSpecificPart());
+					resolved = EFSUtils.getLocalFileStore(osFile).toURI();
 				}
-			}
-			else if (APP.equals(scheme) && uriMapper != null)
-			{
-				IFileStore fileStore = uriMapper.resolve(uri);
-				if (fileStore != null)
+				else if (HTTP.equals(scheme) && uriMapper != null)
 				{
-					resolved = fileStore.toURI();
+					IFileStore fileStore = uriMapper.resolve(uri);
+					if (fileStore != null)
+					{
+						resolved = fileStore.toURI();
+					}
 				}
-			}
-			else if (JAVASCRIPT.equals(scheme))
-			{
-				if (mainFile != null)
+				else if (APP.equals(scheme) && uriMapper != null)
 				{
-					return mainFile;
+					IFileStore fileStore = uriMapper.resolve(uri);
+					if (fileStore != null)
+					{
+						resolved = fileStore.toURI();
+					}
 				}
-			}
-			if (resolved != null)
-			{
-				sourceResolveCache.put(sourceFile, resolved);
-				return resolved;
+				else if (JAVASCRIPT.equals(scheme))
+				{
+					if (mainFile != null)
+					{
+						return mainFile;
+					}
+				}
+				if (resolved != null)
+				{
+					sourceResolveCache.put(sourceFile, resolved);
+					return resolved;
+				}
 			}
 		}
 		catch (URISyntaxException e)


### PR DESCRIPTION
I couldn't reproduce the issue, so I am going by backtracking.

By analyzing the error log we can understand that, NPE is coming bcoz of <code>URI.getPath()</code> is returning null, this can only happen If URI string does not start path slash(/).

If we look at the uri schemes (app, http, javascript) which we are expecting, Ideally all of them should always start with slash(/) after schema(ex:app:/) but somehow this was missing in certain cases and that leads to this issue.

A simple way to check this is,
<code>
if (!uri.isOpaque())
{
  //http,app, javascript schema operations
}
</code>

