### PR TITLE
fix(editor): significantly improve performance scanning for task tags in comments in editors

### DIFF
--- a/bundles/com.aptana.editor.common/src/com/aptana/editor/common/text/rules/CommentScanner.java
+++ b/bundles/com.aptana.editor.common/src/com/aptana/editor/common/text/rules/CommentScanner.java
@@ -1,40 +1,95 @@
 package com.aptana.editor.common.text.rules;
 
-import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
-import org.eclipse.jface.text.rules.IRule;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.rules.IToken;
-import org.eclipse.jface.text.rules.RuleBasedScanner;
 import org.eclipse.jface.text.rules.Token;
-import org.eclipse.jface.text.rules.WordRule;
 
+import com.aptana.core.IMap;
 import com.aptana.core.resources.TaskTag;
+import com.aptana.core.util.CollectionsUtil;
+import com.aptana.core.util.StringUtil;
 
-public class CommentScanner extends RuleBasedScanner
+public class CommentScanner extends QueuedTokenScanner
 {
 
-	private static final String TASK_TAG_SCOPE = "keyword.other.documentation.task"; //$NON-NLS-1$
+	static final String TASK_TAG_SCOPE = "keyword.other.documentation.task"; //$NON-NLS-1$
+
+	private IToken fDefaultToken;
+	private Pattern fPattern;
+	private static IToken taskToken = new Token(TASK_TAG_SCOPE);
 
 	public CommentScanner(IToken defaultToken)
 	{
-		super();
-		setDefaultReturnToken(defaultToken);
-		List<IRule> rules = createRules();
-		setRules(rules.toArray(new IRule[rules.size()]));
+		this(defaultToken, CollectionsUtil.map(TaskTag.getTaskTags(), new IMap<TaskTag, String>()
+		{
+			public String map(TaskTag item)
+			{
+				return item.getName();
+			}
+		}), TaskTag.isCaseSensitive());
 	}
 
-	protected List<IRule> createRules()
+	public CommentScanner(IToken defaultToken, Collection<String> tags, boolean caseSensitive)
 	{
-		List<IRule> rules = new ArrayList<IRule>();
-		WordRule wordRule = new WordRule(new WordDetector(), Token.UNDEFINED, !TaskTag.isCaseSensitive());
-		IToken taskToken = new Token(TASK_TAG_SCOPE);
-		for (TaskTag tag : TaskTag.getTaskTags())
+		super();
+		this.fDefaultToken = defaultToken;
+		List<String> tagNames = CollectionsUtil.map(tags, new IMap<String, String>()
 		{
-			wordRule.addWord(tag.getName(), taskToken);
+			public String map(String item)
+			{
+				return Pattern.quote(item);
+			}
+		});
+		int flags = 0;
+		if (!caseSensitive)
+		{
+			flags = flags | Pattern.CASE_INSENSITIVE;
 		}
-		rules.add(wordRule);
-		return rules;
+		this.fPattern = Pattern.compile(StringUtil.join("|", tagNames), flags);
+	}
+
+	public void setRange(IDocument document, int offset, int length)
+	{
+		super.setRange(document, offset, length);
+		try
+		{
+			String content = document.get(offset, length);
+			// TODO: Do the matching as we go via nextToken() rather than up-front?
+			Matcher matcher = fPattern.matcher(content);
+			// Queue up the tokens!
+			int currentOffset = 0;
+			while (matcher.find())
+			{
+				int startOffset = matcher.start();
+				if (startOffset > currentOffset)
+				{
+					// we had space between matches, fill with default token
+					queueToken(fDefaultToken, currentOffset + offset, startOffset - currentOffset);
+				}
+				int endOffset = matcher.end();
+				int tokenLength = endOffset - startOffset;
+				queueToken(taskToken, startOffset + offset, tokenLength);
+				currentOffset = endOffset;
+			}
+			// If we have space between end of last task tag and end of region, queue up default token!
+			int lastMatchEnd = currentOffset + offset;
+			int lastTokenLength = length - lastMatchEnd;
+			if (lastTokenLength > 0)
+			{
+				queueToken(fDefaultToken, lastMatchEnd, lastTokenLength);
+			}
+		}
+		catch (BadLocationException e)
+		{
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
 	}
 
 }

--- a/tests/com.aptana.editor.common.tests/src/com/aptana/editor/common/text/rules/CommentScannerTest.java
+++ b/tests/com.aptana.editor.common.tests/src/com/aptana/editor/common/text/rules/CommentScannerTest.java
@@ -1,0 +1,114 @@
+package com.aptana.editor.common.text.rules;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.jface.text.Document;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.rules.IToken;
+import org.eclipse.jface.text.rules.ITokenScanner;
+import org.eclipse.jface.text.rules.Token;
+import org.junit.Test;
+
+import com.aptana.core.util.CollectionsUtil;
+import com.aptana.editor.common.tests.AbstractTokenScannerTestCase;
+
+public class CommentScannerTest extends AbstractTokenScannerTestCase
+{
+
+	private IToken defaultToken = new Token("default");;
+
+	@Test
+	public void testBasicTokenizing()
+	{
+		String src = "// THIS is some long text, man TODO something or other\n";
+		IDocument document = new Document(src);
+		scanner.setRange(document, 0, src.length());
+
+		assertToken(defaultToken, 0, 31);
+		assertToken(getToken(CommentScanner.TASK_TAG_SCOPE), 31, 4);
+		assertToken(defaultToken, 35, 20);
+		assertEOF();
+	}
+	
+	@Test
+	public void testNoTags()
+	{
+		String src = "// THIS is some long text, man test something or other\n";
+		IDocument document = new Document(src);
+		scanner.setRange(document, 0, src.length());
+
+		assertToken(defaultToken, 0, 55);
+		assertEOF();
+	}
+
+	protected void assertEOF()
+	{
+		IToken next = scanner.nextToken();
+		assertEquals(next, Token.EOF);
+	}
+	
+	@Test
+	public void testBasicTokenizingCaseInsensitive()
+	{
+		scanner = new CommentScanner(defaultToken, CollectionsUtil.newList("TODO"), false);
+
+		String src = "// THIS is some long text, man todo something or other\n";
+		IDocument document = new Document(src);
+		scanner.setRange(document, 0, src.length());
+
+		assertToken(defaultToken, 0, 31);
+		assertToken(getToken(CommentScanner.TASK_TAG_SCOPE), 31, 4);
+		assertToken(defaultToken, 35, 20);
+		assertEOF();
+	}
+	
+	@Test
+	public void testMultipleTagsWithMixedCaseAndCaseInsensitive()
+	{
+		scanner = new CommentScanner(defaultToken, CollectionsUtil.newList("TODO", "fixme"), false);
+
+		String src = "// FixMe is some long text, man toDO something or other\n";
+		IDocument document = new Document(src);
+		scanner.setRange(document, 0, src.length());
+
+		assertToken(defaultToken, 0, 3);
+		assertToken(getToken(CommentScanner.TASK_TAG_SCOPE), 3, 5);
+		assertToken(defaultToken, 8, 24);
+		assertToken(getToken(CommentScanner.TASK_TAG_SCOPE), 32, 4);
+		assertToken(defaultToken, 36, 20);
+		assertEOF();
+	}
+	
+	@Test
+	public void testMultipleTagsWithMixedCaseAndCaseSensitiveNotMatching()
+	{
+		String src = "// FixMe is some long text, man toDO something or other\n";
+		IDocument document = new Document(src);
+		scanner.setRange(document, 0, src.length());
+
+		assertToken(defaultToken, 0, 56);
+		assertEOF();
+	}
+	
+	@Test
+	public void testMultipleTagsWithMixedCaseAndCaseSensitiveMatching()
+	{
+		String src = "// fixme is some long text, man TODO something or other\n";
+		IDocument document = new Document(src);
+		scanner.setRange(document, 0, src.length());
+
+		assertToken(defaultToken, 0, 3);
+		assertToken(getToken(CommentScanner.TASK_TAG_SCOPE), 3, 5);
+		assertToken(defaultToken, 8, 24);
+		assertToken(getToken(CommentScanner.TASK_TAG_SCOPE), 32, 4);
+		assertToken(defaultToken, 36, 20);
+		assertEOF();
+	}
+
+	@Override
+	protected ITokenScanner createTokenScanner()
+	{
+		return new CommentScanner(defaultToken, CollectionsUtil.newList("TODO", "fixme"), true);
+	}
+
+}


### PR DESCRIPTION
**JIRA**: https://jira.appcelerator.org/browse/TISTUD-9171

**Description**
Move from per-character scanning to bulk range scanning, which avoids locking the document for *every single characeter* in the range!
Long comment ranges would lead to pathological case where editors would just hang. (i.e. baked in sourcemaps triggered this)

Fixes TISTUD-9171