### PR TITLE
TISTUD-9075 Commenting out code with "command+ / " does not work

### DIFF
--- a/bundles/com.aptana.editor.common/framework/ruble/editor.rb
+++ b/bundles/com.aptana.editor.common/framework/ruble/editor.rb
@@ -243,7 +243,7 @@ module Ruble
     
     def scope_at_offset(offset)
       if editor_part.respond_to? :source_viewer
-        com.aptana.editor.common.CommonEditorPlugin.getDefault.get_document_scope_manager.get_scope_at_offset(editor_part.source_viewer, offset)
+        com.aptana.editor.common.CommonEditorPlugin.getDefault.get_document_scope_manager.get_scope_at_offset(editor_part.getISourceViewer(), offset)
       else
         ''
       end
@@ -301,7 +301,7 @@ module Ruble
       result = {}
       
       if editor_part.kind_of?(com.aptana.editor.common.AbstractThemeableEditor)
-        result['TM_SOFT_TABS'] = editor_part.isTabsToSpacesConversionEnabled() ? "YES" : "NO"
+        result['TM_SOFT_TABS'] = editor_part.isTabsToSpacesConversionEnabledAptana() ? "YES" : "NO"
         result['TM_TAB_SIZE'] = editor_part.getTabSize()
       else
         result['TM_SOFT_TABS'] = "NO"

--- a/bundles/com.aptana.editor.common/src/com/aptana/editor/common/AbstractThemeableEditor.java
+++ b/bundles/com.aptana.editor.common/src/com/aptana/editor/common/AbstractThemeableEditor.java
@@ -1242,9 +1242,9 @@ public abstract class AbstractThemeableEditor extends AbstractFoldingEditor impl
 
 	/**
 	 * Made public so we can set TM_SOFT_TABS for scripting
+	 *  Keeping different method name to avoid issues with the JRuby calls
 	 */
-	@Override
-	public boolean isTabsToSpacesConversionEnabled()
+	public boolean isTabsToSpacesConversionEnabledAptana()
 	{
 		// Make public so we can grab the value
 		return super.isTabsToSpacesConversionEnabled();


### PR DESCRIPTION
The problem here is "we are unable to use protected java method in jruby since jdk9 with the JRuby 9.x" even if the super class method declared as "protected".

So far we are overriding the protected method by public method in the sub-class. But now that does't seem to work even. 

To overcome this issue, we have to make sure all the methods are which are getting invoked by JRuby should be public and accessible. 

This issue is similar to https://github.com/jruby/jruby/issues/4851