### PR TITLE
TISTUD-9107 : Introducing timeout for getEnvironment() call

### DIFF
--- a/bundles/com.aptana.core/src/com/aptana/core/ShellExecutable.java
+++ b/bundles/com.aptana.core/src/com/aptana/core/ShellExecutable.java
@@ -283,7 +283,7 @@ public final class ShellExecutable
 				{
 					try
 					{
-						IStatus status = ProcessUtil.processResult(run(envCommand, workingDirectory, null));
+						IStatus status = ProcessUtil.processResultWithTimeout(run(envCommand, workingDirectory, null), 10000);
 						if (status.isOK())
 						{
 							result = buildEnvironment(status.getMessage());

--- a/bundles/com.aptana.core/src/com/aptana/core/util/ProcessUtil.java
+++ b/bundles/com.aptana.core/src/com/aptana/core/util/ProcessUtil.java
@@ -201,4 +201,18 @@ public class ProcessUtil
 		}
 		return exitcode;
 	}
+
+	/**
+	 * reads the stdout and stderr from process, returns an IStatus with the exit code, and results. Cast to
+	 * ProcessStatus to get at each stream's output separately.
+	 * 
+	 * @param process
+	 * @return status
+	 * @deprecated Use {@link IProcessRunner#processResult(Process)}
+	 */
+	public static IStatus processResultWithTimeout(Process process, long timeOut)
+	{
+		// Supply timeOut in seconds
+		return new ProcessRunner().processResultWithTimeout(process, timeOut);
+	}
 }


### PR DESCRIPTION
On MacOS machines, when a native call to get 'env' are issued, it waits forever.
We needed a timeout here, as this may cause studio to be hung. 

Introducing a 10 second timeout in this particular case.