### PR TITLE
TISTUD-8890 Install node.js 8.7 with the studio 5.0 installers

### DIFF
--- a/plugins/com.aptana.js.core/src/com/aptana/js/core/node/INodeJS.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/core/node/INodeJS.java
@@ -25,7 +25,7 @@ import com.aptana.js.core.node.INodeJSService.NodeJsListener;
  */
 public interface INodeJS extends NodeJsListener
 {
-	public static final String MIN_NODE_VERSION = "4.2.0"; //$NON-NLS-1$
+	public static final String MIN_NODE_VERSION = "7.6.0"; //$NON-NLS-1$
 
 	/**
 	 * Error codes returned by {@link #validate()}

--- a/plugins/com.aptana.js.core/src/com/aptana/js/internal/core/node/NodeJSService.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/internal/core/node/NodeJSService.java
@@ -67,8 +67,8 @@ public class NodeJSService implements INodeJSService
 	private static final String NODE_EXE = "node.exe"; //$NON-NLS-1$
 	private static final String NPM_EXE = "npm.cmd"; //$NON-NLS-1$
 
-	private static final String MAC_NODE_URL = "http://go.appcelerator.com/installer_nodejs_osx"; //$NON-NLS-1$
-	private static final String WIN_NODE_URL = "http://go.appcelerator.com/installer_nodejs_windows.msi"; //$NON-NLS-1$
+	private static final String MAC_NODE_URL = "https://nodejs.org/download/release/v8.7.0/node-v8.7.0.pkg"; //$NON-NLS-1$
+	private static final String WIN_NODE_URL = "https://nodejs.org/download/release/v8.7.0/node-v8.7.0-x86.msi"; //$NON-NLS-1$
 	private static final String MAC_EXTENSION = ".pkg"; //$NON-NLS-1$
 	private static final String WIN_EXTENSION = ".msi"; //$NON-NLS-1$
 

--- a/tests/com.aptana.js.core.tests/src/com/aptana/js/internal/core/node/NodeJSTest.java
+++ b/tests/com.aptana.js.core.tests/src/com/aptana/js/internal/core/node/NodeJSTest.java
@@ -267,7 +267,7 @@ public class NodeJSTest
 				will(returnValue("/path/to/node"));
 
 				oneOf(runner).runInBackground("/path/to/node", "-v"); //$NON-NLS-1$
-				will(returnValue(new ProcessStatus(0, "v4.2.0", "")));
+				will(returnValue(new ProcessStatus(0, "v7.6.0", "")));
 			}
 		});
 		IStatus status = node.validate();


### PR DESCRIPTION
Adding 8.7 node.js temporary links

1. Updated the links with Node.js 8.7 - but these are having temporary links will replace the actual links during the GA time. Please refer https://jira.appcelerator.org/browse/TISTUD-8901
2. Update the minimum version required in the studio Installers to 7.6 - Windows and Mac
3. Update the minimum version required in the studio to 7.6
4. Install the node 8.7 if the minimum version criteria is not met while restarting the studio 5.0