### PR TITLE
FIX: Addressing parser recovery and content proposal issues

### DIFF
--- a/bundles/com.aptana.editor.common/src/com/aptana/editor/common/text/AbstractFoldingComputer.java
+++ b/bundles/com.aptana.editor.common/src/com/aptana/editor/common/text/AbstractFoldingComputer.java
@@ -184,7 +184,7 @@ public abstract class AbstractFoldingComputer implements IFoldingComputer
 				if (add)
 				{
 					end = Math.min(getDocument().getLength(), end);
-					if (start <= end)
+					if (start >= 0 && start <= end)
 					{
 						newPositions.put(initialReconcile ? new ProjectionAnnotation(isCollapsed(child))
 								: new ProjectionAnnotation(), new Position(start, end - start));

--- a/bundles/com.aptana.editor.js/src/com/aptana/editor/js/contentassist/JSLocationIdentifier.java
+++ b/bundles/com.aptana.editor.js/src/com/aptana/editor/js/contentassist/JSLocationIdentifier.java
@@ -61,6 +61,7 @@ import com.aptana.js.core.parsing.ast.JSWithNode;
 import com.aptana.parsing.ast.IParseNode;
 import com.aptana.parsing.lexer.IRange;
 import com.aptana.parsing.lexer.Range;
+import com.oracle.js.parser.TokenType;
 
 public class JSLocationIdentifier extends JSTreeWalker
 {
@@ -176,6 +177,11 @@ public class JSLocationIdentifier extends JSTreeWalker
 				((JSParseRootNode) ast).accept(rangeWalker);
 
 				this._replaceRange = rangeWalker.getRange();
+				
+				if (_targetNode instanceof JSGetPropertyNode && _targetNode.getFirstChild().getText().equals(TokenType.THIS.getName()))
+				{
+					this._type = LocationType.IN_THIS;
+				}
 			}
 		}
 

--- a/bundles/com.aptana.editor.js/src/com/aptana/editor/js/contentassist/JSLocationIdentifier.java
+++ b/bundles/com.aptana.editor.js/src/com/aptana/editor/js/contentassist/JSLocationIdentifier.java
@@ -1377,7 +1377,7 @@ public class JSLocationIdentifier extends JSTreeWalker
 	public void visit(JSVarNode node)
 	{
 		// @formatter:off
-		if (node.contains(this._offset) && (this._offset != node.getEndingOffset() || !node.getSemicolonIncluded()))
+		if (node.contains(this._offset) /**&& (this._offset != node.getEndingOffset() || !node.getSemicolonIncluded()) **/)
 		// @formatter:on
 		{
 			IParseNode firstDeclaration = node.getFirstChild();

--- a/bundles/com.aptana.js.core/src/com/aptana/js/core/parsing/GraalASTWalker.java
+++ b/bundles/com.aptana.js.core/src/com/aptana/js/core/parsing/GraalASTWalker.java
@@ -418,7 +418,7 @@ class GraalASTWalker extends NodeVisitor<LexicalContext>
 			}
 			else
 			{
-				node.setSemicolonIncluded(true);
+				node.setSemicolonIncluded(true); //semicolon added for var statement
 				addToParentAndPushNodeToStack(node);
 			}
 			// There may be an assignment (or not)
@@ -1151,11 +1151,12 @@ class GraalASTWalker extends NodeVisitor<LexicalContext>
 				if (parent instanceof JSFunctionNode)
 				{
 					int maybeRBrace = findChar('}', block.getFinish());
-					if (maybeRBrace != -1)
+					if (maybeRBrace == -1) // '}' doesn't exist in the source but we have built the IR for the content proposals which are dependent on AST
 					{
-						rBrace = maybeRBrace;
-						((JSFunctionNode) parent).setLocation(parent.getStartingOffset(), rBrace);
+						maybeRBrace =  block.getFinish() - 1;
 					}
+					rBrace = maybeRBrace;
+					((JSFunctionNode) parent).setLocation(parent.getStartingOffset(), rBrace);
 				}
 			}
 

--- a/bundles/com.aptana.js.core/src/com/aptana/js/core/parsing/GraalJSParser.java
+++ b/bundles/com.aptana.js.core/src/com/aptana/js/core/parsing/GraalJSParser.java
@@ -24,6 +24,7 @@ import com.oracle.js.parser.Parser;
 import com.oracle.js.parser.ParserException;
 import com.oracle.js.parser.ScriptEnvironment;
 import com.oracle.js.parser.Source;
+import com.oracle.js.parser.Token;
 import com.oracle.js.parser.TokenType;
 import com.oracle.js.parser.ir.FunctionNode;
 import com.oracle.js.parser.ir.LexicalContext;
@@ -199,6 +200,40 @@ public class GraalJSParser extends AbstractParser
 		public IParseNode[] getCommentNodes()
 		{
 			return this.comments.toArray(new IParseNode[comments.size()]);
+		}
+
+		@Override
+		protected void expectDontAdvance(TokenType expected) throws ParserException
+		{
+			if (type != expected)
+			{
+				switch (expected)
+				{
+					case IDENT:
+						expected = TokenType.IDENTIFIER;
+					case RBRACE:
+					case LBRACE:
+					case RBRACKET:
+					case LBRACKET:
+						insertToken(expected);
+						break;
+					default:
+						super.expectDontAdvance(expected);
+						break;
+				}
+			}
+		}
+
+		private void insertToken(TokenType expectedTokenType)
+		{
+			long expectedNewToken = Token.toDesc(expectedTokenType, linePosition,
+					expectedTokenType.getName() != null ? expectedTokenType.getLength() : -1);
+
+			// insert the token that is expected before the unexpected token
+			stream.insert(k, expectedNewToken);
+			token = expectedNewToken;
+			k--;
+
 		}
 
 	}

