### PR TITLE
TISTUD-8516 Avoid error notification for "Unable to retrieve the icon at

### DIFF
--- a/plugins/com.aptana.samples.ui/src/com/aptana/samples/ui/portal/actionController/SamplesActionController.java
+++ b/plugins/com.aptana.samples.ui/src/com/aptana/samples/ui/portal/actionController/SamplesActionController.java
@@ -230,7 +230,7 @@ public class SamplesActionController extends AbstractActionController
 			iconPath = (String) sampleData.get(SAMPLE_INFO.IMAGE.toString());
 			if (StringUtil.isEmpty(iconPath))
 			{
-				IdeLog.logError(SamplesPlugin.getDefault(),
+				IdeLog.logWarning(SamplesPlugin.getDefault(),
 						MessageFormat.format("Unable to retrieve the icon at {0} for sample {1}", iconPath, name)); //$NON-NLS-1$
 
 			}


### PR DESCRIPTION
null for sample Apple WatchOS2"

This needn't to be an error. will just consider as a warning.