### PR TITLE
TISTUD-9145 Semicolons are optional with import and export syntax

### DIFF
--- a/bundles/com.oracle.js.parser/src/com/oracle/js/parser/Parser.java
+++ b/bundles/com.oracle.js.parser/src/com/oracle/js/parser/Parser.java
@@ -5118,7 +5118,7 @@ loop:
                 module.addImportEntry(importEntries.get(i).withFrom(moduleSpecifier));
             }
         }
-        expect(SEMICOLON);
+        endOfLine();
     }
 
     /**
@@ -5238,7 +5238,7 @@ loop:
                         module.addLocalExportEntry(exportEntries.get(i));
                     }
                 }
-                expect(SEMICOLON);
+                endOfLine();
                 break;
             }
             case DEFAULT:
@@ -5275,7 +5275,7 @@ loop:
                     ident = createIdentNode(Token.recast(rhsToken, IDENT), finish, Module.DEFAULT_EXPORT_BINDING_NAME);
                     lc.appendStatementToCurrentNode(new VarNode(lineNumber, Token.recast(rhsToken, LET), finish, ident, assignmentExpression));
                     if (!declaration) {
-                        expect(SEMICOLON);
+                        endOfLine();
                     }
                     module.addLocalExportEntry(ExportEntry.exportDefault());
                 }


### PR DESCRIPTION
This will avoid syntax errors in imported sample project
"hyperloop-examples" which is ES6 based

https://jira.appcelerator.org/browse/TISTUD-9145

Reference:
http://www.bradoncode.com/blog/2015/08/26/javascript-semi-colon-insertion/