### PR TITLE
TISTUD-8847 NPE while importing studio dashboard project sample

### DIFF
--- a/plugins/com.aptana.core/src/com/aptana/core/logging/IdeLog.java
+++ b/plugins/com.aptana.core/src/com/aptana/core/logging/IdeLog.java
@@ -339,6 +339,11 @@ public final class IdeLog
 	{
 		logWarning(plugin, th.getMessage(), th);
 	}
+	
+	public static void logWarning(Plugin plugin, Throwable th, String scope)
+	{
+		logWarning(plugin, th.getMessage(), th, scope);
+	}
 
 	public static void logWarning(Plugin plugin, String message, Throwable th)
 	{

--- a/plugins/com.aptana.git.core/src/com/aptana/git/core/GitRepositoryProviderType.java
+++ b/plugins/com.aptana.git.core/src/com/aptana/git/core/GitRepositoryProviderType.java
@@ -11,6 +11,7 @@ import java.text.MessageFormat;
 
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
@@ -22,6 +23,7 @@ import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.team.core.RepositoryProviderType;
 
 import com.aptana.core.util.EclipseUtil;
+import com.aptana.git.core.model.GitRepository;
 import com.aptana.git.core.model.IGitRepositoryManager;
 
 public class GitRepositoryProviderType extends RepositoryProviderType
@@ -34,7 +36,7 @@ public class GitRepositoryProviderType extends RepositoryProviderType
 		if (getGitRepositoryManager().getAttached(project) != null)
 			return;
 
-		if (autoAttachGitRepos())
+		if (autoAttachGitRepos() && hasGitDir(project))
 		{
 			final IProject toConnect = project;
 			Job job = new Job(Messages.GitRepositoryProviderType_AutoShareJob_Title)
@@ -63,6 +65,16 @@ public class GitRepositoryProviderType extends RepositoryProviderType
 			EclipseUtil.setSystemForJob(job);
 			job.schedule();
 		}
+	}
+
+	protected boolean hasGitDir(IProject project)
+	{
+		final IResource dotGit = project.findMember(GitRepository.GIT_DIR);
+		if (dotGit != null && dotGit.exists())
+		{
+			return true;
+		}
+		return false;
 	}
 
 	private boolean autoAttachGitRepos()

--- a/plugins/com.aptana.git.core/src/com/aptana/git/core/model/GitRepository.java
+++ b/plugins/com.aptana.git.core/src/com/aptana/git/core/model/GitRepository.java
@@ -393,7 +393,7 @@ public class GitRepository
 									}
 									catch (JNotifyException e)
 									{
-										IdeLog.logError(GitPlugin.getDefault(), e, IDebugScopes.DEBUG);
+										IdeLog.logWarning(GitPlugin.getDefault(), e, IDebugScopes.DEBUG);
 									}
 
 									if (remoteDirCreationWatchId == -1)
@@ -412,7 +412,7 @@ public class GitRepository
 											}
 											catch (JNotifyException e)
 											{
-												IdeLog.logError(GitPlugin.getDefault(), e, IDebugScopes.DEBUG);
+												IdeLog.logWarning(GitPlugin.getDefault(), e, IDebugScopes.DEBUG);
 											}
 											return Status.OK_STATUS;
 										}
@@ -504,7 +504,7 @@ public class GitRepository
 		}
 		catch (JNotifyException e)
 		{
-			IdeLog.logError(GitPlugin.getDefault(), e, IDebugScopes.DEBUG);
+			IdeLog.logWarning(GitPlugin.getDefault(), e, IDebugScopes.DEBUG);
 		}
 	}
 
@@ -1708,7 +1708,7 @@ public class GitRepository
 				}
 				catch (JNotifyException e)
 				{
-					IdeLog.logError(GitPlugin.getDefault(), e, IDebugScopes.DEBUG);
+					IdeLog.logWarning(GitPlugin.getDefault(), e, IDebugScopes.DEBUG);
 				}
 			}
 		}

--- a/plugins/com.aptana.js.core/src/com/aptana/js/core/inferencing/CommonJSResolver.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/core/inferencing/CommonJSResolver.java
@@ -94,7 +94,10 @@ public class CommonJSResolver implements IRequireResolver
 						for (IParseNode joinArg : joinArgs)
 						{
 							String arg = getStringValue(joinArg);
-							items.add(arg);
+							if (arg != null)
+							{
+								items.add(arg);
+							}
 						}
 						return StringUtil.join("/", items); //$NON-NLS-1$
 					}

