### PR TITLE
Quick fix to avoid NPE in JSParser

### DIFF
--- a/plugins/com.aptana.js.core/src/com/aptana/js/internal/core/build/JSParserValidator.java
+++ b/plugins/com.aptana.js.core/src/com/aptana/js/internal/core/build/JSParserValidator.java
@@ -79,8 +79,6 @@ public class JSParserValidator extends AbstractBuildParticipant
 
 		// Set our temp fields up
 		this.fContext = context;
-		this.fLocation = context.getURI();
-		this.fPath = fLocation.toString();
 		this.fProblems = new ArrayList<IProblem>();
 
 		try
@@ -89,6 +87,9 @@ public class JSParserValidator extends AbstractBuildParticipant
 			Collection<IParseError> parseErrors = context.getParseErrors();
 			if (!CollectionsUtil.isEmpty(parseErrors))
 			{
+				fLocation = context.getURI();
+				fPath = fLocation.toString();
+
 				fProblems.addAll(CollectionsUtil.map(parseErrors, new IMap<IParseError, IProblem>()
 				{
 


### PR DESCRIPTION
Finally, I could reproduce this!

We are getting into this error when debugger stopped over a breakpoint in the titanium.js file or similar but it doesn't exist in the eclipse workspace project.

A quick fix to avoid computing the file path if the parse errors don't exist!

![jserror](https://user-images.githubusercontent.com/8463287/32587765-28eaeca2-c545-11e7-8618-92e768a22839.png)
