### PR TITLE
TISTUD-8736: Studio hangs upon opening file in offline mode when there was no previous appc session

### DIFF
--- a/plugins/com.aptana.core/src/com/aptana/core/resources/ISocketMessagesHandler.java
+++ b/plugins/com.aptana.core/src/com/aptana/core/resources/ISocketMessagesHandler.java
@@ -28,4 +28,11 @@ public interface ISocketMessagesHandler extends ISocketMessagesHandlerNotifier
 	 */
 	public JsonNode handleRequest(JsonNode request) throws RequestCancelledException;
 
+	/**
+	 * Checks and returns workbench launch status.
+	 * 
+	 * @return <code>true</code> if workbench has been launched, <code>false</code> otherwise.
+	 */
+	public boolean isWorkbenchLaunched();
+
 }

--- a/plugins/com.aptana.core/src/com/aptana/core/resources/SocketMessagesHandler.java
+++ b/plugins/com.aptana.core/src/com/aptana/core/resources/SocketMessagesHandler.java
@@ -37,4 +37,9 @@ public abstract class SocketMessagesHandler implements ISocketMessagesHandler
 	{
 		listeners.remove(listener);
 	}
+	
+	public boolean isWorkbenchLaunched()
+	{
+		return false;
+	}
 }

--- a/plugins/com.aptana.ui/src/com/aptana/ui/handlers/Messages.java
+++ b/plugins/com.aptana.ui/src/com/aptana/ui/handlers/Messages.java
@@ -6,6 +6,8 @@ public class Messages extends NLS
 {
 	private static final String BUNDLE_NAME = "com.aptana.ui.handlers.messages"; //$NON-NLS-1$
 	public static String AppcSocketMessagesHandler_Description;
+	public static String AppcSocketMessagesHandler_SessionInvalidDescription;
+	public static String AppcSocketMessagesHandler_SessionInvalidTitle;
 	public static String AppcSocketMessagesHandler_title;
 	static
 	{

--- a/plugins/com.aptana.ui/src/com/aptana/ui/handlers/messages.properties
+++ b/plugins/com.aptana.ui/src/com/aptana/ui/handlers/messages.properties
@@ -1,2 +1,4 @@
 AppcSocketMessagesHandler_Description=The below details are required to continue the operation.
+AppcSocketMessagesHandler_SessionInvalidDescription=The Axway Appcelerator Studio session has been expired. Please click on OK to restart Studio and re-login. Click on Cancel to work offline.
+AppcSocketMessagesHandler_SessionInvalidTitle=Axway Appcelerator Session Invalid
 AppcSocketMessagesHandler_title=Information


### PR DESCRIPTION

**_(Related titanium_studio PR)_**
https://github.com/appcelerator/titanium_studio/pull/955

**Changes done:**
1. Stopped multiple pop-ups being shown to the user (if one has already been shown to the user and the user has cancelled it or entered credentials), when user session expires.
2. The snooze time for credentials pop-up has been fixed as 24 hours.

Test cases to be covered are as follows.
**_(Post Login cases)_**
1. Make the session invalid by either logging in from another machine or via CLI logout
2. Try to do any operation which requires a valid session (E.g. Dashboard or Publish etc.)
3. Proceed with step-4 OR step-5
4. Select 'OK' on the restart request (pop-up), and see if studio gets restarted.
5. Select 'CANCEL' and see if multiple pup-ups are not being shown. 

_**(Pre login cases)**_
All cases for pre-login should work as before.