--- a/bundles/com.aptana.js.core/src/com/aptana/js/core/parsing/GraalJSParser.java
+++ b/bundles/com.aptana.js.core/src/com/aptana/js/core/parsing/GraalJSParser.java
@@ -237,18 +237,16 @@ public class GraalJSParser extends AbstractParser
 				super.expectDontAdvance(expected);
 				return;
 			}
-
 			if (type != expected)
 			{
 				switch (expected)
 				{
 					case IDENT:
-						expected = TokenType.IDENTIFIER;
 					case RBRACE:
 					case LBRACE:
 					case RBRACKET:
 					case LBRACKET:
-						insertToken(expected);
+//						insertToken(expected);
 						break;
 					default:
 						super.expectDontAdvance(expected);

--- a/bundles/com.aptana.js.core/src/com/aptana/js/core/parsing/GraalJSParser.java
+++ b/bundles/com.aptana.js.core/src/com/aptana/js/core/parsing/GraalJSParser.java
@@ -145,7 +145,7 @@ public class GraalJSParser extends AbstractParser
 			result = fParser.parse(filename, startOffset, source.length() - startOffset, false);
 		}
 
-		// Any errors? If yes, can we recover
+		// If any errors found, will run in a simple recovery mode where will assume basic expected tokens({, },IDENT, (,)) are available and proceed with the parse without failing.
 		if (result == null || !working.getErrors().isEmpty())
 		{
 			// run in recovery mode and see if we can build better IR by inserting tokens. Parse errors won't be

--- a/bundles/com.aptana.js.core/src/com/aptana/js/core/parsing/ThisAssignmentCollector.java
+++ b/bundles/com.aptana.js.core/src/com/aptana/js/core/parsing/ThisAssignmentCollector.java
@@ -15,6 +15,7 @@ import com.aptana.js.core.parsing.ast.JSAssignmentNode;
 import com.aptana.js.core.parsing.ast.JSFunctionNode;
 import com.aptana.js.core.parsing.ast.JSTreeWalker;
 import com.aptana.parsing.ast.IParseNode;
+import com.oracle.js.parser.TokenType;
 
 /**
  * ThisAssignmentCollector
@@ -42,7 +43,7 @@ public class ThisAssignmentCollector extends JSTreeWalker
 	{
 		IParseNode lhs = node.getLeftHandSide();
 
-		if (lhs.getNodeType() == IJSNodeTypes.GET_PROPERTY && lhs.getFirstChild().getNodeType() == IJSNodeTypes.THIS)
+		if (lhs.getNodeType() == IJSNodeTypes.GET_PROPERTY && (lhs.getFirstChild().getNodeType() == IJSNodeTypes.THIS || lhs.getFirstChild().getText().equals(TokenType.THIS.getName()))) //TODO: create JSThisNode directly while building AST
 		{
 			assignments.add(node);
 		}

--- a/bundles/com.aptana.parsing/META-INF/MANIFEST.MF
+++ b/bundles/com.aptana.parsing/META-INF/MANIFEST.MF
@@ -8,7 +8,8 @@ Bundle-Vendor: %providerName
 Require-Bundle: beaver;visibility:=reexport,
  json.simple,
  com.aptana.core,
- com.aptana.core.epl
+ com.aptana.core.epl,
+ com.oracle.js.parser;visibility:=reexport
 Bundle-RequiredExecutionEnvironment: J2SE-1.5
 Bundle-ActivationPolicy: lazy
 Export-Package: com.aptana.json,

--- a/bundles/com.oracle.js.parser/src/com/oracle/js/parser/AbstractParser.java
+++ b/bundles/com.oracle.js.parser/src/com/oracle/js/parser/AbstractParser.java
@@ -506,7 +506,7 @@ public abstract class AbstractParser {
             // Create IDENT node.
             return createIdentNode(identToken, finish, ident);
         } else {
-        		expect(IDENT);
+        		expectDontAdvance(IDENT);
         		
         		// Fake out identifier.
             final long identToken = Token.recast(token, IDENTIFIER);

--- a/bundles/com.oracle.js.parser/src/com/oracle/js/parser/AbstractParser.java
+++ b/bundles/com.oracle.js.parser/src/com/oracle/js/parser/AbstractParser.java
@@ -30,7 +30,6 @@ import static com.oracle.js.parser.TokenType.DIRECTIVE_COMMENT;
 import static com.oracle.js.parser.TokenType.EOF;
 import static com.oracle.js.parser.TokenType.EOL;
 import static com.oracle.js.parser.TokenType.IDENT;
-import static com.oracle.js.parser.TokenType.IDENTIFIER;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -509,8 +508,8 @@ public abstract class AbstractParser {
         		expectDontAdvance(IDENT);
         		
         		// Fake out identifier.
-            final long identToken = Token.recast(token, IDENTIFIER);
-            return createIdentNode(identToken, finish, IDENTIFIER.getName());
+            final long identToken = Token.recast(token, IDENT);
+            return createIdentNode(identToken, finish, "");
         }
     }
 

--- a/bundles/com.oracle.js.parser/src/com/oracle/js/parser/AbstractParser.java
+++ b/bundles/com.oracle.js.parser/src/com/oracle/js/parser/AbstractParser.java
@@ -30,6 +30,7 @@ import static com.oracle.js.parser.TokenType.DIRECTIVE_COMMENT;
 import static com.oracle.js.parser.TokenType.EOF;
 import static com.oracle.js.parser.TokenType.EOL;
 import static com.oracle.js.parser.TokenType.IDENT;
+import static com.oracle.js.parser.TokenType.IDENTIFIER;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -350,7 +351,7 @@ public abstract class AbstractParser {
      *
      * @throws ParserException on unexpected token type
      */
-    protected final void expectDontAdvance(final TokenType expected) throws ParserException {
+    protected void expectDontAdvance(final TokenType expected) throws ParserException {
         if (type != expected) {
             throw error(expectMessage(expected));
         }
@@ -505,8 +506,11 @@ public abstract class AbstractParser {
             // Create IDENT node.
             return createIdentNode(identToken, finish, ident);
         } else {
-            expect(IDENT);
-            return null;
+        		expect(IDENT);
+        		
+        		// Fake out identifier.
+            final long identToken = Token.recast(token, IDENTIFIER);
+            return createIdentNode(identToken, finish, IDENTIFIER.getName());
         }
     }
 

--- a/bundles/com.oracle.js.parser/src/com/oracle/js/parser/ParserContext.java
+++ b/bundles/com.oracle.js.parser/src/com/oracle/js/parser/ParserContext.java
@@ -27,6 +27,7 @@ package com.oracle.js.parser;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
+import com.oracle.js.parser.ir.FunctionNode;
 import com.oracle.js.parser.ir.Statement;
 
 /**
@@ -198,7 +199,7 @@ class ParserContext {
     public ParserContextBlockNode getFunctionBody(final ParserContextFunctionNode functionNode) {
         for (int i = sp - 1; i >= 0; i--) {
             if (stack[i] == functionNode) {
-                return (ParserContextBlockNode) stack[i + 1];
+                return (functionNode.getKind()  == FunctionNode.Kind.MODULE) ? (ParserContextBlockNode) stack[i + 2] : (ParserContextBlockNode) stack[i + 1];
             }
         }
         throw new AssertionError(functionNode.getName() + " not on context stack");

--- a/bundles/com.oracle.js.parser/src/com/oracle/js/parser/TokenStream.java
+++ b/bundles/com.oracle.js.parser/src/com/oracle/js/parser/TokenStream.java
@@ -210,4 +210,31 @@ public class TokenStream {
     void reset() {
         in = out = count = base = 0;
     }
+	
+	/**
+	 * Insert a new token at the specified index
+	 * 
+	 * @param currentTokenIndex
+	 * @param newToken
+	 */
+	public void insert(int currentTokenIndex, long newToken)
+	{
+		 // Allocate new buffer.
+        final long[] newBuffer = new long[buffer.length *2];
+       
+        System.arraycopy(buffer, 0, newBuffer, 0, currentTokenIndex);
+     	newBuffer[currentTokenIndex] = newToken;
+     	System.arraycopy(buffer, currentTokenIndex, newBuffer, currentTokenIndex+1, in-currentTokenIndex);
+        count++;
+        
+        // Update buffer.
+        buffer = newBuffer;
+        
+	}
+	
+	public void rewind()
+	{
+		out = 0;
+	}
+
 }

--- a/bundles/com.oracle.js.parser/src/com/oracle/js/parser/TokenStream.java
+++ b/bundles/com.oracle.js.parser/src/com/oracle/js/parser/TokenStream.java
@@ -231,10 +231,4 @@ public class TokenStream {
         buffer = newBuffer;
         
 	}
-	
-	public void rewind()
-	{
-		out = 0;
-	}
-
 }

--- a/bundles/com.oracle.js.parser/src/com/oracle/js/parser/TokenType.java
+++ b/bundles/com.oracle.js.parser/src/com/oracle/js/parser/TokenType.java
@@ -47,6 +47,7 @@ public enum TokenType {
     EOF                  (SPECIAL,  null),
     EOL                  (SPECIAL,  null),
     COMMENT              (SPECIAL,  null),
+    IDENTIFIER           (SPECIAL,  ""),
     // comments of the form //@ foo=bar or //# foo=bar
     // These comments are treated as special instructions
     // to the lexer, parser or codegenerator.

--- a/bundles/com.oracle.js.parser/src/com/oracle/js/parser/TokenType.java
+++ b/bundles/com.oracle.js.parser/src/com/oracle/js/parser/TokenType.java
@@ -47,7 +47,6 @@ public enum TokenType {
     EOF                  (SPECIAL,  null),
     EOL                  (SPECIAL,  null),
     COMMENT              (SPECIAL,  null),
-    IDENTIFIER           (SPECIAL,  ""),
     // comments of the form //@ foo=bar or //# foo=bar
     // These comments are treated as special instructions
     // to the lexer, parser or codegenerator.

--- a/tests/com.aptana.editor.html.tests/src/com/aptana/editor/html/validator/HTMLParseErrorValidatorTest.java
+++ b/tests/com.aptana.editor.html.tests/src/com/aptana/editor/html/validator/HTMLParseErrorValidatorTest.java
@@ -144,7 +144,7 @@ public class HTMLParseErrorValidatorTest extends AbstractValidatorTestCase
 		assertEquals(0, htmlProblems.size());
 
 		List<IProblem> jsProblems = getParseErrors(text, IJSConstants.JS_PROBLEM_MARKER_TYPE);
-		assertEquals(1, jsProblems.size());
+		assertEquals(2, jsProblems.size());
 		IProblem item = jsProblems.get(0);
 
 		assertEquals("Error was not found on expected line", 2, item.getLineNumber());

--- a/tests/com.aptana.editor.html.tests/src/com/aptana/editor/html/validator/HTMLParseErrorValidatorTest.java
+++ b/tests/com.aptana.editor.html.tests/src/com/aptana/editor/html/validator/HTMLParseErrorValidatorTest.java
@@ -144,12 +144,9 @@ public class HTMLParseErrorValidatorTest extends AbstractValidatorTestCase
 		assertEquals(0, htmlProblems.size());
 
 		List<IProblem> jsProblems = getParseErrors(text, IJSConstants.JS_PROBLEM_MARKER_TYPE);
-		assertEquals(2, jsProblems.size()); //2 errors shown with the GraalVM
+		assertEquals(1, jsProblems.size());
 		IProblem item = jsProblems.get(0);
 
-//		problem ERROR: file:/com.aptana.js.core.problem line=2 offset=14 length=-1 filename.js:4:0 Expected an operand but found }
-//		};
-//		^
 		assertEquals("Error was not found on expected line", 2, item.getLineNumber());
 		assertEquals("Error message did not match expected error message", "SyntaxError:4:0 Expected an operand but found }\n" + 
 				"};\n" + 

--- a/tests/com.aptana.editor.js.tests/src/com/aptana/editor/js/contentassist/JSContentAssistProposalTest.java
+++ b/tests/com.aptana.editor.js.tests/src/com/aptana/editor/js/contentassist/JSContentAssistProposalTest.java
@@ -408,7 +408,7 @@ public class JSContentAssistProposalTest extends JSEditorBasedTestCase
 		{
 			// note template is before true proposal, as we are ordering by trigger prefix
 			this.checkProposals("contentAssist/f-prefix.js", true, true, "false", "finally", "focus", "for", "forward",
-					"frames", "function", "FunctionTemplate", "Function");
+					"frames", "from", "function", "FunctionTemplate", "Function"); //'from' keyword added in ES6 for import usage
 		}
 		finally
 		{


### PR DESCRIPTION
This will address almost 32 Test scenarios which are related to Content Assist and others.

This will bring down the overall failures from 91 to 59.

There is one case which is still failing on JSCA is:
com.aptana.editor.js.contentassist.JSContentAssistProposalTest.testObjectLiteral

which is bit tricky which I'll take after looking into other issues.


