### PR TITLE
Moving chmod from org.eclipse.equinox.p2.touchpoint.eclipse.chmod to org.eclipse.equinox.p2.touchpoint.natives.chmod

### DIFF
--- a/bundles/com.aptana.terminal/META-INF/p2.inf
+++ b/bundles/com.aptana.terminal/META-INF/p2.inf
@@ -1,6 +1,6 @@
  instructions.install = \
-    chmod(targetDir:@artifact,targetFile:os/linux/x86/redtty,permissions:755);\
-    chmod(targetDir:@artifact,targetFile:os/linux/x86_64/redtty,permissions:755);\
-    chmod(targetDir:@artifact,targetFile:os/macosx/redtty,permissions:755);
+    chmod(targetDir:@artifact,targetFile:os/linux/x86/redtty,permissions:777);\
+    chmod(targetDir:@artifact,targetFile:os/linux/x86_64/redtty,permissions:777);\
+    chmod(targetDir:@artifact,targetFile:os/macosx/redtty,permissions:777);
  instructions.install.import= \
-    org.eclipse.equinox.p2.touchpoint.eclipse.chmod
+    org.eclipse.equinox.p2.touchpoint.natives.chmod


### PR DESCRIPTION
The import _org.eclipse.equinox.p2.touchpoint.eclipse.chmod_ seems invalid according to eclipse documentation (ref: https://help.eclipse.org/neon/index.jsp?topic=%2Forg.eclipse.platform.doc.isv%2Fguide%2Fp2_actions_touchpoints.html)

Changing this to **org.eclipse.equinox.p2.touchpoint.natives.chmod**, so that the function gets run as expected.