### PR TITLE
TISTUD 9099 - Incorrect filename shown in message on the error marker

### DIFF
--- a/bundles/com.aptana.js.core/src/com/aptana/js/core/parsing/GraalJSParser.java
+++ b/bundles/com.aptana.js.core/src/com/aptana/js/core/parsing/GraalJSParser.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.aptana.core.build.IProblem.Severity;
+import com.aptana.core.util.StringUtil;
 import com.aptana.js.core.IJSConstants;
 import com.aptana.js.core.parsing.ast.IJSNodeTypes;
 import com.aptana.js.core.parsing.ast.JSCommentNode;
@@ -30,6 +31,7 @@ import com.oracle.js.parser.ir.LexicalContext;
 public class GraalJSParser extends AbstractParser
 {
 
+	private static final String DEFAULT_FILENAME = "filename.js"; //$NON-NLS-1$
 	private CommentCollectingParser fParser;
 
 	protected void parse(IParseState parseState, final WorkingParseResult working) throws Exception
@@ -38,7 +40,7 @@ public class GraalJSParser extends AbstractParser
 		String filename = parseState.getFilename();
 		if (filename == null)
 		{
-			filename = "filename.js"; //$NON-NLS-1$
+			filename = DEFAULT_FILENAME;
 		}
 
 		try
@@ -52,10 +54,10 @@ public class GraalJSParser extends AbstractParser
 				// update node offsets
 				int start = parseState.getStartingOffset();
 				int length = source.length();
-				
+
 				// align root with zero-based offset
 				ast.setLocation(0, length - 1);
-				
+
 				if (start != 0)
 				{
 					// shift all offsets to the correct position
@@ -109,7 +111,13 @@ public class GraalJSParser extends AbstractParser
 			@Override
 			public void error(final ParserException e)
 			{
-				working.addError(new ParseError(IJSConstants.CONTENT_TYPE_JS, e.getLineNumber(), e.getMessage(), Severity.ERROR));
+				String message = e.getMessage();
+				if (!StringUtil.isEmpty(message) && message.contains(DEFAULT_FILENAME))
+				{
+					message = message.replace(DEFAULT_FILENAME, e.getErrorType().name());
+				}
+				working.addError(
+						new ParseError(IJSConstants.CONTENT_TYPE_JS, e.getLineNumber(), message, Severity.ERROR));
 			}
 		};
 		// Subclass and collect comments too

--- a/bundles/com.aptana.parsing/src/com/aptana/parsing/ast/ParseError.java
+++ b/bundles/com.aptana.parsing/src/com/aptana/parsing/ast/ParseError.java
@@ -7,10 +7,9 @@
  */
 package com.aptana.parsing.ast;
 
-import beaver.Symbol;
-
-import com.aptana.core.build.IProblem.Severity;
 import com.aptana.core.build.Problem;
+
+import beaver.Symbol;
 
 /**
  * @author cwilliams

--- a/tests/com.aptana.editor.html.tests/src/com/aptana/editor/html/validator/HTMLParseErrorValidatorTest.java
+++ b/tests/com.aptana.editor.html.tests/src/com/aptana/editor/html/validator/HTMLParseErrorValidatorTest.java
@@ -151,7 +151,7 @@ public class HTMLParseErrorValidatorTest extends AbstractValidatorTestCase
 //		};
 //		^
 		assertEquals("Error was not found on expected line", 2, item.getLineNumber());
-		assertEquals("Error message did not match expected error message", "filename.js:4:0 Expected an operand but found }\n" + 
+		assertEquals("Error message did not match expected error message", "SyntaxError:4:0 Expected an operand but found }\n" + 
 				"};\n" + 
 				"^",
 				item.getMessage());

--- a/tests/com.aptana.js.core.tests/src/com/aptana/js/core/parsing/GraalJSParserTest.java
+++ b/tests/com.aptana.js.core.tests/src/com/aptana/js/core/parsing/GraalJSParserTest.java
@@ -14,7 +14,7 @@ public class GraalJSParserTest extends JSParserTest
 	@Override
 	protected String mismatchedToken(int line, int offset, String token)
 	{
-		return "filename.js:" + line + ":" + offset + " Expected an operand but found " + token;
+		return "SyntaxError:" + line + ":" + offset + " Expected an operand but found " + token;
 	}
 
 	@Override

--- a/tests/com.aptana.js.core.tests/src/com/aptana/js/core/parsing/JSParserTest.java
+++ b/tests/com.aptana.js.core.tests/src/com/aptana/js/core/parsing/JSParserTest.java
@@ -1148,35 +1148,35 @@ public abstract class JSParserTest
 	public void testMissingClosingParenthesis() throws Exception
 	{
 		parse("testing(");
-		assertParseErrors("filename.js:1:8 Expected an operand but found eof\n" + "testing(\n" + "        ^");
+		assertParseErrors("SyntaxError:1:8 Expected an operand but found eof\n" + "testing(\n" + "        ^");
 	}
 
 	@Test
 	public void testMissingIdentifier() throws Exception
 	{
 		parse("var x =");
-		assertParseErrors("filename.js:1:7 Expected an operand but found eof\n" + "var x =\n" + "       ^");
+		assertParseErrors("SyntaxError:1:7 Expected an operand but found eof\n" + "var x =\n" + "       ^");
 	}
 
 	@Test
 	public void testMissingIdentifier2() throws Exception
 	{
 		parse("x.");
-		assertParseErrors("filename.js:1:2 Expected ident but found eof\n" + "x.\n" + "  ^");
+		assertParseErrors("SyntaxError:1:2 Expected ident but found eof\n" + "x.\n" + "  ^");
 	}
 
 	@Test
 	public void testMissingArg() throws Exception
 	{
 		parse("fun(a,);");
-		assertParseErrors("filename.js:1:6 Expected an operand but found )\n" + "fun(a,);\n" + "      ^");
+		assertParseErrors("SyntaxError:1:6 Expected an operand but found )\n" + "fun(a,);\n" + "      ^");
 	}
 
 	@Test
 	public void testMissingIdentifier3() throws Exception
 	{
 		parse("new");
-		assertParseErrors("filename.js:1:3 Expected an operand but found eof\n" + "new\n" + "   ^");
+		assertParseErrors("SyntaxError:1:3 Expected an operand but found eof\n" + "new\n" + "   ^");
 	}
 
 	@Test
@@ -1246,7 +1246,7 @@ public abstract class JSParserTest
 	{
 		parse("var string = 'something");
 		assertParseErrors(
-				"filename.js:1:23 Missing close quote\n" + "var string = 'something\n" + "                       ^");
+				"SyntaxError:1:23 Missing close quote\n" + "var string = 'something\n" + "                       ^");
 	}
 
 	@Test
@@ -1254,7 +1254,7 @@ public abstract class JSParserTest
 	{
 		parse("var thing; /* comment");
 		assertParseErrors(
-				"filename.js:1:11 Expected an operand but found error\n" + "var thing; /* comment\n" + "           ^");
+				"SyntaxError:1:11 Expected an operand but found error\n" + "var thing; /* comment\n" + "           ^");
 	}
 
 	protected abstract String unexpectedToken(String token);
@@ -1264,7 +1264,7 @@ public abstract class JSParserTest
 	{
 		parse("var regexp = /;");
 		assertParseErrors(
-				"filename.js:1:13 Expected an operand but found /\n" + "var regexp = /;\n" + "             ^");
+				"SyntaxError:1:13 Expected an operand but found /\n" + "var regexp = /;\n" + "             ^");
 	}
 
 	@Test
@@ -1292,7 +1292,7 @@ public abstract class JSParserTest
 	public void testReservedWordAsFunctionName() throws Exception
 	{
 		parse("function import() {};" + EOL);
-		assertParseErrors("filename.js:1:9 Expected ( but found import\n" + "function import() {};\n" + "         ^");
+		assertParseErrors("SyntaxError:1:9 Expected ( but found import\n" + "function import() {};\n" + "         ^");
 	}
 
 	@Test
@@ -1569,7 +1569,7 @@ public abstract class JSParserTest
 	public void testSemicolonInsertion1() throws Exception
 	{
 		parse("{ 1 2 } 3" + EOL);
-		assertParseErrors("filename.js:1:4 Expected ; but found 2\n" + "{ 1 2 } 3\n" + "    ^");
+		assertParseErrors("SyntaxError:1:4 Expected ; but found 2\n" + "{ 1 2 } 3\n" + "    ^");
 	}
 
 	/**
@@ -1620,7 +1620,7 @@ public abstract class JSParserTest
 	public void testSemicolonInsertion3() throws Exception
 	{
 		parse("for (a; b" + EOL + ")" + EOL);
-		assertParseErrors("filename.js:2:0 Expected ; but found )\n" + ")\n" + "^");
+		assertParseErrors("SyntaxError:2:0 Expected ; but found )\n" + ")\n" + "^");
 	}
 
 	/**
@@ -1650,7 +1650,7 @@ public abstract class JSParserTest
 	public void testSemicolonInsertion4() throws Exception
 	{
 		assertParseResult("return" + EOL + "a + b" + EOL, "a + b;" + EOL);
-//		assertNoErrors(); //java.lang.AssertionError: problem ERROR: null line=-1 offset=-1 length=-1 filename.js:1:0 Invalid return statement
+//		assertNoErrors(); //java.lang.AssertionError: problem ERROR: null line=-1 offset=-1 length=-1 SyntaxError:1:0 Invalid return statement
 	}
 
 	/**
@@ -1694,7 +1694,7 @@ public abstract class JSParserTest
 	public void testSemicolonInsertion6() throws Exception
 	{
 		parse("if (a > b)" + EOL + "else c = d" + EOL);
-		assertParseErrors("filename.js:2:0 Expected an operand but found else\n" + "else c = d\n" + "^");
+		assertParseErrors("SyntaxError:2:0 Expected an operand but found else\n" + "else c = d\n" + "^");
 	}
 
 	/**

--- a/tests/com.aptana.js.core.tests/src/com/aptana/js/core/parsing/JSParserTest.java
+++ b/tests/com.aptana.js.core.tests/src/com/aptana/js/core/parsing/JSParserTest.java
@@ -50,6 +50,15 @@ public abstract class JSParserTest
 	protected abstract IParser createParser();
 
 	@Test
+	public void testReferenceError() throws Exception
+	{
+		parse("'string' = 2;" + EOL);
+		assertParseErrors("ReferenceError:1:1 Invalid left hand side for assignment\n" + 
+				"'string' = 2;\n" + 
+				" ^");
+	}
+	
+	@Test
 	public void testEmptyStatement() throws Exception
 	{
 		assertParseResult(";" + EOL);

--- a/tests/com.aptana.js.core.tests/src/com/aptana/js/internal/core/build/JSParserValidatorTest.java
+++ b/tests/com.aptana.js.core.tests/src/com/aptana/js/internal/core/build/JSParserValidatorTest.java
@@ -63,7 +63,7 @@ public class JSParserValidatorTest extends AbstractValidatorTestCase
 		IProblem item = items.get(0);
 
 		assertEquals("Error was not found on expected line", 3, item.getLineNumber());
-		assertEquals("Error message did not match expected error message", "filename.js:3:0 Expected an operand but found }\n" + 
+		assertEquals("Error message did not match expected error message", "SyntaxError:3:0 Expected an operand but found }\n" + 
 				"};\n" + 
 				"^",
 				item.getMessage());


### PR DESCRIPTION
Removed the filename.js from the error marker.
Will include the error type in the error message which is either SyntaxError or ReferenceError.

**Example1:**

> 'string' = 2;

```
ReferenceError:1:1 Invalid left hand side for assignment\n" + 
				"'string' = 2;\n" + 
				" ^"
```

**Example2:**

> testing(

`SyntaxError:1:8 Expected an operand but found eof\n" + "testing(\n" + "        ^`
