### PR TITLE
TISTUD-7442 : Refactoring Studio <-> CLI communication w.r.t. sessions

### DIFF
--- a/bundles/com.aptana.projects/src/com/aptana/projects/internal/wizards/Messages.java
+++ b/bundles/com.aptana.projects/src/com/aptana/projects/internal/wizards/Messages.java
@@ -35,6 +35,7 @@ public class Messages extends NLS
 	public static String AbstractNewProjectWizard_ProjectListener_TaskName;
 
 	public static String AbstractNewProjectWizard_ProjectListenerErrorTitle;
+	public static String AbstractNewProjectWizard_ProjectListenerSessionExpired;
 
 	public static String OverwriteFilesSelectionDialog_overwriteFilesTitle;
 

--- a/bundles/com.aptana.projects/src/com/aptana/projects/internal/wizards/NewWebProjectWizard.java
+++ b/bundles/com.aptana.projects/src/com/aptana/projects/internal/wizards/NewWebProjectWizard.java
@@ -49,6 +49,11 @@ public class NewWebProjectWizard extends AbstractNewProjectWizard
 	{
 		return "project.create.web"; //$NON-NLS-1$
 	}
+	
+	protected boolean isCLISessionInvalid(String errorMessage)
+	{
+		return false;
+	}
 
 	/*
 	 * (non-Javadoc)

--- a/bundles/com.aptana.projects/src/com/aptana/projects/internal/wizards/messages.properties
+++ b/bundles/com.aptana.projects/src/com/aptana/projects/internal/wizards/messages.properties
@@ -16,6 +16,7 @@ AbstractNewProjectWizard_CloningFromGitMsg=Cloning from git...
 AbstractNewProjectWizard_ProjectListener_NoDescriptor_Error=No project descriptor
 AbstractNewProjectWizard_ProjectListener_TaskName=Perform project hooks
 AbstractNewProjectWizard_ProjectListenerErrorTitle=Error during project creation
+AbstractNewProjectWizard_ProjectListenerSessionExpired=Appcelerator user session has been invalidated or expired. \nPlease re-login to create Project. \n\nClick on the user name displayed in status bar to re-login.
 OverwriteFilesSelectionDialog_overwriteFilesTitle=Overwrite Files
 ProjectTemplateSelectionPage_AvailableTemplates_TXT=Available Templates:
 ProjectTemplateSelectionPage_Description=Select the template for this project


### PR DESCRIPTION
Ref: https://jira.appcelerator.org/browse/TISTUD-7442 & https://jira.appcelerator.org/browse/CLI-1065

Introduced new enum to match Error codes returned by CLI (Ref CLI-1065)
Started adopting to the Error messages in various scenarios where Studio used to throw the user a question dialog (for credentials) each time there is a session expiry/invalidation.
Addressed multiple scenarios which make use of a user session.
Let us update this PR with all observations and suggestions to improve this further.