### PR TITLE
TISTUD-9125 Deleting a closed project thrown an exception

### DIFF
--- a/bundles/com.aptana.usage/src/com/aptana/usage/internal/SendPingJob.java
+++ b/bundles/com.aptana.usage/src/com/aptana/usage/internal/SendPingJob.java
@@ -186,6 +186,10 @@ public class SendPingJob extends Job
 				try
 				{
 					IProject project = event.getResource().getProject();
+					if (project == null ||  !project.isOpen())
+					{
+						return; //Don't send the project delete events for the project which is closed since project.getDescription() won't be available!
+					}
 					IProjectDescription description = project.getDescription();
 					String[] natures = description.getNatureIds();
 					if (!ArrayUtil.isEmpty(natures))


### PR DESCRIPTION
Let's not send the delete events for the closed project as it throws the exception while fetching the project description
