### PR TITLE
TISTUD-8703 Error reporting: NPE after launching the Studio

### DIFF
--- a/plugins/com.aptana.core/src/com/aptana/core/util/ProcessRunner.java
+++ b/plugins/com.aptana.core/src/com/aptana/core/util/ProcessRunner.java
@@ -271,7 +271,8 @@ public class ProcessRunner implements IProcessRunner
 				}
 				else
 				{
-					CollectionsUtil.addToList(arguments, ">", outFile.getAbsolutePath(), "2>", errFile.getAbsolutePath()); //$NON-NLS-1$ //$NON-NLS-2$
+					CollectionsUtil.addToList(arguments,
+							">", outFile.getAbsolutePath(), "2>", errFile.getAbsolutePath()); //$NON-NLS-1$ //$NON-NLS-2$
 					p = run(workingDirectory, environment, arguments.toArray(new String[arguments.size()]));
 				}
 				return processData(p, outFile, errFile);
@@ -398,9 +399,9 @@ public class ProcessRunner implements IProcessRunner
 		}
 		catch (InterruptedException e)
 		{
-			IdeLog.logError(CorePlugin.getDefault(), e);
+			//As the process request couldn't complete successfully, let's throw the error status so that callers will get to know about it.
+			return new Status(IStatus.ERROR, CorePlugin.PLUGIN_ID, e.getMessage(), e);
 		}
-		return null;
 	}
 
 	private void logProcessOutput(String stdout, String stderr)


### PR DESCRIPTION
NPE is at :https://github.com/appcelerator/titanium_studio/blob/694eaa3db28ea34dc4d3138dc82a8748a9808c3e/plugins/com.appcelerator.titanium.core/src/com/appcelerator/titanium/core/internal/cli/NodeAppcCLI.java#L769

It was caused by InterruptedException at https://github.com/aptana/studio3/blob/61328452f22122753ebbed313cb5a14d9293e976/plugins/com.aptana.core/src/com/aptana/core/util/ProcessRunner.java#L403

so the solution is to, send the original status of the process execution so that callers will know the cause and handle them the way it's required - whether it's reporting to the user, log it or ignoring. 