### PR TITLE
Let's not log the index file data

### DIFF
--- a/bundles/com.aptana.index.core/src/com/aptana/internal/index/core/DiskIndex.java
+++ b/bundles/com.aptana.index.core/src/com/aptana/internal/index/core/DiskIndex.java
@@ -1501,8 +1501,8 @@ public class DiskIndex
 				default:
 					throw new UTFDataFormatException(
 							MessageFormat
-									.format("Unexpected byte value ''{0}'' at index {1}, reading string of length {2}. Read so far: ''{3}''. Possibly corrupt index file: ''{4}''", //$NON-NLS-1$
-											b, i, length, new String(word), indexFile.getAbsolutePath()));
+									.format("Unexpected byte value ''{0}'' at index {1}, reading string of length {2}. Possibly corrupt index file: ''{3}''", //$NON-NLS-1$
+											b, i, length, indexFile.getAbsolutePath()));
 			}
 		}
 


### PR DESCRIPTION
1. This is to avoid huge amount of JS code dumping into the crash reports and hence increasing the crash file sizes

Example for the crash report
[crashreport_UTFDataformat.txt](https://github.com/aptana/studio3/files/2332007/crashreport_UTFDataformat.txt)