### PR TITLE
Fix for TISTUD-8984: Eclipse-oxygen-2: Exceptions while creating Mobile Project in App Explorer view

### DIFF
--- a/plugins/com.aptana.explorer/src/com/aptana/explorer/internal/ui/SingleProjectView.java
+++ b/plugins/com.aptana.explorer/src/com/aptana/explorer/internal/ui/SingleProjectView.java
@@ -7,6 +7,7 @@
  */
 package com.aptana.explorer.internal.ui;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -36,7 +37,10 @@ import org.eclipse.jface.dialogs.IDialogSettings;
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.layout.GridLayoutFactory;
 import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.jface.viewers.ITreeSelection;
 import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.jface.viewers.TreePath;
+import org.eclipse.jface.viewers.TreeSelection;
 import org.eclipse.jface.wizard.WizardDialog;
 import org.eclipse.search.ui.NewSearchUI;
 import org.eclipse.search.ui.text.FileTextSearchScope;
@@ -508,7 +512,13 @@ public abstract class SingleProjectView extends CommonNavigator implements Searc
 			{
 				ISelection sel = super.getSelection();
 				if (sel.isEmpty() && selectedProject != null)
-					return new StructuredSelection(selectedProject);
+				{
+					List<IProject> selectedProjectList = new ArrayList<IProject>();
+					selectedProjectList.add(selectedProject);
+					TreePath treePath = new TreePath(selectedProjectList.toArray());
+					ITreeSelection treeSelection = new TreeSelection(treePath);
+					return treeSelection;
+				}
 				return sel;
 			}
 		};


### PR DESCRIPTION
**Jira**: https://jira.appcelerator.org/browse/TISTUD-8984 

**Cause**: per eclipse documentation, recent versions of eclipse mandate that we return ITreeViewer object on any overridden getSelection() method of AbstractTreeViewer class.

Excerpt from doc - 
_Subclasses do not typically override this method, but implement getSelectionFromWidget(List) instead. If they override this method, they should return an ITreeSelection as well._

**Fix**: Removed old implementation of returning IStructuredSelection and returning ITreeSelection object on the project node.
 