--- a/tests/com.aptana.git.core.tests/src/com/aptana/git/core/GitCoreTests.java
+++ b/tests/com.aptana.git.core.tests/src/com/aptana/git/core/GitCoreTests.java
@@ -12,7 +12,7 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 @RunWith(Suite.class)
-@SuiteClasses({ GitMoveDeleteIntegrationTest.class, GitMoveDeleteHookTest.class })
+@SuiteClasses({ GitMoveDeleteIntegrationTest.class, GitMoveDeleteHookTest.class, GitRepositoryProviderTest.class })
 public class GitCoreTests
 {
 

--- a/tests/com.aptana.git.core.tests/src/com/aptana/git/core/GitRepositoryProviderTest.java
+++ b/tests/com.aptana.git.core.tests/src/com/aptana/git/core/GitRepositoryProviderTest.java
@@ -1,0 +1,83 @@
+package com.aptana.git.core;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.jmock.Expectations;
+import org.jmock.Mockery;
+import org.jmock.lib.legacy.ClassImposteriser;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.aptana.git.core.model.GitRepository;
+
+/**
+ * @author kkolipaka
+ */
+public class GitRepositoryProviderTest
+{
+	private Mockery context;
+	private IResource resource;
+	private IProject project;
+	private GitRepositoryProviderType repoProviderType;
+
+	@Before
+	public void setUp() throws Exception
+	{
+		context = new Mockery()
+		{
+			{
+				setImposteriser(ClassImposteriser.INSTANCE);
+			}
+		};
+		project = context.mock(IProject.class);
+		resource = context.mock(IResource.class);
+		repoProviderType = new GitRepositoryProviderType();
+
+	}
+
+	@After
+	public void tearDown() throws Exception
+	{
+		context = null;
+		project = null;
+		repoProviderType = null;
+		resource = null;
+	}
+
+	@Test
+	public void testGitDirExists()
+	{
+		context.checking(new Expectations()
+		{
+			{
+				oneOf(project).findMember(GitRepository.GIT_DIR);
+				will(returnValue(resource));
+
+				oneOf(resource).exists();
+				will(returnValue(true));
+			}
+		});
+		assertTrue(repoProviderType.hasGitDir(project));
+	}
+
+	@Test
+	public void testGitDirNotExist()
+	{
+		context.checking(new Expectations()
+		{
+			{
+				oneOf(project).findMember(GitRepository.GIT_DIR);
+				will(returnValue(resource));
+
+				oneOf(resource).exists();
+				will(returnValue(false));
+			}
+		});
+		assertFalse(repoProviderType.hasGitDir(project));
+	}
+
+}


### PR DESCRIPTION
Commit#1: address the below issue

```
Exception:java.lang.NullPointerException: null
at com.aptana.core.util.StringUtil.join(StringUtil.java:406)
at com.aptana.core.util.StringUtil.join(StringUtil.java:311)
at com.aptana.js.core.inferencing.CommonJSResolver.getModuleId(CommonJSResolver.java:99)
at com.aptana.js.core.inferencing.JSNodeTypeInferrer.visit(JSNodeTypeInferrer.java:775)
at com.aptana.js.core.parsing.ast.JSInvokeNode.accept(JSInvokeNode.java:31)
at com.aptana.js.core.inferencing.JSNodeTypeInferrer.addTypes(JSNodeTypeInferrer.java:194)
at com.aptana.js.core.inferencing.JSNodeTypeInferrer.visit(JSNodeTypeInferrer.java:442)
at com.aptana.js.core.parsing.ast.JSConditionalNode.accept(JSConditionalNode.java:39)
at com.aptana.js.core.parsing.ast.JSTreeWalker.visit(JSTreeWalker.java:176)
at com.aptana.js.internal.core.inferencing.JSSymbolTypeInferrer.processValues(JSSymbolTypeInferrer.java:606)
at com.aptana.js.internal.core.inferencing.JSSymbolTypeInferrer.getSymbolPropertyElement(JSSymbolTypeInferrer.java:359)
at com.aptana.js.internal.core.inferencing.JSSymbolTypeInferrer.getSymbolPropertyElement(JSSymbolTypeInferrer.java:420)
at com.aptana.js.core.inferencing.JSNodeTypeInferrer.visit(JSNodeTypeInferrer.java:677)
at com.aptana.js.core.parsing.ast.JSIdentifierNode.accept(JSIdentifierNode.java:33)
at com.aptana.js.core.parsing.ast.JSTreeWalker.visit(JSTreeWalker.java:176)
at com.aptana.js.internal.core.inferencing.JSSymbolTypeInferrer.processValues(JSSymbolTypeInferrer.java:606)
at com.aptana.js.internal.core.inferencing.JSSymbolTypeInferrer.getSymbolPropertyElement(JSSymbolTypeInferrer.java:359)
at com.aptana.js.internal.core.inferencing.JSSymbolTypeInferrer.processProperties(JSSymbolTypeInferrer.java:520)
at com.aptana.js.core.inferencing.JSNodeTypeInferrer.visit(JSNodeTypeInferrer.java:876)
at com.aptana.js.core.parsing.ast.JSObjectNode.accept(JSObjectNode.java:39)
at com.aptana.js.core.parsing.ast.JSTreeWalker.visit(JSTreeWalker.java:176)
at com.aptana.js.core.inferencing.JSNodeTypeInferrer.getTypes(JSNodeTypeInferrer.java:281)
at com.aptana.js.core.inferencing.JSNodeTypeInferrer.visit(JSNodeTypeInferrer.java:522)
at com.aptana.js.core.parsing.ast.JSFunctionNode.accept(JSFunctionNode.java:46)
at com.aptana.js.core.parsing.ast.JSTreeWalker.visit(JSTreeWalker.java:176)
at com.aptana.js.i
```

Commit 2: Will address the NPE while importing the sample project